### PR TITLE
upload coverage to Codecov and add live badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,13 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: maven
       - run: mvn -B verify
+      - name: Upload coverage to Codecov
+        if: matrix.java == 21
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: "**/target/site/jacoco/jacoco.xml"
+          fail_ci_if_error: false
       - name: README compatibility table guard
         if: matrix.java == 21
         run: bash scripts/check-readme-compat.sh

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 <p align="center">
   <a href="https://github.com/stacktale/stacktale/actions/workflows/ci.yml"><img src="https://github.com/stacktale/stacktale/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/stacktale/stacktale"><img src="https://codecov.io/gh/stacktale/stacktale/graph/badge.svg" alt="Coverage"></a>
   <a href="https://central.sonatype.com/artifact/io.github.gabrielbbaldez/stacktale"><img src="https://img.shields.io/maven-central/v/io.github.gabrielbbaldez/stacktale" alt="Maven Central"></a>
   <img src="https://img.shields.io/badge/Java-17%2B-orange" alt="Java 17+">
   <img src="https://img.shields.io/badge/License-Apache--2.0-blue" alt="Apache-2.0">


### PR DESCRIPTION
## The problem

Right now, every time code is pushed, our tests run and something called JaCoCo quietly measures how much of the code those tests actually exercised — think of it like a teacher marking which lines of an essay were actually read versus skimmed. That number exists, but it's buried: you can only see it if you open one specific GitHub Actions run and scroll to its summary. Nobody landing on the repo's homepage would ever stumble onto it. This PR closes #41 by publishing that number as a badge on the README — the same kind of small icon you already see there for "CI passing" or "Java 17+".

## How I checked this was really a problem, on my own machine first

Before writing any fix, I wanted to see the actual gap with my own eyes, not just take the issue's word for it. So I ran the exact same build our automated pipeline runs:

```
mvn -B verify
```

This builds every module and runs all the tests, and along the way JaCoCo writes out its "who read what" report for each module. I checked that it actually did that:

```
find . -path '*/site/jacoco/jacoco.csv'
```

Then I added up all seven modules' numbers into one overall percentage, using the same math our pipeline already uses internally:

```
awk -F, 'FNR>1 {m+=$8; c+=$9} END {printf "Line coverage: %.1f%% (%d/%d lines)\n", c*100/(c+m), c, c+m}' $(find . -path '*/site/jacoco/jacoco.csv')
```

This printed 78.3% (1579 out of 2016 lines) — noticeably lower than the ~93% someone mentioned when this issue was first filed. Digging into it, one module (stacktale-jul) is only tested about 32% of the way through and is dragging the average down. That's a separate, pre-existing gap — not something I'm fixing here — but it's a good example of exactly why this issue matters: the number people are quoting is already out of date, because there's no live source of truth anyone can just glance at.

I also double-checked that nobody had already started wiring this up:

```
grep -ril "codecov" . --include="*.yml" --include="*.md" --include="*.xml"
```

Nothing came back, confirming this integration genuinely never existed — it's a missing feature, not something broken.

To actually see this rather than just stare at a raw number in a terminal, I opened the visual, color-coded version of one module's report in my browser:

```
open stacktale-core/target/site/jacoco/index.html
```

That's the page in the screenshot below — the green portion of each bar is the code our tests already exercise, and the red portion is what nothing has touched yet.


<img width="2859" height="438" alt="Screenshot 2026-07-23 at 1 49 08 PM" src="https://github.com/user-attachments/assets/71935eec-1bdd-4931-a95c-155997f6c130" />


## How I checked the same thing actually happens on GitHub, not just on my laptop

Running it locally proves the report gets generated — but the issue is really about what shows up during an automated build on GitHub itself, so I wanted to see that too, before writing any fix. Since I only have read access to the real project, I made a throwaway copy of a branch on my own personal copy of the repo and opened a temporary test PR there — purely to make GitHub's automated pipeline run once so I could look at its output:

```
git checkout -b feat/codecov-badge
git commit --allow-empty -m "chore: trigger CI for reproduction check"
git push -u origin feat/codecov-badge
```

That test run printed Line coverage: 78.0% (1571 out of 2015 lines) in its summary — matching what I saw on my own machine almost exactly (the tiny difference is just normal fluctuation between two separate test runs, not a bug). That confirmed the same gap shows up on GitHub's side too, not just locally. I closed that test PR afterward — it was only ever meant to prove the number, never meant to be kept or merged.

<img width="1440" height="900" alt="Screenshot 2026-07-23 at 3 02 59 PM" src="https://github.com/user-attachments/assets/aedea7d5-28f3-48b4-9566-b5cb2c8b782a" />


## What I actually changed

Two small, separate edits:

1. The automated pipeline file (`.github/workflows/ci.yml`) — added one new step, right after the build-and-test step, that takes those JaCoCo reports and uploads them to Codecov (a free website that turns raw coverage reports into a readable percentage and a badge, similar to how a package tracking site turns raw shipping data into a friendly progress bar). This only runs once per build, not once per Java version we test against, to avoid uploading the same data twice.
2. The README — added the badge itself, right next to the existing "CI passing" badge at the top.

## Why I can't fully prove this works before it's merged

GitHub deliberately withholds private keys (in this case, the key that lets us publish to our Codecov account) from any automated run that was triggered by someone else's copy of the repo — the same way a bank won't let you use a card that isn't registered to the account you're standing at the counter for, even if you're clearly trying to pay for something legitimate. Since my test run came from my own fork, GitHub correctly refused to hand it that key. I set the step to not fail the build if that happens (`fail_ci_if_error: false`), so this shows up as a graceful skip rather than a red X. That means my own test run can prove "this doesn't break anything," but it genuinely cannot prove "the upload itself works" — that part only becomes possible once this runs for real, on the actual project's main branch, where the key is available.

## What to check after this is merged

- Watch the very next automated build on the real main branch — the upload step should now actually succeed instead of skipping, and should print a link to a report on codecov.io.
- Open https://app.codecov.io/gh/stacktale/stacktale — a real coverage percentage should now show up there.
- Refresh the README on GitHub — the badge should now show an actual colored percentage instead of a plain gray placeholder.