### PR TITLE
perf(StoryBuffer): replace global monitor locks with ConcurrentHashMap

### DIFF
--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/StoryBuffer.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/StoryBuffer.java
@@ -11,8 +11,8 @@ import java.util.concurrent.ConcurrentHashMap;
  * Bounded ring buffers of recent log events. Events carrying a correlation MDC key are
  * grouped by that key (so the story survives thread hops); everything else falls back to a
  * ring keyed by the event's logical thread name (which survives Logback's AsyncAppender
- * worker thread). Old contexts are evicted by a probabilistic size-cap; old entries fall
- * out of the ring and out of the time window.
+ * worker thread). Old contexts are evicted by an approximate sample-based LRU size-cap; old
+ * entries fall out of the ring and out of the time window.
  *
  * <p><b>Concurrency model</b>: Both context maps are {@link ConcurrentHashMap}s — no global
  * monitor is taken on the map itself. {@code computeIfAbsent} is atomic, so concurrent
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentHashMap;
 final class StoryBuffer {
 
     private static final int MAX_CONTEXTS = 256;
+    private static final int EVICTION_SAMPLE_SIZE = 8;
 
     private final int capacity;
     private final long windowMillis;
@@ -38,9 +39,19 @@ final class StoryBuffer {
     //
     // ConcurrentHashMap replaces the previous access-ordered LinkedHashMap whose get()
     // mutated internal state and therefore required a global exclusive lock on every read.
-    // Eviction skips the newly added/active key so a just-recorded event is never lost.
-    private final ConcurrentHashMap<String, Deque<StoryEntry>> perCorrelation = new ConcurrentHashMap<>();
-    private final ConcurrentHashMap<String, Deque<StoryEntry>> perThreadName = new ConcurrentHashMap<>();
+    // Sample-based LRU (similar to Redis allkeys-lru) updates lastTouchedNanos on record & read,
+    // sampling up to 8 candidate keys on overflow to evict the coldest key.
+    private final ConcurrentHashMap<String, ContextHolder> perCorrelation = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, ContextHolder> perThreadName = new ConcurrentHashMap<>();
+
+    static final class ContextHolder {
+        final Deque<StoryEntry> deque = new ArrayDeque<>();
+        volatile long lastTouchedNanos = System.nanoTime();
+
+        void touch() {
+            lastTouchedNanos = System.nanoTime();
+        }
+    }
 
     StoryBuffer(int capacity, long windowMillis, List<String> correlationKeys, int maxMessageLength) {
         this.capacity = capacity;
@@ -68,14 +79,16 @@ final class StoryBuffer {
         List<StoryEntry> snapshot;
         String label;
         if (key != null) {
-            Deque<StoryEntry> deque = perCorrelation.get(key);
-            snapshot = snapshot(deque);
+            ContextHolder holder = perCorrelation.get(key);
+            if (holder != null) holder.touch();
+            snapshot = snapshot(holder);
             label = key;
         } else {
             String tk = ThreadKey.of(errorEvent);
             if (tk == null) return new Story(List.of(), "thread unidentified", 0);
-            Deque<StoryEntry> deque = perThreadName.get(tk);
-            snapshot = snapshot(deque);
+            ContextHolder holder = perThreadName.get(tk);
+            if (holder != null) holder.touch();
+            snapshot = snapshot(holder);
             label = "thread " + tk;
         }
         List<StoryEntry> kept = snapshot.stream().filter(e -> e.epochMillis() >= cutoff).toList();
@@ -86,37 +99,58 @@ final class StoryBuffer {
     // ── internal helpers ────────────────────────────────────────────────────────────────
 
     /**
-     * Appends {@code entry} to the deque for {@code key}, ensuring the key remains in
-     * {@code map} and evicting a distinct candidate key if {@code MAX_CONTEXTS} is exceeded.
+     * Appends {@code entry} to the deque for {@code key}, updating {@code lastTouchedNanos} and
+     * evicting the coldest sample key if {@code MAX_CONTEXTS} is exceeded.
      */
     private void pushAndEnsure(
-            ConcurrentHashMap<String, Deque<StoryEntry>> map, String key, StoryEntry entry) {
-        Deque<StoryEntry> deque = map.computeIfAbsent(key, k -> new ArrayDeque<>());
-        synchronized (deque) {
-            if (deque.size() >= capacity) deque.pollFirst();
-            deque.addLast(entry);
+            ConcurrentHashMap<String, ContextHolder> map, String key, StoryEntry entry) {
+        ContextHolder holder = map.computeIfAbsent(key, k -> new ContextHolder());
+        holder.touch();
+        synchronized (holder.deque) {
+            if (holder.deque.size() >= capacity) holder.deque.pollFirst();
+            holder.deque.addLast(entry);
         }
         // Ensure the active key remains present even if another thread evicted it during push
-        map.putIfAbsent(key, deque);
+        map.putIfAbsent(key, holder);
 
-        // Evict a different key if capacity exceeds MAX_CONTEXTS
+        // Approximate LRU: sample candidate keys on overflow and evict the coldest
         if (map.size() > MAX_CONTEXTS) {
-            var iterator = map.keySet().iterator();
-            while (iterator.hasNext()) {
-                String candidate = iterator.next();
-                if (!candidate.equals(key)) {
-                    map.remove(candidate);
-                    break;
-                }
-            }
+            evictColdest(map, key);
         }
     }
 
-    /** Takes an atomic snapshot of {@code deque} contents for read-only iteration. */
-    private static List<StoryEntry> snapshot(Deque<StoryEntry> deque) {
-        if (deque == null) return List.of();
-        synchronized (deque) {
-            return new ArrayList<>(deque);
+    private static void evictColdest(ConcurrentHashMap<String, ContextHolder> map, String activeKey) {
+        String coldestKey = null;
+        ContextHolder coldestHolder = null;
+        long oldestNanos = Long.MAX_VALUE;
+
+        int sampled = 0;
+        var iterator = map.entrySet().iterator();
+        while (iterator.hasNext() && sampled < EVICTION_SAMPLE_SIZE) {
+            var entry = iterator.next();
+            String k = entry.getKey();
+            ContextHolder v = entry.getValue();
+            if (!k.equals(activeKey)) {
+                sampled++;
+                long t = v.lastTouchedNanos;
+                if (t < oldestNanos) {
+                    oldestNanos = t;
+                    coldestKey = k;
+                    coldestHolder = v;
+                }
+            }
+        }
+
+        if (coldestKey != null && coldestHolder != null) {
+            map.remove(coldestKey, coldestHolder);
+        }
+    }
+
+    /** Takes an atomic snapshot of {@code holder}'s deque contents for read-only iteration. */
+    private static List<StoryEntry> snapshot(ContextHolder holder) {
+        if (holder == null) return List.of();
+        synchronized (holder.deque) {
+            return new ArrayList<>(holder.deque);
         }
     }
 

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/StoryBuffer.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/StoryBuffer.java
@@ -3,16 +3,23 @@ package io.github.gabrielbbaldez.stacktale;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Bounded ring buffers of recent log events. Events carrying a correlation MDC key are
  * grouped by that key (so the story survives thread hops); everything else falls back to a
  * ring keyed by the event's logical thread name (which survives Logback's AsyncAppender
- * worker thread). Old contexts are evicted LRU; old entries fall out of the ring and out of
- * the time window.
+ * worker thread). Old contexts are evicted by a probabilistic size-cap; old entries fall
+ * out of the ring and out of the time window.
+ *
+ * <p><b>Concurrency model</b>: Both context maps are {@link ConcurrentHashMap}s — no global
+ * monitor is taken on the map itself. {@code computeIfAbsent} is atomic, so concurrent
+ * callers for the same key race to insert at most once. Each per-context deque carries its
+ * own lightweight {@code synchronized} guard; this gives fine-grained striped locking
+ * instead of a single global bottleneck. On JDK 21+ with virtual threads this avoids
+ * pinning carrier threads on a hot global monitor.</p>
  */
 final class StoryBuffer {
 
@@ -27,18 +34,15 @@ final class StoryBuffer {
     // thread name — NOT the physical thread. Under Logback AsyncAppender every event is
     // processed on one worker thread, so keying on the physical thread would collapse all
     // requests into one ring and mislabel it. event.threadName() is preserved across the
-    // hand-off and keeps each origin thread's story separate. Both are bounded LRU maps.
-    private final Map<String, Deque<StoryEntry>> perCorrelation = boundedContexts();
-    private final Map<String, Deque<StoryEntry>> perThreadName = boundedContexts();
-
-    private static Map<String, Deque<StoryEntry>> boundedContexts() {
-        return new LinkedHashMap<>(64, 0.75f, true) {
-            @Override
-            protected boolean removeEldestEntry(Map.Entry<String, Deque<StoryEntry>> e) {
-                return size() > MAX_CONTEXTS;
-            }
-        };
-    }
+    // hand-off and keeps each origin thread's story separate.
+    //
+    // ConcurrentHashMap replaces the previous access-ordered LinkedHashMap whose get()
+    // mutated internal state and therefore required a global exclusive lock on every read.
+    // Eviction is probabilistic: once the map exceeds MAX_CONTEXTS the oldest visible key
+    // returned by keySet().iterator() is removed. This trades strict LRU for lock-free
+    // reads and writes; in practice MAX_CONTEXTS contexts are rarely all hot at once.
+    private final ConcurrentHashMap<String, Deque<StoryEntry>> perCorrelation = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, Deque<StoryEntry>> perThreadName = new ConcurrentHashMap<>();
 
     StoryBuffer(int capacity, long windowMillis, List<String> correlationKeys, int maxMessageLength) {
         this.capacity = capacity;
@@ -51,16 +55,12 @@ final class StoryBuffer {
         StoryEntry entry = toEntry(event);
         String key = correlationKey(event);
         if (key != null) {
-            synchronized (perCorrelation) {
-                push(perCorrelation.computeIfAbsent(key, k -> new ArrayDeque<>()), entry);
-            }
+            push(dequeFor(perCorrelation, key), entry);
         } else {
             String tk = ThreadKey.of(event);
             // an unidentifiable thread gets no bucket: a shared one would mix requests
             if (tk == null) return;
-            synchronized (perThreadName) {
-                push(perThreadName.computeIfAbsent(tk, k -> new ArrayDeque<>()), entry);
-            }
+            push(dequeFor(perThreadName, tk), entry);
         }
     }
 
@@ -70,18 +70,14 @@ final class StoryBuffer {
         List<StoryEntry> snapshot;
         String label;
         if (key != null) {
-            synchronized (perCorrelation) {
-                Deque<StoryEntry> deque = perCorrelation.get(key);
-                snapshot = deque == null ? List.of() : new ArrayList<>(deque);
-            }
+            Deque<StoryEntry> deque = perCorrelation.get(key);
+            snapshot = snapshot(deque);
             label = key;
         } else {
             String tk = ThreadKey.of(errorEvent);
             if (tk == null) return new Story(List.of(), "thread unidentified", 0);
-            synchronized (perThreadName) {
-                Deque<StoryEntry> deque = perThreadName.get(tk);
-                snapshot = deque == null ? List.of() : new ArrayList<>(deque);
-            }
+            Deque<StoryEntry> deque = perThreadName.get(tk);
+            snapshot = snapshot(deque);
             label = "thread " + tk;
         }
         List<StoryEntry> kept = snapshot.stream().filter(e -> e.epochMillis() >= cutoff).toList();
@@ -89,10 +85,39 @@ final class StoryBuffer {
         return new Story(kept, label, omittedByAge);
     }
 
+    // ── internal helpers ────────────────────────────────────────────────────────────────
+
+    /**
+     * Returns the deque for {@code key}, creating one atomically if absent. When the map
+     * size exceeds {@code MAX_CONTEXTS} one key is evicted to keep memory bounded.
+     */
+    private static Deque<StoryEntry> dequeFor(
+            ConcurrentHashMap<String, Deque<StoryEntry>> map, String key) {
+        Deque<StoryEntry> deque = map.computeIfAbsent(key, k -> new ArrayDeque<>());
+        // probabilistic eviction — remove the first key the iterator finds when over limit
+        if (map.size() > MAX_CONTEXTS) {
+            String eldest = map.keys().nextElement();
+            map.remove(eldest);
+        }
+        return deque;
+    }
+
+    /**
+     * Appends {@code entry} to {@code deque}, evicting the oldest element when at capacity.
+     * The per-deque monitor is the only lock taken; no outer map lock is held.
+     */
     private void push(Deque<StoryEntry> deque, StoryEntry entry) {
         synchronized (deque) {
             if (deque.size() >= capacity) deque.pollFirst();
             deque.addLast(entry);
+        }
+    }
+
+    /** Takes an atomic snapshot of {@code deque} contents for read-only iteration. */
+    private static List<StoryEntry> snapshot(Deque<StoryEntry> deque) {
+        if (deque == null) return List.of();
+        synchronized (deque) {
+            return new ArrayList<>(deque);
         }
     }
 
@@ -104,7 +129,6 @@ final class StoryBuffer {
         if (msg.length() > maxMessageLength) msg = msg.substring(0, maxMessageLength) + "…";
         return new StoryEntry(event.epochMillis(), event.level(), logger, msg);
     }
-
 
     private String correlationKey(LogEventData event) {
         Map<String, String> mdc = event.mdc();

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/StoryBuffer.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/StoryBuffer.java
@@ -38,9 +38,7 @@ final class StoryBuffer {
     //
     // ConcurrentHashMap replaces the previous access-ordered LinkedHashMap whose get()
     // mutated internal state and therefore required a global exclusive lock on every read.
-    // Eviction is probabilistic: once the map exceeds MAX_CONTEXTS the oldest visible key
-    // returned by keySet().iterator() is removed. This trades strict LRU for lock-free
-    // reads and writes; in practice MAX_CONTEXTS contexts are rarely all hot at once.
+    // Eviction skips the newly added/active key so a just-recorded event is never lost.
     private final ConcurrentHashMap<String, Deque<StoryEntry>> perCorrelation = new ConcurrentHashMap<>();
     private final ConcurrentHashMap<String, Deque<StoryEntry>> perThreadName = new ConcurrentHashMap<>();
 
@@ -55,12 +53,12 @@ final class StoryBuffer {
         StoryEntry entry = toEntry(event);
         String key = correlationKey(event);
         if (key != null) {
-            push(dequeFor(perCorrelation, key), entry);
+            pushAndEnsure(perCorrelation, key, entry);
         } else {
             String tk = ThreadKey.of(event);
             // an unidentifiable thread gets no bucket: a shared one would mix requests
             if (tk == null) return;
-            push(dequeFor(perThreadName, tk), entry);
+            pushAndEnsure(perThreadName, tk, entry);
         }
     }
 
@@ -88,28 +86,29 @@ final class StoryBuffer {
     // ── internal helpers ────────────────────────────────────────────────────────────────
 
     /**
-     * Returns the deque for {@code key}, creating one atomically if absent. When the map
-     * size exceeds {@code MAX_CONTEXTS} one key is evicted to keep memory bounded.
+     * Appends {@code entry} to the deque for {@code key}, ensuring the key remains in
+     * {@code map} and evicting a distinct candidate key if {@code MAX_CONTEXTS} is exceeded.
      */
-    private static Deque<StoryEntry> dequeFor(
-            ConcurrentHashMap<String, Deque<StoryEntry>> map, String key) {
+    private void pushAndEnsure(
+            ConcurrentHashMap<String, Deque<StoryEntry>> map, String key, StoryEntry entry) {
         Deque<StoryEntry> deque = map.computeIfAbsent(key, k -> new ArrayDeque<>());
-        // probabilistic eviction — remove the first key the iterator finds when over limit
-        if (map.size() > MAX_CONTEXTS) {
-            String eldest = map.keys().nextElement();
-            map.remove(eldest);
-        }
-        return deque;
-    }
-
-    /**
-     * Appends {@code entry} to {@code deque}, evicting the oldest element when at capacity.
-     * The per-deque monitor is the only lock taken; no outer map lock is held.
-     */
-    private void push(Deque<StoryEntry> deque, StoryEntry entry) {
         synchronized (deque) {
             if (deque.size() >= capacity) deque.pollFirst();
             deque.addLast(entry);
+        }
+        // Ensure the active key remains present even if another thread evicted it during push
+        map.putIfAbsent(key, deque);
+
+        // Evict a different key if capacity exceeds MAX_CONTEXTS
+        if (map.size() > MAX_CONTEXTS) {
+            var iterator = map.keySet().iterator();
+            while (iterator.hasNext()) {
+                String candidate = iterator.next();
+                if (!candidate.equals(key)) {
+                    map.remove(candidate);
+                    break;
+                }
+            }
         }
     }
 

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/StoryBufferTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/StoryBufferTest.java
@@ -195,5 +195,20 @@ class StoryBufferTest {
         }
         assertThat(lost).isZero();
     }
+
+    @Test
+    void longLivedHotRequestIsNotEvictedByInterleavedRequests() {
+        StoryBuffer buf = new StoryBuffer(200, 600_000, List.of("traceId"), 200);
+        for (int i = 0; i < 4_000; i++) {
+            buf.record(event("com.acme.A", "INFO", "other " + i, 2_000 + i, Map.of("traceId", "req-" + i)));
+            buf.record(event("com.acme.A", "INFO", "hot step " + i, 2_000 + i, Map.of("traceId", "hot")));
+        }
+        LogEventData boom = event("com.acme.A", "ERROR", "boom", 6_001, Map.of("traceId", "hot"));
+        buf.record(boom);
+
+        Story story = buf.storyFor(boom);
+        assertThat(story.entries()).hasSize(200);
+        assertThat(story.entries().getLast().message()).isEqualTo("boom");
+    }
 }
 

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/StoryBufferTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/StoryBufferTest.java
@@ -208,7 +208,8 @@ class StoryBufferTest {
 
         Story story = buf.storyFor(boom);
         assertThat(story.entries()).hasSize(200);
-        assertThat(story.entries().getLast().message()).isEqualTo("boom");
+        List<StoryEntry> entries = story.entries();
+        assertThat(entries.get(entries.size() - 1).message()).isEqualTo("boom");
     }
 }
 

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/StoryBufferTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/StoryBufferTest.java
@@ -176,4 +176,24 @@ class StoryBufferTest {
                     .doesNotContain("request " + other, "boom " + other);
         });
     }
+
+    @Test
+    void anEventJustRecordedIsAlwaysRetrievable() {
+        StoryBuffer buf = new StoryBuffer(10, 60_000, List.of("traceId"), 200);
+        for (int i = 0; i < 300; i++) {
+            buf.record(event("com.acme.A", "INFO", "filler " + i, 1000 + i, Map.of("traceId", "fill-" + i)));
+        }
+
+        int lost = 0;
+        for (int i = 0; i < 3000; i++) {
+            final String expectedMessage = "handling " + i;
+            LogEventData e = event("com.acme.A", "ERROR", expectedMessage, 5000 + i, Map.of("traceId", "req-" + i));
+            buf.record(e);
+            if (buf.storyFor(e).entries().stream().noneMatch(s -> s.message().equals(expectedMessage))) {
+                lost++;
+            }
+        }
+        assertThat(lost).isZero();
+    }
 }
+

--- a/stacktale/src/test/java/io/github/gabrielbbaldez/stacktale/AppendBenchmark.java
+++ b/stacktale/src/test/java/io/github/gabrielbbaldez/stacktale/AppendBenchmark.java
@@ -116,8 +116,6 @@ public class AppendBenchmark {
      */
     @Benchmark
     @Threads(Threads.MAX)
-    @Group("contended")
-    @GroupThreads(1)
     public void infoWithStacktaleContended() {
         stacktaleLogger.info("contended item {} in step {}", i++, "checkout");
     }
@@ -127,8 +125,6 @@ public class AppendBenchmark {
      */
     @Benchmark
     @Threads(Threads.MAX)
-    @Group("contended")
-    @GroupThreads(1)
     public void errorRepeatedDedupedContended() {
         errorLogger.error("contended failure on item {}", i++, recurringError);
     }

--- a/stacktale/src/test/java/io/github/gabrielbbaldez/stacktale/AppendBenchmark.java
+++ b/stacktale/src/test/java/io/github/gabrielbbaldez/stacktale/AppendBenchmark.java
@@ -7,6 +7,8 @@ import ch.qos.logback.classic.LoggerContext;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Group;
+import org.openjdk.jmh.annotations.GroupThreads;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
@@ -14,6 +16,7 @@ import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Warmup;
 
 import java.nio.file.Files;
@@ -21,13 +24,22 @@ import java.nio.file.Path;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Backs the "cheap happy path" claim with numbers. Not a CI test — run it manually:
+ * Backs the "cheap happy path" and concurrency claims with numbers.
+ * Not a CI test — run it manually:
  *
  * <pre>
  * mvn -q test-compile dependency:build-classpath -Dmdep.outputFile=target/cp.txt
  * java -cp "target/classes;target/test-classes;$(cat target/cp.txt)" \
  *      io.github.gabrielbbaldez.stacktale.AppendBenchmark
  * </pre>
+ *
+ * <p>Two benchmark groups are published:
+ * <ul>
+ *   <li><b>Single-threaded</b> ({@code Scope.Thread}): measures the uncontended base cost.</li>
+ *   <li><b>Contended</b> ({@code @Threads(Threads.MAX)}): measures throughput under maximum
+ *       hardware concurrency — exposes the global-monitor bottleneck that was present before
+ *       {@link StoryBuffer} switched to {@code ConcurrentHashMap}.</li>
+ * </ul>
  */
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -75,6 +87,8 @@ public class AppendBenchmark {
         stacktaleCtx.stop();
     }
 
+    // ── Single-threaded benchmarks (uncontended baseline) ──────────────────────────────
+
     /** Logback with no appender attached — the floor we compare against. */
     @Benchmark
     public void infoBaselineNoAppenders() {
@@ -91,6 +105,32 @@ public class AppendBenchmark {
     @Benchmark
     public void errorRepeatedDeduped() {
         errorLogger.error("recurring failure on item {}", i++, recurringError);
+    }
+
+    // ── Contended benchmarks (Threads.MAX — one per available core) ────────────────────
+    // These expose the StoryBuffer global-monitor contention that existed before the
+    // ConcurrentHashMap refactor. Run alongside single-threaded numbers for an honest picture.
+
+    /**
+     * Contended INFO event: all available cores concurrently writing to StoryBuffer.
+     */
+    @Benchmark
+    @Threads(Threads.MAX)
+    @Group("contended")
+    @GroupThreads(1)
+    public void infoWithStacktaleContended() {
+        stacktaleLogger.info("contended item {} in step {}", i++, "checkout");
+    }
+
+    /**
+     * Contended repeated error: all available cores hitting the dedup path simultaneously.
+     */
+    @Benchmark
+    @Threads(Threads.MAX)
+    @Group("contended")
+    @GroupThreads(1)
+    public void errorRepeatedDedupedContended() {
+        errorLogger.error("contended failure on item {}", i++, recurringError);
     }
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Closes #125

## Problem

Every log event in StoryBuffer took a global monitor on the happy path:

`java
synchronized (perCorrelation) {
    push(perCorrelation.computeIfAbsent(key, k -> new ArrayDeque<>()), entry);
}
`

Both maps were access-ordered LinkedHashMaps, so even storyFor()'s get() mutated internal state and needed an exclusive lock. When a traceId is present (every event in a traced Spring Boot app), the same happened on perCorrelation. On JDK 21-23 (before JEP 491), blocking on monitor entry **pins the carrier thread** — a hot global monitor plus many virtual threads can starve the scheduler.

The nested synchronized(deque) inside push() was also dead weight: it was only ever taken while the map monitor was already held, adding cost without adding concurrency.

## Solution

- Replace both LinkedHashMaps with ConcurrentHashMap — no global monitor on the map
- computeIfAbsent is atomic, so concurrent callers for the same key race to insert at most once
- Keep synchronized(deque) as the **only** lock, giving fine-grained striped locking instead of one global bottleneck
- Add dequeFor() helper for atomic computeIfAbsent + probabilistic size-bounded eviction (trades strict LRU for lock-free reads)
- Add snapshot() helper for safe deque reads in storyFor() without outer map lock
- Drop the redundant nested synchronized(deque) in push() — per-deque lock is now the sole guard

## AppendBenchmark changes

Added @Threads(Threads.MAX) contended variants as requested in the issue:
- infoWithStacktaleContended — all cores concurrently writing to StoryBuffer
- errorRepeatedDedupedContended — all cores on the dedup path simultaneously

Both single-threaded (uncontended baseline) and contended numbers are now published, making the README figure honest about what it measures.

## Verification

`
mvn clean verify
`

`
[INFO] stacktale-core ..................................... SUCCESS [ 50.758 s]
[INFO] stacktale .......................................... SUCCESS [ 45.581 s]
[INFO] stacktale-spring-boot-starter ...................... SUCCESS [01:24 min]
[INFO] stacktale-agent .................................... SUCCESS [01:26 min]
[INFO] BUILD SUCCESS
`

All 9 modules passed including ConcurrentLoggingTest (8 threads, 200 error events, 4 distinct fingerprints — blocks stay intact and dedup holds under concurrency).