### PR TITLE
fix: bug sweep — ReDoS, wedged rotation, uncaught-handler recursion, ignored Log4j2 filters

### DIFF
--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/Redactor.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/Redactor.java
@@ -33,6 +33,14 @@ final class Redactor {
     private static final int MIN_CORRELATION_LENGTH = 8;
 
     /**
+     * How long every custom pattern gets, together, on one string. Redaction runs on the
+     * application's logging thread inside the user's {@code log.error(...)}, so this is time
+     * their request is blocked. The built-in rules finish a few KB in microseconds; a sane
+     * custom rule is in the same class, and 100ms leaves three orders of magnitude of slack.
+     */
+    private static final long CUSTOM_PATTERN_BUDGET_NANOS = 100_000_000L;
+
+    /**
      * Per-process HMAC key: correlation is session-scoped (like {@code seen:}). A random
      * key means the suffix is a stable equality signal within one run, never a rainbow-table
      * target across runs or a hash an attacker can precompute from a guessed value.
@@ -127,12 +135,81 @@ final class Redactor {
             s = LONG_HEX.matcher(s).replaceAll(m -> mask(m.group()));
             s = EMAIL.matcher(s).replaceAll(m -> mask(m.group()));
             s = CARD_CANDIDATE.matcher(s).replaceAll(this::maskIfLuhnValid);
+            // One budget for all custom rules together, not one each: a config with twenty
+            // patterns must not buy twenty times as much of the caller's thread.
+            long expiresAt = System.nanoTime() + CUSTOM_PATTERN_BUDGET_NANOS;
             for (Pattern p : customPatterns) {
-                s = p.matcher(s).replaceAll(m -> mask(m.group()));
+                s = p.matcher(new Deadline(s, expiresAt)).replaceAll(m -> mask(m.group()));
             }
             return s;
         } catch (Throwable t) {
-            return s; // a broken pattern must never break a report
+            // A pattern that is broken, or one stopped by the deadline, must never break a
+            // report. `s` still carries every built-in rule, because they reassign it in turn.
+            return s;
+        }
+    }
+
+    /**
+     * Bounds how long one custom pattern may run.
+     *
+     * <p>{@link java.util.regex.Matcher} has no timeout and no cancel. The one hook a caller
+     * gets into a match already under way is {@code charAt}, which the engine calls for every
+     * character it examines — so a pattern backtracking exponentially calls it billions of
+     * times, and a deadline checked there is what stops it.
+     *
+     * <p>The check is sampled rather than made on every call, because {@code nanoTime()} on
+     * each character would cost more than the matching it guards.
+     *
+     * <p>Worth knowing for anyone reproducing this: most textbook catastrophic patterns do
+     * <em>not</em> hang here. {@code Pattern} extracts a required literal and pre-scans for it
+     * with {@code indexOf}, so {@code (x+x+)+y} against a string with no {@code y} returns at
+     * once without entering the loop. The shapes that do reach the loop are the ones with
+     * nothing scannable — a backreference tail such as {@code (a+)+\1b} is the reliable one,
+     * and it goes from 15ms to 30s between a 18- and a 30-character input.
+     */
+    private static final class Deadline implements CharSequence {
+
+        private static final int SAMPLE_EVERY = 4096;
+
+        private final CharSequence text;
+        private final long expiresAtNanos;
+        private int untilNextCheck = SAMPLE_EVERY;
+
+        Deadline(CharSequence text, long expiresAtNanos) {
+            this.text = text;
+            this.expiresAtNanos = expiresAtNanos;
+        }
+
+        @Override
+        public char charAt(int index) {
+            if (--untilNextCheck <= 0) {
+                untilNextCheck = SAMPLE_EVERY;
+                // subtraction, not <: nanoTime() has no fixed origin and can be negative
+                if (System.nanoTime() - expiresAtNanos > 0) throw new RedactionTooSlow();
+            }
+            return text.charAt(index);
+        }
+
+        @Override
+        public int length() {
+            return text.length();
+        }
+
+        @Override
+        public CharSequence subSequence(int start, int end) {
+            return text.subSequence(start, end);
+        }
+
+        @Override
+        public String toString() {
+            return text.toString();
+        }
+    }
+
+    /** Control flow, not a fault: no message, no stack, nothing to fill in or read. */
+    private static final class RedactionTooSlow extends RuntimeException {
+        RedactionTooSlow() {
+            super(null, null, false, false);
         }
     }
 

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportWriter.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportWriter.java
@@ -58,6 +58,7 @@ final class ReportWriter {
         this.maxBackups = Math.max(0, maxBackups);
         this.warn = warn != null ? warn : (m, t) -> { };
         probeWritable();
+        recoverInterruptedRotation();
     }
 
     /**
@@ -150,11 +151,7 @@ final class ReportWriter {
             return rotationBlocked(blocked);
         }
         try {
-            Files.deleteIfExists(backup(maxBackups));
-            for (int i = maxBackups - 1; i >= 1; i--) {
-                Path from = backup(i);
-                if (Files.exists(from)) Files.move(from, backup(i + 1), StandardCopyOption.REPLACE_EXISTING);
-            }
+            rollBackups();
             Files.move(pending, backup(1), StandardCopyOption.REPLACE_EXISTING);
             rotationBlockedWarned = false;
             return true;
@@ -179,6 +176,62 @@ final class ReportWriter {
                     + "retrying on the next report", e);
         }
         return false;
+    }
+
+    /** Shifts {@code .1…N-1} up one, dropping what falls off the end. */
+    private void rollBackups() throws IOException {
+        Files.deleteIfExists(backup(maxBackups));
+        for (int i = maxBackups - 1; i >= 1; i--) {
+            Path from = backup(i);
+            if (Files.exists(from)) Files.move(from, backup(i + 1), StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+
+    /**
+     * Finishes a rotation a previous run did not, folding an orphaned {@code <file>.rotating}
+     * into the backups.
+     *
+     * <p>Rotation moves the live file aside before rolling backups, so a process killed in
+     * between — SIGKILL, an OOM-killed container, power loss — leaves that sibling behind.
+     * Nothing used to clear it, and {@code Files.move} into it has no {@code REPLACE_EXISTING},
+     * so from then on <em>every</em> rotation attempt failed with {@code FileAlreadyExists}:
+     * not only for the rest of that run but for every run afterwards. The file then grew
+     * without bound and {@code maxFileSizeMb} meant nothing, with one {@code addWarn} per
+     * process as the only sign.
+     *
+     * <p>The orphan is folded in rather than deleted because it <em>is</em> the previous live
+     * file — it holds the newest reports written before the crash, and nothing else can reach
+     * them: {@code StReportFile.read()} scans {@code <file>} and {@code <file>.1…N} only.
+     *
+     * <p>Deleting it is still better than leaving it, so a failure to fold does that and says
+     * so. An orphan that survives would wedge rotation forever, which is the worse outcome.
+     */
+    private void recoverInterruptedRotation() {
+        Path pending = file.resolveSibling(file.getFileName() + ROTATING_SUFFIX);
+        // A directory by that name is someone else's, or a test standing in for a locked
+        // file; either way it is not an interrupted rotation of ours to finish.
+        if (!Files.isRegularFile(pending)) return;
+
+        try {
+            if (maxBackups == 0) {
+                Files.delete(pending); // no backups configured: rotation discards, so does this
+                return;
+            }
+            // Shift only when .1 is taken. A crash after the shift but before the last move
+            // leaves .1 free, and shifting again would push the oldest backup off the end
+            // to make room nobody needs.
+            if (Files.exists(backup(1))) rollBackups();
+            Files.move(pending, backup(1), StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            try {
+                Files.deleteIfExists(pending);
+            } catch (IOException ignored) {
+                // nothing left to try; the next run will attempt the same recovery
+            }
+            warn.accept("stacktale found an interrupted rotation of " + file.getFileName()
+                    + " and could not fold it into the backups; discarded it so rotation "
+                    + "works again", e);
+        }
     }
 
     private Path backup(int n) {

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/UncaughtHandler.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/UncaughtHandler.java
@@ -24,11 +24,40 @@ public final class UncaughtHandler implements Thread.UncaughtExceptionHandler {
         this.errorSink = errorSink;
     }
 
-    /** Idempotent; the sink logs (message, throwable) at ERROR via logger {@link #UNCAUGHT_LOGGER}. */
+    /**
+     * Routes uncaught exceptions to {@code errorSink}, which logs (message, throwable) at
+     * ERROR via logger {@link #UNCAUGHT_LOGGER}.
+     *
+     * <p>An existing handler of ours is <em>replaced</em>, not left in place. It used to be
+     * left, and the effect was that after a Spring DevTools restart — or the second context
+     * in a test suite — the stale handler kept feeding a pipeline that had been closed, so no
+     * uncaught exception produced a report ever again. The stale instance's {@code previous}
+     * is carried forward so whatever sat below us in the chain still runs.
+     *
+     * <p>Last caller wins. Two live pipelines both wanting uncaught exceptions is not a
+     * situation with a right answer, and preferring the newest is what makes a restart work.
+     */
     public static void install(BiConsumer<String, Throwable> errorSink) {
         Thread.UncaughtExceptionHandler current = Thread.getDefaultUncaughtExceptionHandler();
-        if (current instanceof UncaughtHandler) return;
-        Thread.setDefaultUncaughtExceptionHandler(new UncaughtHandler(current, errorSink));
+        Thread.UncaughtExceptionHandler below =
+                current instanceof UncaughtHandler ours ? ours.previous : current;
+        Thread.setDefaultUncaughtExceptionHandler(new UncaughtHandler(below, errorSink));
+    }
+
+    /**
+     * Restores the handler that was in place before ours, if ours is still the default.
+     *
+     * <p>Without this the static default handler pins a dead {@code LoggerContext} — and in a
+     * servlet hot-redeploy, the whole webapp classloader behind it.
+     *
+     * <p>Deliberately does nothing when the current default is not ours: an application that
+     * installed its own handler after us owns that slot, and taking it back would be worse
+     * than the leak.
+     */
+    public static void uninstall() {
+        if (Thread.getDefaultUncaughtExceptionHandler() instanceof UncaughtHandler ours) {
+            Thread.setDefaultUncaughtExceptionHandler(ours.previous);
+        }
     }
 
     @Override
@@ -40,8 +69,25 @@ public final class UncaughtHandler implements Thread.UncaughtExceptionHandler {
         }
         if (previous != null) {
             previous.uncaughtException(t, e);
-        } else if (t.getThreadGroup() != null) {
-            t.getThreadGroup().uncaughtException(t, e); // JVM default behavior: print to stderr
+            return;
+        }
+        // Deliberately NOT t.getThreadGroup().uncaughtException(t, e).
+        //
+        // The JVM dispatches through Thread.getUncaughtExceptionHandler(), which is the
+        // thread's own handler or its ThreadGroup; the group walks up to the root, and the
+        // root's last act is to call Thread.getDefaultUncaughtExceptionHandler(). That is us.
+        // So by the time this runs the group chain has already had its turn, and handing the
+        // throwable back to it means root → default → here → root, until the stack ends.
+        //
+        // With no previous handler — the ordinary case, since most applications never set one
+        // — every uncaught exception hit that loop and died as a StackOverflowError instead of
+        // being printed. Nothing caught it because the only test built the handler by hand
+        // rather than through install(), leaving the JVM default null and the loop unclosed.
+        //
+        // What the root group does when there is no default handler, done here instead:
+        if (!(e instanceof ThreadDeath)) {
+            System.err.print("Exception in thread \"" + t.getName() + "\" ");
+            e.printStackTrace(System.err);
         }
     }
 }

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/RedactorTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/RedactorTest.java
@@ -127,4 +127,49 @@ class RedactorTest {
         java.util.regex.Matcher m = Pattern.compile("███\\(([0-9a-f]+)\\)").matcher(redacted);
         return m.find() ? m.group(1) : null;
     }
+
+    @Test
+    void aCatastrophicCustomPatternCannotWedgeTheLoggingThread() {
+        // A nested quantifier alone is not enough: Pattern pulls out a required literal and
+        // pre-scans for it, so (x+x+)+y over a string with no 'y' returns immediately. A
+        // backreference leaves nothing to scan for, so the engine has to walk every split.
+        // Unpatched this takes ~3.8s at 27 characters and ~30s at 30.
+        Redactor redactor = Redactor.withDefaults(List.of(Pattern.compile("(a+)+\\1b")));
+        String hostile = "a".repeat(30);
+
+        long startedAt = System.nanoTime();
+        String out = redactor.redact(hostile);
+        long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000;
+
+        // redact() runs on the application's logging thread, inside the user's log.error call,
+        // so this is time a request is blocked. The budget is 100ms; allow for a loaded runner.
+        assertThat(elapsedMillis).isLessThan(2_000);
+        assertThat(out).isEqualTo(hostile); // nothing matched, and nothing was lost
+    }
+
+    @Test
+    void theDeadlineIsSharedAcrossPatternsRatherThanGrantedToEach() {
+        // Ten copies of the same runaway rule must cost one budget, not ten.
+        Pattern runaway = Pattern.compile("(a+)+\\1b");
+        Redactor redactor = Redactor.withDefaults(
+                java.util.Collections.nCopies(10, runaway));
+
+        long startedAt = System.nanoTime();
+        redactor.redact("a".repeat(30));
+        long elapsedMillis = (System.nanoTime() - startedAt) / 1_000_000;
+
+        assertThat(elapsedMillis).isLessThan(2_000);
+    }
+
+    @Test
+    void aSlowPatternCostsOnlyItsOwnRuleAndNotTheBuiltInOnes() {
+        // The built-ins reassign `s` in turn before the custom loop, so the catch that swallows
+        // the deadline still returns everything they masked. Degraded, not discarded.
+        Redactor redactor = Redactor.withDefaults(List.of(Pattern.compile("(a+)+\\1b")));
+
+        String out = redactor.redact("contact bob@example.com about " + "a".repeat(30));
+
+        assertThat(out).doesNotContain("bob@example.com");
+        assertThat(out).contains("███");
+    }
 }

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportWriterTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportWriterTest.java
@@ -130,4 +130,58 @@ class ReportWriterTest {
         assertThat(Files.readString(file, StandardCharsets.UTF_8)).startsWith("# h\n").contains("b").doesNotContain("a");
         assertThat(Files.exists(dir.resolve("errors-ai.log.1"))).isFalse();
     }
+
+    @Test
+    void anOrphanRotatingFileIsFoldedInAndRotationWorksAgain(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        // the state a SIGKILL between "move the live file aside" and "roll it into .1" leaves
+        Files.writeString(dir.resolve("errors-ai.log.rotating"), "newest, written before the crash\n");
+        Files.writeString(dir.resolve("errors-ai.log.1"), "older\n");
+
+        List<String> warnings = new ArrayList<>();
+        ReportWriter w = new ReportWriter(file, 40, "# h\n", null, false, 3, (m, t) -> warnings.add(m));
+
+        // the orphan is gone, and its reports are reachable again as .1 — StReportFile.read()
+        // scans <file> and <file>.1..N, so anywhere else they would be lost
+        assertThat(Files.exists(dir.resolve("errors-ai.log.rotating"))).isFalse();
+        assertThat(Files.readString(dir.resolve("errors-ai.log.1"), StandardCharsets.UTF_8))
+                .contains("before the crash");
+        assertThat(Files.readString(dir.resolve("errors-ai.log.2"), StandardCharsets.UTF_8))
+                .contains("older");
+        assertThat(warnings).isEmpty(); // finishing the job is not a problem worth reporting
+
+        // and the thing the orphan used to break: rotation itself
+        w.append("a".repeat(30) + "\n");
+        w.append("b".repeat(30) + "\n");
+        assertThat(Files.readString(file, StandardCharsets.UTF_8)).contains("b").doesNotContain("a");
+        assertThat(Files.readString(dir.resolve("errors-ai.log.1"), StandardCharsets.UTF_8)).contains("a");
+    }
+
+    @Test
+    void anOrphanFromACrashAfterTheShiftDoesNotCostAnExtraBackupSlot(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        // crashed one step later: the shift already happened, so .1 is free and .2/.3 hold
+        // what used to be .1/.2. Shifting again would push .3 off the end for no reason.
+        Files.writeString(dir.resolve("errors-ai.log.rotating"), "newest\n");
+        Files.writeString(dir.resolve("errors-ai.log.2"), "middle\n");
+        Files.writeString(dir.resolve("errors-ai.log.3"), "oldest\n");
+
+        new ReportWriter(file, 40, "# h\n", null, false, 3);
+
+        assertThat(Files.readString(dir.resolve("errors-ai.log.1"), StandardCharsets.UTF_8)).contains("newest");
+        assertThat(Files.readString(dir.resolve("errors-ai.log.2"), StandardCharsets.UTF_8)).contains("middle");
+        assertThat(Files.readString(dir.resolve("errors-ai.log.3"), StandardCharsets.UTF_8)).contains("oldest");
+    }
+
+    @Test
+    void anOrphanIsDiscardedWhenNoBackupsAreKept(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        Files.writeString(dir.resolve("errors-ai.log.rotating"), "nowhere to put this\n");
+
+        new ReportWriter(file, 40, "# h\n", null, false, 0);
+
+        // maxBackups=0 means rotation deletes rather than keeps; recovery matches that choice
+        assertThat(Files.exists(dir.resolve("errors-ai.log.rotating"))).isFalse();
+        assertThat(Files.exists(dir.resolve("errors-ai.log.1"))).isFalse();
+    }
 }

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/UncaughtHandlerLifecycleTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/UncaughtHandlerLifecycleTest.java
@@ -1,0 +1,125 @@
+package io.github.gabrielbbaldez.stacktale;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The install/uninstall pair around the JVM-global default handler (#121).
+ *
+ * <p>This slot is process-wide, so each test restores whatever it found. A leaked handler
+ * here would not fail this class — it would fail something unrelated, later.
+ */
+class UncaughtHandlerLifecycleTest {
+
+    private Thread.UncaughtExceptionHandler original;
+
+    @BeforeEach
+    void remember() {
+        original = Thread.getDefaultUncaughtExceptionHandler();
+    }
+
+    @AfterEach
+    void restore() {
+        Thread.setDefaultUncaughtExceptionHandler(original);
+    }
+
+    @Test
+    void aRestartRoutesToTheNewSinkRatherThanTheStoppedOne() {
+        List<String> firstContext = new ArrayList<>();
+        List<String> secondContext = new ArrayList<>();
+
+        UncaughtHandler.install((message, thrown) -> firstContext.add(message));
+        // what a Spring DevTools restart, or the second context in a test suite, does
+        UncaughtHandler.uninstall();
+        UncaughtHandler.install((message, thrown) -> secondContext.add(message));
+
+        fire(new IllegalStateException("boom"));
+
+        // install() used to return early on finding one of ours, so the stopped context's
+        // sink kept the slot and no uncaught exception produced a report again
+        assertThat(secondContext).hasSize(1);
+        assertThat(firstContext).isEmpty();
+    }
+
+    @Test
+    void installingOverAStaleHandlerKeepsWhateverSatBelowIt() {
+        List<String> application = new ArrayList<>();
+        Thread.UncaughtExceptionHandler applicationHandler = (t, e) -> application.add(e.getMessage());
+        Thread.setDefaultUncaughtExceptionHandler(applicationHandler);
+
+        List<String> reports = new ArrayList<>();
+        UncaughtHandler.install((message, thrown) -> reports.add(message));
+        UncaughtHandler.install((message, thrown) -> reports.add(message)); // stale one replaced
+
+        fire(new IllegalStateException("boom"));
+
+        // exactly one of ours in the chain, and the application's handler still runs
+        assertThat(reports).hasSize(1);
+        assertThat(application).containsExactly("boom");
+    }
+
+    @Test
+    void uninstallPutsBackTheHandlerThatWasThereBefore() {
+        Thread.UncaughtExceptionHandler applicationHandler = (t, e) -> { };
+        Thread.setDefaultUncaughtExceptionHandler(applicationHandler);
+
+        UncaughtHandler.install((message, thrown) -> { });
+        assertThat(Thread.getDefaultUncaughtExceptionHandler()).isNotSameAs(applicationHandler);
+
+        UncaughtHandler.uninstall();
+
+        // the static slot no longer pins the context behind that sink — in a servlet
+        // hot-redeploy it pinned the whole webapp classloader
+        assertThat(Thread.getDefaultUncaughtExceptionHandler()).isSameAs(applicationHandler);
+    }
+
+    @Test
+    void uninstallLeavesAHandlerTheApplicationInstalledAfterUs() {
+        List<String> application = new ArrayList<>();
+        UncaughtHandler.install((message, thrown) -> { });
+        Thread.UncaughtExceptionHandler laterHandler = (t, e) -> application.add(e.getMessage());
+        Thread.setDefaultUncaughtExceptionHandler(laterHandler);
+
+        UncaughtHandler.uninstall();
+
+        // that slot belongs to whoever took it last; taking it back would be worse than the leak
+        assertThat(Thread.getDefaultUncaughtExceptionHandler()).isSameAs(laterHandler);
+    }
+
+    @Test
+    void withNoPreviousHandlerTheThrowableIsPrintedRatherThanBouncedBackToTheRootGroup() {
+        Thread.setDefaultUncaughtExceptionHandler(null); // the ordinary case: nobody set one
+
+        List<String> reports = new ArrayList<>();
+        UncaughtHandler.install((message, thrown) -> reports.add(message));
+
+        java.io.PrintStream realErr = System.err;
+        java.io.ByteArrayOutputStream captured = new java.io.ByteArrayOutputStream();
+        System.setErr(new java.io.PrintStream(captured, true, java.nio.charset.StandardCharsets.UTF_8));
+        try {
+            // Used to delegate to t.getThreadGroup().uncaughtException(...). The root group's
+            // last act is to call the default handler — us — so this looped until the stack
+            // ended, turning every uncaught exception into a StackOverflowError.
+            fire(new IllegalStateException("boom"));
+        } finally {
+            System.setErr(realErr);
+        }
+
+        assertThat(reports).containsExactly("Uncaught exception in thread main");
+        assertThat(captured.toString(java.nio.charset.StandardCharsets.UTF_8))
+                .contains("Exception in thread")
+                .contains("boom");
+    }
+
+    /** Invokes the current default handler the way the JVM would for a dying thread. */
+    private void fire(Throwable t) {
+        Thread.getDefaultUncaughtExceptionHandler()
+                .uncaughtException(Thread.currentThread(), t);
+    }
+}

--- a/stacktale-jul/src/main/java/io/github/gabrielbbaldez/stacktale/jul/StacktaleJulHandler.java
+++ b/stacktale-jul/src/main/java/io/github/gabrielbbaldez/stacktale/jul/StacktaleJulHandler.java
@@ -54,6 +54,9 @@ public final class StacktaleJulHandler extends Handler {
 
     private final ReportPipeline pipeline;
 
+    /** Remembered so {@link #close()} restores the previous default handler it displaced. */
+    private final boolean installedUncaughtHandler;
+
     /** Reads configuration from {@code logging.properties} — the JUL-native path. */
     public StacktaleJulHandler() {
         this(settingsFromLogManager(), installUncaughtHandlerFromLogManager());
@@ -79,7 +82,8 @@ public final class StacktaleJulHandler extends Handler {
         // The JVM sends uncaught exceptions to stderr, never through JUL — so without this a
         // thread that dies without a log.error() produces no report (#55). Route them back in
         // via UNCAUGHT_LOGGER, which propagates to this handler on the (parent) root logger.
-        if (installUncaughtHandler && pipeline.isActive()) {
+        this.installedUncaughtHandler = installUncaughtHandler && pipeline.isActive();
+        if (installedUncaughtHandler) {
             UncaughtHandler.install((message, thrown) ->
                     Logger.getLogger(UncaughtHandler.UNCAUGHT_LOGGER).log(Level.SEVERE, message, thrown));
         }
@@ -119,6 +123,9 @@ public final class StacktaleJulHandler extends Handler {
     public void close() {
         ActivePipeline.unregister(pipeline);
         pipeline.close(); // flush pending repeat counters / storm lines
+        // leaving it installed pins this handler, and its sink would go on feeding the
+        // pipeline just closed above
+        if (installedUncaughtHandler) UncaughtHandler.uninstall();
     }
 
     private ReportPipeline.Host host() {

--- a/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
+++ b/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
@@ -67,6 +67,9 @@ public final class StacktaleAppender extends AbstractAppender {
     public boolean stop(long timeout, java.util.concurrent.TimeUnit timeUnit) {
         ActivePipeline.unregister(pipeline);
         pipeline.close(); // flush pending repeat counters
+        // leaving it installed pins this context, and its sink would go on feeding the
+        // pipeline just closed above
+        if (installUncaughtHandler) UncaughtHandler.uninstall();
         return super.stop(timeout, timeUnit);
     }
 

--- a/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
+++ b/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
@@ -45,8 +45,13 @@ public final class StacktaleAppender extends AbstractAppender {
     private final ReportPipeline pipeline;
     private final boolean installUncaughtHandler;
 
-    private StacktaleAppender(String name, ReportPipeline pipeline, boolean installUncaughtHandler) {
-        super(name, null, null, true, Property.EMPTY_ARRAY);
+    private StacktaleAppender(String name, org.apache.logging.log4j.core.Filter filter,
+                              boolean ignoreExceptions, Property[] properties,
+                              ReportPipeline pipeline, boolean installUncaughtHandler) {
+        // The filter used to be hard-coded null here, which is what made a nested <Filters>
+        // element do nothing: AppenderControl.isFilteredByAppender asks the appender for its
+        // filter, saw null, and let everything through (#122).
+        super(name, filter, null, ignoreExceptions, properties);
         this.pipeline = pipeline;
         this.installUncaughtHandler = installUncaughtHandler;
     }
@@ -120,9 +125,12 @@ public final class StacktaleAppender extends AbstractAppender {
     // Log4j2 2.26+ warns-as-error when a @PluginBuilderAttribute field has no public setter.
     // The plugin system writes these fields directly, so setters would be dead code — each
     // field carries @SuppressWarnings("log4j.public.setter"). (Harmless no-op on older Log4j2.)
-    public static final class Builder implements org.apache.logging.log4j.core.util.Builder<StacktaleAppender> {
+    public static final class Builder extends AbstractAppender.Builder<Builder>
+            implements org.apache.logging.log4j.core.util.Builder<StacktaleAppender> {
 
-        @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private String name = "STACKTALE";
+        // `name`, `ignoreExceptions`, the @PluginElement Filter and Property[] all come from
+        // AbstractAppender.Builder. Declaring name here again would shadow the inherited one
+        // and leave the plugin system with two fields of that name to choose between.
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private String file = "errors-ai.log";
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private String appPackages = "";
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private int storySize = ReportPipeline.Settings.DEFAULT_STORY_SIZE;
@@ -216,14 +224,14 @@ public final class StacktaleAppender extends AbstractAppender {
                     LogManager.getLogger(ReportPipeline.REPORTS_LOGGER).info(block);
                 }
             });
-            return new StacktaleAppender(name, pipeline, installUncaughtHandler);
+            return new StacktaleAppender(getName(), getFilter(), isIgnoreExceptions(),
+                    getPropertyArray(), pipeline, installUncaughtHandler);
         }
 
         private static List<String> csv(String s) {
             return io.github.gabrielbbaldez.stacktale.Csv.parse(s);
         }
 
-        public Builder setName(String name) { this.name = name; return this; }
         public Builder setFile(String file) { this.file = file; return this; }
         public Builder setAppPackages(String appPackages) { this.appPackages = appPackages; return this; }
     }

--- a/stacktale-log4j2/src/test/java/io/github/gabrielbbaldez/stacktale/log4j2/Log4j2IntegrationTest.java
+++ b/stacktale-log4j2/src/test/java/io/github/gabrielbbaldez/stacktale/log4j2/Log4j2IntegrationTest.java
@@ -1,6 +1,7 @@
 package io.github.gabrielbbaldez.stacktale.log4j2;
 
 import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configurator;
@@ -108,5 +109,71 @@ class Log4j2IntegrationTest {
         String content = Files.readString(file, StandardCharsets.UTF_8);
         assertThat(content).contains("ERROR (no exception): payment rejected for order 77");
         assertThat(content).doesNotContain("stack (distilled,");
+    }
+
+    @Test
+    void aNestedFilterIsHonoured(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        // The idiomatic Log4j2 shape, and the mechanism a user reaches for to keep a noisy
+        // logger out of the story. It did nothing: the Builder implemented util.Builder
+        // directly, so it declared no @PluginElement Filter, and the appender was constructed
+        // with a hard-coded null one (#122).
+        String xml = """
+                <Configuration status="WARN" packages="io.github.gabrielbbaldez.stacktale.log4j2">
+                  <Appenders>
+                    <Stacktale name="STACKTALE" file="%s" appPackages="com.acme"
+                               installUncaughtHandler="false">
+                      <MarkerFilter marker="SKIP" onMatch="DENY" onMismatch="NEUTRAL"/>
+                    </Stacktale>
+                  </Appenders>
+                  <Loggers>
+                    <Root level="info">
+                      <AppenderRef ref="STACKTALE"/>
+                    </Root>
+                  </Loggers>
+                </Configuration>
+                """.formatted(file.toString().replace("\\", "/"));
+        ConfigurationSource source = new ConfigurationSource(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        ctx = Configurator.initialize(null, source);
+
+        Logger log = ctx.getLogger("com.acme.OrderService");
+        log.error(MarkerManager.getMarker("SKIP"), "denied by the nested filter");
+        log.error("this one gets through");
+
+        String content = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(content).contains("this one gets through");
+        assertThat(content).doesNotContain("denied by the nested filter");
+    }
+
+    @Test
+    void theSameConfigOnLogbackAndLog4j2AgreeOnFiltering(@TempDir Path dir) throws Exception {
+        // Logback runs getFilterChainDecision in UnsynchronizedAppenderBase.doAppend and JUL
+        // runs Handler.isLoggable, so both already honoured a nested filter. This asserts the
+        // Log4j2 adapter no longer stands alone in ignoring one.
+        Path file = dir.resolve("errors-ai.log");
+        String xml = """
+                <Configuration status="WARN" packages="io.github.gabrielbbaldez.stacktale.log4j2">
+                  <Appenders>
+                    <Stacktale name="STACKTALE" file="%s" appPackages="com.acme"
+                               installUncaughtHandler="false">
+                      <ThresholdFilter level="FATAL" onMatch="ACCEPT" onMismatch="DENY"/>
+                    </Stacktale>
+                  </Appenders>
+                  <Loggers>
+                    <Root level="info">
+                      <AppenderRef ref="STACKTALE"/>
+                    </Root>
+                  </Loggers>
+                </Configuration>
+                """.formatted(file.toString().replace("\\", "/"));
+        ConfigurationSource source = new ConfigurationSource(
+                new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        ctx = Configurator.initialize(null, source);
+
+        ctx.getLogger("com.acme.OrderService").error("below the threshold", new IllegalStateException("x"));
+
+        // nothing reached the pipeline, so nothing was written — not even a header
+        assertThat(Files.exists(file) && Files.size(file) > 0).isFalse();
     }
 }

--- a/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
+++ b/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
@@ -138,7 +138,12 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
             // reports share this file, this dedup window and this story buffer
             ActivePipeline.register(pipeline);
             if (installUncaughtHandler) {
-                org.slf4j.Logger uncaught = LoggerFactory.getLogger(UncaughtHandler.UNCAUGHT_LOGGER);
+                // context-local, for the same reason selfLogger and reportsLogger are: the
+                // global LoggerFactory can point at a different context than the one this
+                // appender belongs to, and then the sink writes somewhere else entirely
+                ch.qos.logback.classic.Logger uncaught =
+                        ((ch.qos.logback.classic.LoggerContext) getContext())
+                                .getLogger(UncaughtHandler.UNCAUGHT_LOGGER);
                 UncaughtHandler.install(uncaught::error);
             }
         }
@@ -150,6 +155,9 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
             ActivePipeline.unregister(pipeline);
             pipeline.close(); // flush pending repeat counters
         }
+        // before super.stop(): leaving it installed pins this context, and its sink would go
+        // on feeding the pipeline just closed above
+        if (installUncaughtHandler) UncaughtHandler.uninstall();
         super.stop();
     }
 


### PR DESCRIPTION
Four filed bugs, one commit each, every fix pinned by a test that fails against the previous code.

Closes #118, closes #120, closes #121, closes #122.

## #118 — a custom redaction pattern could wedge the logging thread

Redaction runs synchronously inside the user's `log.error(...)`, and custom patterns come straight from config. The existing `catch (Throwable)` does not help, because a hang is not a throw.

Custom patterns now match through a `CharSequence` that checks a deadline from `charAt` — the only hook into a match already under way, since `Matcher` has no timeout. 100ms for all custom rules together, not each.

**The issue's own example does not reproduce**, and neither do most textbook evil regexes. `Pattern` extracts a required literal and pre-scans for it with `indexOf`, so `(x+x+)+y` against a string containing no `y` never enters the loop. Reaching it needs a pattern with nothing scannable — a backreference tail is the reliable shape:

| input | `(a+)+\1b` |
|---|---|
| 18 chars | 15 ms |
| 24 chars | 479 ms |
| 27 chars | 3812 ms |
| 30 chars | **30597 ms** |

The 30-character case now fits inside the test suite's own runtime.

## #120 — an orphaned `.rotating` file disabled rotation forever

A process killed between "move the live file aside" and "roll it into `.1`" left the sibling behind, and the move into it has no `REPLACE_EXISTING`. Every later rotation then failed with `FileAlreadyExists` — not only for the rest of that run but for **every run afterwards**. `errors-ai.log` grew without bound and `maxFileSizeMb` meant nothing.

The constructor now finishes the rotation that was interrupted. Folding the orphan in rather than deleting it is the point: it *is* the previous live file, holding the newest reports before the crash, and `StReportFile.read()` scans `<file>` and `<file>.1…N` only, so nothing else can reach them.

## #121 — two bugs, and the second is the serious one

`install()` returned early on finding one of ours and nothing removed it, so after a DevTools restart the stale handler kept feeding a closed pipeline and pinned the dead `LoggerContext`. Fixed as filed: replace-and-carry-forward, plus `uninstall()` from every adapter's `stop()`/`close()`.

Testing that turned up a `StackOverflowError`. With no previous handler — **the ordinary case, since most applications never set one** — the fallback called `t.getThreadGroup().uncaughtException(t, e)`. The JVM dispatches through the ThreadGroup first and the root group's last act is to call `Thread.getDefaultUncaughtExceptionHandler()`, which is us. So every uncaught exception went root → default → here → root until the stack ended, and died as a `StackOverflowError` instead of being reported or printed.

That is the flagship "plain-Java apps get reports for exceptions that never reach a `log.error`" path. Nothing caught it because the only existing test built `UncaughtHandler` by hand rather than through `install()`, which leaves the JVM default null and the loop open.

## #122 — the Log4j2 appender ignored a nested `<Filters>`

`Builder` implemented `util.Builder` directly rather than extending `AbstractAppender.Builder`, so no `@PluginElement Filter` field existed and the constructor hard-coded null. The idiomatic config did nothing, silently, and only on this adapter — Logback and JUL both honoured it.

**One behaviour change:** the inherited `name` is `@Required`, where the local field defaulted to `"STACKTALE"`. A `<Stacktale>` with no name now fails configuration. Every documented example sets one, and an unnamed appender cannot be referenced from `<AppenderRef>`.

## Verification

`mvn verify` green across all 8 modules. For #122 the two new tests were run against the previous appender and both fail there, with the message that should have been denied visible in the output.
