### PR TITLE
feat(core): collapse recursive frames — StackOverflowError reports name the recursion

### DIFF
--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/StackDistiller.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/StackDistiller.java
@@ -107,14 +107,22 @@ final class StackDistiller {
             // Recursion first: a StackOverflowError's noise is the app's own
             // code, which the framework collapsing below never touches. Keep
             // one full cycle visible (including the culprit), then mark the rest.
-            RecursionRun recursion = detectRecursion(frames, i, culpritIdx > i ? culpritIdx : frames.length);
+            // Past the frame cap the tail marker below handles everything,
+            // including further recursive runs — no trailing marker pile-up.
+            RecursionRun recursion = shown < MAX_SHOWN_FRAMES
+                    ? detectRecursion(frames, i, culpritIdx > i ? culpritIdx : frames.length)
+                    : null;
             if (recursion != null) {
                 for (int k = 0; k < recursion.period && shown < MAX_SHOWN_FRAMES; k++) {
                     out.add(location(frames[i + k]) + (i + k == culpritIdx ? " ← culprit" : ""));
                     shown++;
                 }
-                out.add("… recursion ×" + (recursion.frameCount - recursion.period)
-                        + " (" + cycleLabel(frames, i, recursion.period) + ")");
+                // Frames, not cycles: "98 recursive frames" of a 2-frame cycle
+                // is 49 repetitions — counting frames keeps the unit identical
+                // to the neighbouring "… N collapsed (…)" marker and avoids
+                // rounding when a run isn't a whole multiple of the period.
+                out.add("… " + (recursion.frameCount - recursion.period)
+                        + " recursive frames (" + cycleLabel(frames, i, recursion.period) + ")");
                 i += recursion.frameCount;
                 continue;
             }

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/StackDistiller.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/StackDistiller.java
@@ -104,6 +104,20 @@ final class StackDistiller {
         int shown = 0;
         int i = 0;
         while (i < frames.length) {
+            // Recursion first: a StackOverflowError's noise is the app's own
+            // code, which the framework collapsing below never touches. Keep
+            // one full cycle visible (including the culprit), then mark the rest.
+            RecursionRun recursion = detectRecursion(frames, i, culpritIdx > i ? culpritIdx : frames.length);
+            if (recursion != null) {
+                for (int k = 0; k < recursion.period && shown < MAX_SHOWN_FRAMES; k++) {
+                    out.add(location(frames[i + k]) + (i + k == culpritIdx ? " ← culprit" : ""));
+                    shown++;
+                }
+                out.add("… recursion ×" + (recursion.frameCount - recursion.period)
+                        + " (" + cycleLabel(frames, i, recursion.period) + ")");
+                i += recursion.frameCount;
+                continue;
+            }
             StackTraceElement el = frames[i];
             boolean mustShow = i == 0 || i == culpritIdx || isAppFrame(el);
             if (mustShow) {
@@ -179,6 +193,55 @@ final class StackDistiller {
         String cls = simpleName(el.getClassName());
         String file = el.getFileName() == null ? "Unknown" : el.getFileName();
         return cls + "." + el.getMethodName() + "(" + file + ":" + el.getLineNumber() + ")";
+    }
+
+    // Recursion detection: a run where every frame equals the frame `period`
+    // positions earlier is a recursive cycle (period 1 = self-recursion). Only
+    // runs of at least MIN_RECURSION_REPEATS full cycles collapse, so a method
+    // that legitimately appears two or three times (tree walk, retry) is
+    // rendered exactly as before.
+    private static final int MIN_RECURSION_REPEATS = 3;
+    private static final int MAX_RECURSION_PERIOD = 8;
+
+    private static final class RecursionRun {
+        final int period;
+        final int frameCount;
+
+        RecursionRun(int period, int frameCount) {
+            this.period = period;
+            this.frameCount = frameCount;
+        }
+    }
+
+    private static boolean sameFrame(StackTraceElement a, StackTraceElement b) {
+        return a.getLineNumber() == b.getLineNumber()
+                && a.getClassName().equals(b.getClassName())
+                && a.getMethodName().equals(b.getMethodName());
+    }
+
+    private static RecursionRun detectRecursion(StackTraceElement[] frames, int start, int limit) {
+        for (int period = 1; period <= MAX_RECURSION_PERIOD; period++) {
+            if (start + (long) period * MIN_RECURSION_REPEATS > limit) break;
+            int n = period;
+            while (start + n < limit && sameFrame(frames[start + n], frames[start + n - period])) n++;
+            if (n >= period * MIN_RECURSION_REPEATS) return new RecursionRun(period, n);
+        }
+        return null;
+    }
+
+    private static String cycleLabel(StackTraceElement[] frames, int start, int period) {
+        StringBuilder sb = new StringBuilder();
+        for (int k = 0; k < period; k++) {
+            if (k > 0) sb.append(" → ");
+            sb.append(methodLabel(frames[start + k]));
+        }
+        // Close the loop visually for multi-frame cycles: a → b → a.
+        if (period > 1) sb.append(" → ").append(methodLabel(frames[start]));
+        return sb.toString();
+    }
+
+    private static String methodLabel(StackTraceElement el) {
+        return simpleName(el.getClassName()) + "." + el.getMethodName();
     }
 
     private static String simpleName(String fqn) {

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/StackDistillerTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/StackDistillerTest.java
@@ -118,7 +118,7 @@ class StackDistillerTest {
         assertThat(d.frameLines().get(0))
                 .contains("PricingService.discountFor(PricingService.java:51)")
                 .contains("← culprit");
-        assertThat(d.frameLines().get(1)).isEqualTo("… recursion ×999 (PricingService.discountFor)");
+        assertThat(d.frameLines().get(1)).isEqualTo("… 999 recursive frames (PricingService.discountFor)");
         // One visible frame + one marker, not fifteen identical lines.
         assertThat(d.frameLines().stream()
                 .filter(l -> l.contains("PricingService.discountFor(PricingService.java:51)"))
@@ -139,7 +139,7 @@ class StackDistillerTest {
         assertThat(d.frameLines().get(0)).contains("OrderService.confirm(OrderService.java:20)");
         assertThat(d.frameLines().get(1)).contains("PricingService.apply(PricingService.java:33)");
         assertThat(d.frameLines().get(2))
-                .isEqualTo("… recursion ×98 (OrderService.confirm → PricingService.apply → OrderService.confirm)");
+                .isEqualTo("… 98 recursive frames (OrderService.confirm → PricingService.apply → OrderService.confirm)");
     }
 
     @Test
@@ -156,7 +156,7 @@ class StackDistillerTest {
         DistilledStack d = new StackDistiller(List.of("com.acme")).distill(e);
 
         assertThat(d.frameLines()).hasSize(5);
-        assertThat(d.frameLines()).noneSatisfy(l -> assertThat(l).contains("recursion"));
+        assertThat(d.frameLines()).noneSatisfy(l -> assertThat(l).contains("recursive frames"));
     }
 
     @Test
@@ -172,7 +172,7 @@ class StackDistillerTest {
         DistilledStack d = new StackDistiller(List.of("io.github.gabrielbbaldez")).distill(e);
 
         assertThat(d.frameLines()).anySatisfy(l ->
-                assertThat(l).contains("… recursion ×").contains("StackDistillerTest.recurse"));
+                assertThat(l).contains("recursive frames").contains("StackDistillerTest.recurse"));
         // The report stays tiny even though the raw trace has hundreds of frames.
         assertThat(d.frameLines().size()).isLessThanOrEqualTo(6);
     }

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/StackDistillerTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/StackDistillerTest.java
@@ -105,4 +105,79 @@ class StackDistillerTest {
         assertThat(d.suppressed()).hasSize(1);
         assertThat(d.suppressed().get(0)).contains("IllegalArgumentException").contains("cleanup failed");
     }
+
+    @Test
+    void collapsesSelfRecursionIntoOneMarker() {
+        StackTraceElement[] frames = new StackTraceElement[1024];
+        for (int i = 0; i < 1000; i++) frames[i] = el("com.acme.PricingService", "discountFor", "PricingService.java", 51);
+        for (int i = 1000; i < 1024; i++) frames[i] = el("com.acme.Main", "m" + i, "Main.java", i);
+        StackOverflowError e = withStack(new StackOverflowError(), frames);
+
+        DistilledStack d = new StackDistiller(List.of("com.acme")).distill(e);
+
+        assertThat(d.frameLines().get(0))
+                .contains("PricingService.discountFor(PricingService.java:51)")
+                .contains("← culprit");
+        assertThat(d.frameLines().get(1)).isEqualTo("… recursion ×999 (PricingService.discountFor)");
+        // One visible frame + one marker, not fifteen identical lines.
+        assertThat(d.frameLines().stream()
+                .filter(l -> l.contains("PricingService.discountFor(PricingService.java:51)"))
+                .count()).isEqualTo(1);
+    }
+
+    @Test
+    void collapsesMutualRecursionNamingTheCycle() {
+        StackTraceElement[] frames = new StackTraceElement[100];
+        for (int i = 0; i < 100; i += 2) {
+            frames[i] = el("com.acme.OrderService", "confirm", "OrderService.java", 20);
+            frames[i + 1] = el("com.acme.PricingService", "apply", "PricingService.java", 33);
+        }
+        StackOverflowError e = withStack(new StackOverflowError(), frames);
+
+        DistilledStack d = new StackDistiller(List.of("com.acme")).distill(e);
+
+        assertThat(d.frameLines().get(0)).contains("OrderService.confirm(OrderService.java:20)");
+        assertThat(d.frameLines().get(1)).contains("PricingService.apply(PricingService.java:33)");
+        assertThat(d.frameLines().get(2))
+                .isEqualTo("… recursion ×98 (OrderService.confirm → PricingService.apply → OrderService.confirm)");
+    }
+
+    @Test
+    void doesNotCollapseLegitimateRepeats() {
+        // A recursive tree walk of depth 2 plus a retry pair: methods repeat,
+        // but never three full cycles in a row.
+        RuntimeException e = withStack(new RuntimeException("x"),
+                el("com.acme.Tree", "walk", "Tree.java", 12),
+                el("com.acme.Tree", "walk", "Tree.java", 12),
+                el("com.acme.Retry", "call", "Retry.java", 40),
+                el("com.acme.Retry", "call", "Retry.java", 40),
+                el("com.acme.Main", "main", "Main.java", 5));
+
+        DistilledStack d = new StackDistiller(List.of("com.acme")).distill(e);
+
+        assertThat(d.frameLines()).hasSize(5);
+        assertThat(d.frameLines()).noneSatisfy(l -> assertThat(l).contains("recursion"));
+    }
+
+    @Test
+    void collapsesARealStackOverflowError() {
+        StackOverflowError e;
+        try {
+            recurse(0);
+            throw new IllegalStateException("expected StackOverflowError");
+        } catch (StackOverflowError caught) {
+            e = caught;
+        }
+
+        DistilledStack d = new StackDistiller(List.of("io.github.gabrielbbaldez")).distill(e);
+
+        assertThat(d.frameLines()).anySatisfy(l ->
+                assertThat(l).contains("… recursion ×").contains("StackDistillerTest.recurse"));
+        // The report stays tiny even though the raw trace has hundreds of frames.
+        assertThat(d.frameLines().size()).isLessThanOrEqualTo(6);
+    }
+
+    private static int recurse(int depth) {
+        return recurse(depth + 1);
+    }
 }


### PR DESCRIPTION
## What

Implements #101. `renderFrames` only collapsed runs of *framework* frames; in a `StackOverflowError` the noise is the app's own code, so every frame was `mustShow` and the report printed 15 identical lines without ever saying **recursion**.

## How

Before the existing framework-collapsing logic, detect a repeating run at the current index: walk forward while `frames[i]` equals `frames[i - period]` (class + method + line), trying periods 1..8 smallest-first — exactly the suggested approach. Then:

- **≥ 3 full cycles required** to collapse; anything shorter renders exactly as today (the no-false-positive rule)
- one full cycle stays visible above the marker, culprit annotation included
- self-recursion: `… recursion ×1023 (PricingService.discountFor)`
- mutual recursion names the whole cycle: `… recursion ×98 (OrderService.confirm → PricingService.apply → OrderService.confirm)`
- the check runs on app *and* framework frames (a looping proxy/serializer collapses the same way)
- if the culprit sits inside the run beyond the first cycle, the run is cut at the culprit so it stays visible

## Tests

Four new tests in `StackDistillerTest`:
- 1000× identical frame → culprit line + one `… recursion ×999` marker, and the frame's location appears exactly once
- alternating pair → arrow-joined cycle label, `×98`
- **no false positives**: depth-2 tree walk + a retry pair + main → 5 lines, no `recursion` marker
- a real `StackOverflowError` caught from an actually-recursive test method → one marker naming `StackDistillerTest.recurse`, report ≤ 6 lines

## Golden files

`mvn -pl stacktale-core test` passes (all suites, golden tests included) with **zero changes** under `src/test/resources/golden/` — the detection never fires on the existing corpus, per the issue's gotcha.

Fixes #101