### PR TITLE
Fix app name resolution for Spring Boot applications

### DIFF
--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/EnvCollector.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/EnvCollector.java
@@ -13,10 +13,13 @@ import java.util.Properties;
 final class EnvCollector {
 
     private final ClassLoader classLoader;
+    private final String configuredAppName, configuredAppVersion;
     private volatile String cached;
 
-    EnvCollector(ClassLoader classLoader) {
+    EnvCollector(ClassLoader classLoader, String configuredAppName, String configuredAppVersion) {
         this.classLoader = classLoader;
+        this.configuredAppName = configuredAppName;
+        this.configuredAppVersion = configuredAppVersion;
     }
 
     String envLine() {
@@ -38,8 +41,18 @@ final class EnvCollector {
         Properties buildInfo = load("META-INF/build-info.properties");
         Properties git = load("git.properties");
 
-        String name = firstNonBlank(System.getProperty("stacktale.app.name"), buildInfo.getProperty("build.name"), "?");
-        String version = firstNonBlank(System.getProperty("stacktale.app.version"), buildInfo.getProperty("build.version"), "");
+        String name = firstNonBlank(
+                System.getProperty("stacktale.app.name"),
+                buildInfo.getProperty("build.name"),
+                configuredAppName,
+                "?"
+        );
+        String version = firstNonBlank(
+                System.getProperty("stacktale.app.version"),
+                buildInfo.getProperty("build.version"),
+                configuredAppVersion,
+                ""
+        );
         String sha = firstNonBlank(git.getProperty("git.commit.id.abbrev"), "");
         String profile = firstNonBlank(System.getProperty("spring.profiles.active"),
                 System.getenv("SPRING_PROFILES_ACTIVE"), System.getenv("APP_ENV"), "");

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportPipeline.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportPipeline.java
@@ -28,6 +28,8 @@ public final class ReportPipeline {
     /** All knobs, framework-neutral. Times in millis, sizes in bytes. */
     public record Settings(
             String file,
+            String appName,
+            String appVersion,
             List<String> appPackages,
             int storySize,
             long storyWindowMillis,
@@ -88,6 +90,8 @@ public final class ReportPipeline {
          */
         public static final class Builder {
             private String file = "errors-ai.log";
+            private String appName = "";
+            private String appVersion = "";
             private List<String> appPackages = List.of();
             private int storySize = DEFAULT_STORY_SIZE;
             private long storyWindowMillis = DEFAULT_STORY_WINDOW_SECONDS * 1000L;
@@ -109,6 +113,15 @@ public final class ReportPipeline {
             private boolean jsonFormat = false;
 
             public Builder file(String v) { this.file = v; return this; }
+            public Builder appName(String v) {
+                this.appName = v;
+                return this;
+            }
+
+            public Builder appVersion(String v) {
+                this.appVersion = v;
+                return this;
+            }
             public Builder appPackages(List<String> v) { this.appPackages = v; return this; }
             public Builder storySize(int v) { this.storySize = v; return this; }
             public Builder storyWindowMillis(long v) { this.storyWindowMillis = v; return this; }
@@ -130,7 +143,7 @@ public final class ReportPipeline {
             public Builder jsonFormat(boolean v) { this.jsonFormat = v; return this; }
 
             public Settings build() {
-                return new Settings(file, appPackages, storySize, storyWindowMillis, dedupWindowMillis,
+                return new Settings(file, appName,appVersion,appPackages, storySize, storyWindowMillis, dedupWindowMillis,
                         maxFileBytes, maxBackups, truncateOnStart, reportErrorsWithoutThrowable,
                         captureExceptionFields, redactionEnabled, redactPatterns, redactionCorrelation,
                         correlationMdcKeys, zone,
@@ -208,7 +221,9 @@ public final class ReportPipeline {
         this.stormLimiter = settings.maxReportsPerMinute() > 0
                 ? new StormLimiter(settings.maxReportsPerMinute(), 60_000, 10_000, System::currentTimeMillis)
                 : StormLimiter.disabled();
-        this.env = new EnvCollector(Thread.currentThread().getContextClassLoader());
+        this.env = new EnvCollector(Thread.currentThread().getContextClassLoader(),
+                settings.appName(),
+                settings.appVersion());
     }
 
     /** Never throws: a broken configuration produces a warned, no-op pipeline. */

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/EnvCollectorTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/EnvCollectorTest.java
@@ -19,8 +19,16 @@ class EnvCollectorTest {
 
     @Test
     void readsBuildInfoAndGitPropertiesFromClasspath() {
-        String line = new EnvCollector(getClass().getClassLoader()).envLine();
+        String line = new EnvCollector(getClass().getClassLoader(),"","").envLine();
         assertThat(line).contains("app=shop-api 1.4.2").contains("(git 7e3c1f)").contains("java ");
+    }
+    @Test
+    void configuredAppNameIsUsedWhenBuildInfoIsMissing() {
+        ClassLoader empty = new URLClassLoader(new URL[0], null);
+
+        String line = new EnvCollector(empty, "demo-shop", "").envLine();
+
+        assertThat(line).startsWith("app=demo-shop");
     }
 
     @Test
@@ -28,14 +36,14 @@ class EnvCollectorTest {
         System.setProperty("stacktale.app.name", "override");
         System.setProperty("stacktale.app.version", "9.9.9");
         System.setProperty("spring.profiles.active", "dev");
-        String line = new EnvCollector(getClass().getClassLoader()).envLine();
+        String line = new EnvCollector(getClass().getClassLoader(),"","").envLine();
         assertThat(line).contains("app=override 9.9.9").contains("profile=dev");
     }
 
     @Test
     void degradesGracefullyWithEmptyClasspath() {
         ClassLoader empty = new URLClassLoader(new URL[0], null);
-        String line = new EnvCollector(empty).envLine();
+        String line = new EnvCollector(empty,"","").envLine();
         assertThat(line).startsWith("app=?").doesNotContain("git").contains("java ");
     }
 
@@ -44,7 +52,7 @@ class EnvCollectorTest {
         // Properties.load throws IllegalArgumentException (not IOException) on a broken \-u escape
         java.nio.file.Files.writeString(dir.resolve("git.properties"), "git.commit.id.abbrev=\\uZZZZ");
         try (URLClassLoader cl = new URLClassLoader(new URL[]{dir.toUri().toURL()}, null)) {
-            EnvCollector collector = new EnvCollector(cl);
+            EnvCollector collector = new EnvCollector(cl,"","");
             org.assertj.core.api.Assertions.assertThatCode(collector::envLine).doesNotThrowAnyException();
             assertThat(collector.envLine()).contains("java ");
         }

--- a/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleAutoConfiguration.java
+++ b/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleAutoConfiguration.java
@@ -16,6 +16,7 @@ import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ImportRuntimeHints;
 import org.springframework.core.Ordered;
+import org.springframework.core.env.Environment;
 
 /**
  * Zero-config stacktale for Spring Boot: registers the appender on Logback's root logger
@@ -37,7 +38,7 @@ public class StacktaleAutoConfiguration {
     static final String AUTO_APPENDER_NAME = "STACKTALE_AUTO";
 
     @Bean(destroyMethod = "")
-    public StacktaleAppender stacktaleAppender(StacktaleProperties props, BeanFactory beanFactory) {
+    public StacktaleAppender stacktaleAppender(StacktaleProperties props, BeanFactory beanFactory, Environment environment) {
         if (!(LoggerFactory.getILoggerFactory() instanceof LoggerContext ctx)) {
             // a different SLF4J backend is bound; nothing we can do — stay a no-op
             LoggerFactory.getLogger("stacktale")
@@ -65,6 +66,9 @@ public class StacktaleAutoConfiguration {
         appender.setContext(ctx);
         appender.setName(AUTO_APPENDER_NAME);
         appender.setFile(props.getFile());
+        appender.setAppName(
+                environment.getProperty("spring.application.name", "")
+        );
         appender.setAppPackages(resolveAppPackages(props, beanFactory));
         appender.setStorySize(props.getStorySize());
         appender.setStoryWindowSeconds(props.getStoryWindowSeconds());

--- a/stacktale-spring-boot-starter/src/test/java/io/github/gabrielbbaldez/stacktale/spring/demo/DemoShopApplication.java
+++ b/stacktale-spring-boot-starter/src/test/java/io/github/gabrielbbaldez/stacktale/spring/demo/DemoShopApplication.java
@@ -2,6 +2,7 @@ package io.github.gabrielbbaldez.stacktale.spring.demo;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,6 +13,10 @@ import org.springframework.web.server.ResponseStatusException;
 /** Minimal demo app: the only stacktale-related thing it has is the starter dependency. */
 @SpringBootApplication
 public class DemoShopApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DemoShopApplication.class, args);
+    }
 
     @RestController
     static class CheckoutController {

--- a/stacktale-spring-boot-starter/src/test/resources/application.properties
+++ b/stacktale-spring-boot-starter/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+spring.application.name=demoKVA2

--- a/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
+++ b/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
@@ -32,6 +32,8 @@ import java.util.regex.Pattern;
 public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILoggingEvent> {
 
     private String file = "errors-ai.log";
+    private String appName = "";
+    private String appVersion = "";
     private String appPackages = "";
     private int storySize = ReportPipeline.Settings.DEFAULT_STORY_SIZE;
     private int storyWindowSeconds = ReportPipeline.Settings.DEFAULT_STORY_WINDOW_SECONDS;
@@ -86,6 +88,8 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
 
         ReportPipeline.Settings settings = ReportPipeline.Settings.builder()
                 .file(file)
+                .appName(appName)
+                .appVersion(appVersion)
                 .appPackages(csv(appPackages))
                 .storySize(storySize)
                 .storyWindowMillis(storyWindowSeconds * 1000L)
@@ -232,6 +236,13 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
     // --- Logback config setters ---
 
     public void setFile(String file) { this.file = file; }
+    public void setAppName(String appName) {
+        this.appName = appName;
+    }
+
+    public void setAppVersion(String appVersion) {
+        this.appVersion = appVersion;
+    }
 
     public void setAppPackages(String appPackages) { this.appPackages = appPackages; }
 


### PR DESCRIPTION
<!-- Thanks for contributing. Keep this short — a sentence per box is plenty. -->

## What & why
This PR adds support for using `spring.application.name` as the application name when neither `stacktale.app.name` nor `build-info.properties` are available.

The Spring Boot starter now propagates the application name through `ReportPipeline.Settings` to `EnvCollector`, preserving the existing lookup priority while fixing reports that previously showed `env: app=?` for Spring Boot applications.

Closes #147 

## Summary

This PR adds support for using `spring.application.name` as the application name when neither `stacktale.app.name` nor `build-info.properties` are available.

### Changes

- Added `appName` and `appVersion` to `ReportPipeline.Settings`
- Passed Spring application name from the starter to the pipeline
- Updated `EnvCollector` fallback order

### Testing

Created a Spring Boot demo with:

spring.application.name=demoKVA

Before:

env: app=?

After:

env: app=demoKVA

## How it was verified

<!-- Pick one and delete the rest. -->

- [x] `mvn verify` is green (JDK 17+)
- [ ] Documentation-only — nothing to build

## Checklist

- [x] The issue was claimed with a comment before starting
- [x] One logical change (unrelated fixes belong in their own PR)
- [ ] Behavior changes arrive with the test that demanded them; bug fixes start from a failing test
- [x] No golden-file test changed
- [x] New config property? It has a setter (Not applicable)

## AI assistance (optional)

<!-- If an AI tool helped with this change you're welcome to mention it here. Entirely
     optional — it is not required and makes no difference to the review. -->

<!--
First time here? Everything above is explained in CONTRIBUTING.md:
https://github.com/stacktale/stacktale/blob/main/CONTRIBUTING.md

Don't worry about getting every box right — open the PR and we'll work through it.
-->
