### PR TITLE
ci: guard the README compatibility table against drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: maven
       - run: mvn -B verify
+      - name: README compatibility table guard
+        if: matrix.java == 21
+        run: bash scripts/check-readme-compat.sh
       - name: Coverage summary
         if: matrix.java == 21
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,11 @@ mvn verify        # JDK 17+ (CI runs 17 and 21)
 The full suite must be green before a PR. Coverage report lands in
 `target/site/jacoco/index.html`.
 
+CI also runs `scripts/check-readme-compat.sh`, which fails when the README's
+**Compatibility** table disagrees (at major.minor precision) with the versions
+the build actually tests — the pom properties and the `compat.yml` matrix. If
+that check fails after a dependency bump, update the table in `README.md`.
+
 ## The one rule that matters: the report format is a public API
 
 The `st/1` report format is specified in [docs/FORMAT.md](docs/FORMAT.md) and pinned by

--- a/scripts/check-readme-compat.sh
+++ b/scripts/check-readme-compat.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Guard the README "Compatibility" table against drifting from the build.
+#
+# "Tested up to" for a dependency is the highest version the build actually
+# exercises: the pom property (Dependabot keeps that current) or any override
+# pinned in the .github/workflows/compat.yml matrix, whichever is higher.
+# Comparison is major.minor only — the table says "2.26.x" on purpose, and a
+# patch bump must not turn CI red for a documentation nit.
+#
+# On mismatch, edit the Compatibility table in README.md (see CONTRIBUTING.md).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+pom_property() {
+  mvn -q help:evaluate -DforceStdout -Dexpression="$1" 2>/dev/null
+}
+
+# Highest -D<property>=X override exercised by the compat matrix (may be empty).
+matrix_max() {
+  grep -oE -- "-D$1=[0-9]+(\.[0-9]+)*" .github/workflows/compat.yml \
+    | cut -d= -f2 | sort -V | tail -n1 || true
+}
+
+# "Tested up to" cell for the row whose first cell starts with $1, stripped of
+# spaces (e.g. "2.26.x"). The pattern is anchored to the row's first cell so
+# rows in other tables (the benchmark table's "Logback INFO ...") can't match.
+readme_tested_up_to() {
+  { grep -E "^\| $1" README.md || true; } | head -n1 \
+    | awk -F'|' '{gsub(/ /, "", $4); print $4}'
+}
+
+major_minor() {
+  echo "$1" | cut -d. -f1,2
+}
+
+check_row() {
+  local display="$1" pattern="$2" property="$3"
+  local pom matrix highest table
+  pom="$(pom_property "$property")"
+  matrix="$(matrix_max "$property")"
+  highest="$(printf '%s\n%s\n' "$pom" "$matrix" | grep -v '^$' | sort -V | tail -n1)"
+  table="$(readme_tested_up_to "$pattern")"
+  if [[ -z "$table" ]]; then
+    echo "README compatibility table: could not find the $display row" >&2
+    fail=1
+  elif [[ "$(major_minor "$table")" != "$(major_minor "$highest")" ]]; then
+    echo "README compatibility table: $display says $table but the build tests up to $highest" >&2
+    fail=1
+  fi
+}
+
+check_row "Logback" 'Logback \|' "logback.version"
+check_row "Log4j2" 'Log4j2 \|' "log4j2.version"
+check_row "Spring Boot" 'Spring Boot ' "spring-boot.version"
+
+# Java: the floor ("17+") tracks the pom's compiler release; "Tested up to"
+# tracks the highest java-version in the CI matrices.
+java_floor_pom="$(pom_property maven.compiler.release)"
+java_floor_table="$(grep -E '^\| Java \|' README.md | awk -F'|' '{gsub(/[ +]/, "", $3); print $3}')"
+if [[ "$java_floor_table" != "$java_floor_pom" ]]; then
+  echo "README compatibility table: Java floor says ${java_floor_table}+ but pom compiles for release $java_floor_pom" >&2
+  fail=1
+fi
+
+java_max_ci="$(grep -hoE 'java(-version)?: *\[?[0-9, ]+' .github/workflows/ci.yml .github/workflows/compat.yml \
+  | grep -oE '[0-9]+' | sort -n | tail -n1)"
+java_table="$(readme_tested_up_to 'Java \|')"
+if [[ "$java_table" != "$java_max_ci" ]]; then
+  echo "README compatibility table: Java says tested up to $java_table but CI tests up to $java_max_ci" >&2
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "" >&2
+  echo "Fix: update the Compatibility table in README.md (major.minor precision, e.g. '2.26.x')." >&2
+  exit 1
+fi
+
+echo "README compatibility table matches the build."


### PR DESCRIPTION
## What

Implements #104: CI now fails when the README **Compatibility** table disagrees with what the build actually tests.

`scripts/check-readme-compat.sh` (plain bash, no new tooling, per the issue):

1. reads each version property with `mvn help:evaluate -q -DforceStdout`
2. takes the max of the pom property and any `-Dprop=X` override in the `compat.yml` matrix — this matters for Spring Boot, where the pom pins 3.4.5 but the matrix tests 3.5.6, which is what the table's `3.5.x` claims
3. parses the row's `Tested up to` cell (anchored to the first cell, so the benchmark table's "Logback INFO …" row can't shadow the real one)
4. compares **major.minor only** — `2.26.x` vs `2.26.1` passes; a patch bump can't turn CI red
5. fails naming the row and both values: `README compatibility table: Log4j2 says 2.26.x but the build tests up to 2.27.0`

Java is checked in both directions: the `17+` floor against `maven.compiler.release`, and `Tested up to 21` against the highest `java-version` in `ci.yml`/`compat.yml`.

Wired into `ci.yml` on the Java 21 leg (after `mvn verify`, so maven is warm), and CONTRIBUTING.md's Build & test section now says what the failure means and which file to edit.

## Done-when verification (run locally)

- current `main`: **passes** (`README compatibility table matches the build.`)
- pom bumped to `log4j2 2.27.0` without touching the README: **fails** with the message above
- `maven.compiler.release` changed to 21: **fails** naming the Java floor

## Nice-to-have from the issue

Left the floor-vs-matrix check out to keep this the tested-up-to slice the issue prioritizes; the script's structure (per-row pattern + property) makes that a small follow-up.

Fixes #104