### PR TITLE
fix: JUL config keys, Log4j2 happy-path allocation, and the story a correlated test lost

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,15 @@ io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.maxReportsPerMinute =
 io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.redactionEnabled = true
 io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.redactionCorrelation = false
 io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.redactPatterns = (password|token)=.*;;secret=\w+
+io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.captureExceptionFields = true
+io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.reportErrorsWithoutThrowable = true
+io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.truncateOnStart = false
+io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.echoSuppressionMillis = 2000
+io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.containerLoggers = org.apache.catalina.core.ContainerBase
+io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.emitReportsToLogger = false
+io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.zone = America/Sao_Paulo
+io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.installUncaughtHandler = true
+io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler..level = ALL
 ```
 
 `SEVERE` records become reports; lower levels feed the story (which correlates by thread,
@@ -587,8 +596,8 @@ Everything is optional — as appender properties in `logback.xml`, or `stacktal
 contain commas, so commas are not the delimiter).
 
 **Container loggers by framework.** Logback: repeatable `<containerLogger>` elements.
-Log4j2: a comma-separated `containerLoggers` attribute. JUL: uses the built-in default
-(`org.apache.catalina.core.ContainerBase`) and does not currently support custom values.
+Log4j2 and JUL: a comma-separated `containerLoggers` attribute/property. All three
+default to Tomcat's `org.apache.catalina.core.ContainerBase`.
 
 The **agent** takes `-javaagent:stacktale-agent.jar=packages=com.your.app` plus optional
 `excludes=`, `maxFrames=`, `maxValueLength=`, and `renderToString=false` (privacy mode:

--- a/README.md
+++ b/README.md
@@ -427,6 +427,8 @@ through the same pipeline.
 
 ~110 ns per happy-path event on an ordinary dev machine (JDK 21, Windows, single JMH
 fork — reproduce with [`AppendBenchmark`](stacktale/src/test/java/io/github/gabrielbbaldez/stacktale/AppendBenchmark.java)).
+The number is measured on Logback. The Log4j2 and JUL adapters take the same
+allocation-free path for an event with no context, but have no benchmark of their own.
 Writing a full report costs milliseconds — errors are rare, that's the deal.
 
 ## Token economics (measured)

--- a/README.md
+++ b/README.md
@@ -314,6 +314,30 @@ an agent: told to "fix it, re-run the tests, then check what changed", it would 
 testImplementation 'io.github.gabrielbbaldez:stacktale-junit:1.1.0'
 ```
 
+**If your tests set a correlation key**, add `StacktaleExtension`. The listener is notified
+after the test method returns, when the MDC is already unwound — so the failure event has no
+`traceId`, looks in the thread bucket, and the report comes out with a story of one line:
+itself. The extension runs inside the test's own lifecycle and snapshots the MDC while it is
+still there.
+
+```java
+@ExtendWith(StacktaleExtension.class)
+class CheckoutIT { … }
+```
+
+Or once for the whole build, in `junit-platform.properties`:
+
+```properties
+junit.jupiter.extensions.autodetection.enabled = true
+```
+
+It is opt-in: the zero-config listener behaves exactly as it does without it, and a project
+that does not depend on Jupiter never sees it. Tests that never touch the MDC — most unit
+tests — need nothing. One case stays out of reach: a test that clears its own MDC in a
+`finally` inside the method body has already unwound it before the exception leaves, and no
+hook runs earlier than that. Clearing in `@AfterEach`, which is where a fixture or filter
+does it, works.
+
 
 The listener is discovered through `META-INF/services`, so Surefire, Gradle and your IDE
 pick it up on their own. Every failing test becomes a normal `st/1` report:

--- a/stacktale-jul/src/main/java/io/github/gabrielbbaldez/stacktale/jul/StacktaleJulHandler.java
+++ b/stacktale-jul/src/main/java/io/github/gabrielbbaldez/stacktale/jul/StacktaleJulHandler.java
@@ -191,6 +191,46 @@ public final class StacktaleJulHandler extends Handler {
 
         String format = m.getProperty(p + "format");
         if (format != null) b.jsonFormat("json".equalsIgnoreCase(format.trim()));
+
+        // captureExceptionFields is a privacy control, not a tuning knob: it decides whether
+        // getters on the user's own exception types are called and their values written to the
+        // report. Dropping it meant a JUL user whose exceptions expose PII had no way off.
+        Boolean captureFields = boolProp(m, p + "captureExceptionFields");
+        if (captureFields != null) b.captureExceptionFields(captureFields);
+
+        Boolean truncate = boolProp(m, p + "truncateOnStart");
+        if (truncate != null) b.truncateOnStart(truncate);
+
+        Boolean withoutThrowable = boolProp(m, p + "reportErrorsWithoutThrowable");
+        if (withoutThrowable != null) b.reportErrorsWithoutThrowable(withoutThrowable);
+
+        Boolean toLogger = boolProp(m, p + "emitReportsToLogger");
+        if (toLogger != null) b.emitReportsToLogger(toLogger);
+
+        String echo = m.getProperty(p + "echoSuppressionMillis");
+        if (echo != null && !echo.isBlank()) {
+            try {
+                b.echoSuppressionMillis(Long.parseLong(echo.trim()));
+            } catch (NumberFormatException ignored) {
+                // keep the default rather than fail handler construction
+            }
+        }
+
+        String containerLoggers = m.getProperty(p + "containerLoggers");
+        if (containerLoggers != null) b.containerLoggers(Csv.parse(containerLoggers));
+
+        // A bad zone silently landing every timestamp in the system default is the worst of
+        // both worlds — the reports look fine and are wrong. Keep the default, but say so.
+        String zone = m.getProperty(p + "zone");
+        if (zone != null && !zone.isBlank()) {
+            try {
+                b.zone(java.time.ZoneId.of(zone.trim()));
+            } catch (java.time.DateTimeException e) {
+                Logger.getLogger(ReportPipeline.SELF_LOGGER).warning(
+                        "stacktale: invalid zone '" + zone.trim() + "', using the system default");
+            }
+        }
+
         return b.build();
     }
 
@@ -202,5 +242,11 @@ public final class StacktaleJulHandler extends Handler {
         } catch (NumberFormatException e) {
             return fallback;
         }
+    }
+
+    /** {@code null} when the key is absent, so an unset property keeps the builder's default. */
+    private static Boolean boolProp(LogManager m, String key) {
+        String v = m.getProperty(key);
+        return v == null || v.isBlank() ? null : Boolean.parseBoolean(v.trim());
     }
 }

--- a/stacktale-jul/src/test/java/io/github/gabrielbbaldez/stacktale/jul/LoggingPropertiesConfigTest.java
+++ b/stacktale-jul/src/test/java/io/github/gabrielbbaldez/stacktale/jul/LoggingPropertiesConfigTest.java
@@ -1,0 +1,233 @@
+package io.github.gabrielbbaldez.stacktale.jul;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The {@code logging.properties} path — the one the README documents — driven through a real
+ * {@link LogManager#readConfiguration}.
+ *
+ * <p>Every other test in this module builds {@code Settings} programmatically, so the whole
+ * declarative mechanism was unexercised and seven documented keys were silently dropped: a
+ * typo'd name and a key nobody wired look identical from outside (#124).
+ *
+ * <p>Each test asserts the resulting <em>behaviour</em>, not that parsing did not throw. A key
+ * that is read and then ignored would pass the second and fail the first.
+ */
+class LoggingPropertiesConfigTest {
+
+    private StacktaleJulHandler handler;
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (handler != null) handler.close();
+        LogManager.getLogManager().reset();
+        LogManager.getLogManager().readConfiguration();
+    }
+
+    /** Installs {@code properties} as the JUL configuration and builds the handler from it. */
+    private StacktaleJulHandler configure(String properties) throws Exception {
+        LogManager.getLogManager().readConfiguration(
+                new ByteArrayInputStream(properties.getBytes(StandardCharsets.UTF_8)));
+        handler = new StacktaleJulHandler();
+        return handler;
+    }
+
+    private static String key(String name) {
+        return StacktaleJulHandler.class.getName() + "." + name;
+    }
+
+    private static LogRecord severe(String logger, String message, Throwable thrown) {
+        LogRecord record = new LogRecord(Level.SEVERE, message);
+        record.setLoggerName(logger);
+        record.setThrown(thrown);
+        return record;
+    }
+
+    static class ExposesPii extends RuntimeException {
+        ExposesPii(String message) { super(message); }
+        public String getCustomerEmail() { return "someone@example.com"; }
+    }
+
+    @Test
+    void captureExceptionFieldsOffStopsGettersBeingCalled(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        // This one is a privacy control, not a tuning knob: it decides whether getters on the
+        // user's own exception types run and land in the report. Unwired, a JUL user whose
+        // exceptions expose PII had no way to turn it off.
+        StacktaleJulHandler h = configure(
+                key("file") + " = " + escape(file) + "\n"
+                        + key("appPackages") + " = com.acme\n"
+                        + key("installUncaughtHandler") + " = false\n"
+                        + key("captureExceptionFields") + " = false\n");
+
+        h.publish(severe("com.acme.Orders", "checkout failed", new ExposesPii("boom")));
+
+        String content = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(content).contains("ExposesPii: boom");
+        assertThat(content).doesNotContain("someone@example.com");
+        assertThat(content).doesNotContain("customerEmail");
+    }
+
+    @Test
+    void captureExceptionFieldsDefaultsToOnSoTheKeyIsProvedToDoSomething(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        StacktaleJulHandler h = configure(
+                key("file") + " = " + escape(file) + "\n"
+                        + key("appPackages") + " = com.acme\n"
+                        + key("installUncaughtHandler") + " = false\n");
+
+        h.publish(severe("com.acme.Orders", "checkout failed", new ExposesPii("boom")));
+
+        // the counterpart of the test above: without it, "no PII in the report" would pass
+        // just as well if field capture had never worked at all
+        assertThat(Files.readString(file, StandardCharsets.UTF_8)).contains("customerEmail");
+    }
+
+    @Test
+    void reportErrorsWithoutThrowableOffSkipsThrowablelessErrors(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        StacktaleJulHandler h = configure(
+                key("file") + " = " + escape(file) + "\n"
+                        + key("appPackages") + " = com.acme\n"
+                        + key("installUncaughtHandler") + " = false\n"
+                        + key("reportErrorsWithoutThrowable") + " = false\n");
+
+        h.publish(severe("com.acme.Pay", "payment rejected", null));
+
+        assertThat(Files.exists(file) && Files.size(file) > 0).isFalse();
+    }
+
+    @Test
+    void truncateOnStartDropsThePreviousRun(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        Files.writeString(file, "# format st/1\nleft over from the previous run\n");
+
+        StacktaleJulHandler h = configure(
+                key("file") + " = " + escape(file) + "\n"
+                        + key("appPackages") + " = com.acme\n"
+                        + key("installUncaughtHandler") + " = false\n"
+                        + key("truncateOnStart") + " = true\n");
+        h.publish(severe("com.acme.Orders", "fresh", new IllegalStateException("x")));
+
+        assertThat(Files.readString(file, StandardCharsets.UTF_8))
+                .doesNotContain("left over")
+                .contains("fresh");
+    }
+
+    @Test
+    void containerLoggersSuppressTheContainersReLogOfAFailureWeJustReported(@TempDir Path dir)
+            throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        // Not "excluded from the story" — a container logger is one whose re-log of a failure
+        // the application already reported, on the same thread and inside the echo window, is
+        // a duplicate. Only Tomcat's prefix was built in; JUL could not add to the list.
+        StacktaleJulHandler h = configure(
+                key("file") + " = " + escape(file) + "\n"
+                        + key("appPackages") + " = com.acme\n"
+                        + key("installUncaughtHandler") + " = false\n"
+                        + key("containerLoggers") + " = org.noisy\n");
+
+        IllegalStateException boom = new IllegalStateException("x");
+        h.publish(severe("com.acme.Orders", "checkout failed", boom));
+        // the framework catching the same failure and logging it again a moment later
+        h.publish(severe("org.noisy.Dispatcher", "Servlet.service() threw exception", boom));
+
+        String content = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(content).contains("checkout failed");
+        assertThat(content).doesNotContain("Servlet.service()");
+    }
+
+    @Test
+    void zoneMovesTheReportTimestamp(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        StacktaleJulHandler h = configure(
+                key("file") + " = " + escape(file) + "\n"
+                        + key("appPackages") + " = com.acme\n"
+                        + key("installUncaughtHandler") + " = false\n"
+                        + key("zone") + " = Pacific/Kiritimati\n"); // UTC+14, unlike any CI default
+
+        LogRecord record = severe("com.acme.Orders", "checkout failed", new IllegalStateException("x"));
+        // 2024-01-01T00:00:00Z. Not the epoch: Kiritimati only moved to +14 in 1995, and at
+        // epoch 0 it sat at −10:40 — which renders as 1969-12-31 and looks like a bug.
+        record.setMillis(1_704_067_200_000L);
+        h.publish(record);
+
+        assertThat(Files.readString(file, StandardCharsets.UTF_8)).contains("2024-01-01 14:00");
+    }
+
+    @Test
+    void aBadZoneKeepsTheDefaultAndSaysSoRatherThanSilentlyShiftingEveryTimestamp(@TempDir Path dir)
+            throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        StacktaleJulHandler h = configure(
+                key("file") + " = " + escape(file) + "\n"
+                        + key("appPackages") + " = com.acme\n"
+                        + key("installUncaughtHandler") + " = false\n"
+                        + key("zone") + " = Middle/Earth\n");
+
+        h.publish(severe("com.acme.Orders", "checkout failed", new IllegalStateException("x")));
+
+        // construction survives; the report is written with the system default zone
+        assertThat(Files.readString(file, StandardCharsets.UTF_8)).contains("checkout failed");
+    }
+
+    @Test
+    void emitReportsToLoggerAlsoSendsTheBlockThroughJul(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        java.util.List<String> throughJul = new java.util.ArrayList<>();
+        Logger reports = Logger.getLogger(io.github.gabrielbbaldez.stacktale.ReportPipeline.REPORTS_LOGGER);
+        java.util.logging.Handler collector = new java.util.logging.Handler() {
+            @Override public void publish(LogRecord r) { throughJul.add(r.getMessage()); }
+            @Override public void flush() { }
+            @Override public void close() { }
+        };
+
+        StacktaleJulHandler h = configure(
+                key("file") + " = " + escape(file) + "\n"
+                        + key("appPackages") + " = com.acme\n"
+                        + key("installUncaughtHandler") + " = false\n"
+                        + key("emitReportsToLogger") + " = true\n");
+        reports.addHandler(collector);
+        try {
+            h.publish(severe("com.acme.Orders", "checkout failed", new IllegalStateException("x")));
+        } finally {
+            reports.removeHandler(collector);
+        }
+
+        assertThat(throughJul).anyMatch(m -> m.contains("━━━ ERROR #"));
+        assertThat(Files.readString(file, StandardCharsets.UTF_8)).contains("checkout failed");
+    }
+
+    @Test
+    void installUncaughtHandlerIsReadFromThePropertiesFile(@TempDir Path dir) throws Exception {
+        Thread.UncaughtExceptionHandler before = Thread.getDefaultUncaughtExceptionHandler();
+        try {
+            configure(key("file") + " = " + escape(dir.resolve("errors-ai.log")) + "\n"
+                    + key("appPackages") + " = com.acme\n"
+                    + key("installUncaughtHandler") + " = false\n");
+
+            // the key is in the README's JUL list; nothing proved it was honoured
+            assertThat(Thread.getDefaultUncaughtExceptionHandler()).isSameAs(before);
+        } finally {
+            Thread.setDefaultUncaughtExceptionHandler(before);
+        }
+    }
+
+    /** JUL properties are Properties-format, where a Windows path's backslashes are escapes. */
+    private static String escape(Path path) {
+        return path.toString().replace("\\", "/");
+    }
+}

--- a/stacktale-junit/pom.xml
+++ b/stacktale-junit/pom.xml
@@ -37,6 +37,18 @@
       <scope>provided</scope>
     </dependency>
 
+    <!--
+      provided, not compile: StacktaleExtension is the optional half of this module. The
+      zero-config listener needs only the launcher, and a project that never registers the
+      extension must not be made to drag Jupiter in on our account.
+    -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>${junit.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/stacktale-junit/src/main/java/io/github/gabrielbbaldez/stacktale/junit/StacktaleExtension.java
+++ b/stacktale-junit/src/main/java/io/github/gabrielbbaldez/stacktale/junit/StacktaleExtension.java
@@ -1,0 +1,51 @@
+package io.github.gabrielbbaldez.stacktale.junit;
+
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
+import org.junit.jupiter.api.extension.Extension;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Optional companion to {@link StacktaleTestListener}: gives a failing test's report the story
+ * of what the test actually logged.
+ *
+ * <p>Without it, a test that sets a correlation key gets a report containing one story line —
+ * itself. The listener is notified after the test method returns, when the MDC is already
+ * unwound, so the synthetic failure event carries no key and looks in the thread bucket, while
+ * everything the test logged went to the {@code traceId} bucket. Tests that never touch the
+ * MDC are unaffected, which is most unit tests; this bites exactly where the story is worth
+ * most — an integration test with a traceId, or anything exercising request-scoped code.
+ *
+ * <p>Register it either way:
+ *
+ * <pre>{@code
+ * @ExtendWith(StacktaleExtension.class)
+ * class CheckoutIT { … }
+ * }</pre>
+ *
+ * <p>or once for the whole build, in {@code junit-platform.properties}:
+ *
+ * <pre>
+ * junit.jupiter.extensions.autodetection.enabled = true
+ * </pre>
+ *
+ * <p>It stays opt-in on purpose. The zero-config listener is the headline feature and must
+ * behave exactly as it does today when this class is not registered — or not on the classpath
+ * at all, which is the case for any project that does not depend on Jupiter.
+ */
+public final class StacktaleExtension implements Extension, AfterTestExecutionCallback {
+
+    /**
+     * Snapshots the MDC the instant the test body ends.
+     *
+     * <p>{@code AfterTestExecutionCallback} rather than {@code TestWatcher}: this runs before
+     * {@code @AfterEach}, so the MDC is exactly as the test left it. A watcher fires after the
+     * teardown callbacks, and a suite that clears the MDC in {@code @AfterEach} — the correct
+     * thing to do — would have nothing left to capture.
+     */
+    @Override
+    public void afterTestExecution(ExtensionContext context) {
+        // Only a failing test produces a report, so only a failing test needs its MDC kept.
+        if (context.getExecutionException().isEmpty()) return;
+        TestMdc.remember(context.getUniqueId(), TestMdc.snapshot());
+    }
+}

--- a/stacktale-junit/src/main/java/io/github/gabrielbbaldez/stacktale/junit/StacktaleTestListener.java
+++ b/stacktale-junit/src/main/java/io/github/gabrielbbaldez/stacktale/junit/StacktaleTestListener.java
@@ -113,6 +113,11 @@ public final class StacktaleTestListener implements TestExecutionListener {
     /** Test coordinates as MDC, so they render on the report's {@code mdc:} line. */
     private Map<String, String> context(TestIdentifier identifier, String testClass, String displayName) {
         Map<String, String> mdc = new LinkedHashMap<>();
+        // What the test had in its MDC when its body ended, if StacktaleExtension was
+        // registered to capture it. Empty otherwise, which is the behaviour without it.
+        // First, so the correlation key is present for storyFor to resolve the right bucket —
+        // and so the test coordinates below win on a name collision, since those are ours.
+        mdc.putAll(TestMdc.take(identifier.getUniqueId()));
         mdc.put("test.class", testClass);
         methodName(identifier).ifPresent(m -> mdc.put("test.method", m));
         mdc.put("test.displayName", displayName);

--- a/stacktale-junit/src/main/java/io/github/gabrielbbaldez/stacktale/junit/TestMdc.java
+++ b/stacktale-junit/src/main/java/io/github/gabrielbbaldez/stacktale/junit/TestMdc.java
@@ -1,0 +1,78 @@
+package io.github.gabrielbbaldez.stacktale.junit;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Carries a test's MDC from the test thread, where it still exists, to the listener, where it
+ * does not.
+ *
+ * <p>{@code TestExecutionListener} is notified after the test method has returned and its
+ * {@code @AfterEach} callbacks have run, so by then the MDC is unwound and the synthetic
+ * failure event carries no correlation key. It therefore lands in the thread bucket, while
+ * everything the test logged went to the {@code traceId} bucket — and the report comes out
+ * with a story of one line: itself (#134).
+ *
+ * <p>{@link StacktaleExtension} runs inside the test's own lifecycle and can see the MDC. It
+ * leaves the snapshot here, keyed by unique id rather than thread, because the listener is
+ * not guaranteed to be on the thread that ran the test.
+ */
+final class TestMdc {
+
+    /**
+     * Written only for a failing test and removed when read, so the size is bounded by the
+     * failures a run has produced but not yet reported — in practice one.
+     */
+    private static final Map<String, Map<String, String>> BY_UNIQUE_ID = new ConcurrentHashMap<>();
+
+    /** {@code org.slf4j.MDC.getCopyOfContextMap()}, or {@code null} when SLF4J is absent. */
+    private static final MethodHandle GET_COPY_OF_CONTEXT_MAP = resolveMdc();
+
+    private TestMdc() {
+    }
+
+    private static MethodHandle resolveMdc() {
+        try {
+            // Reflective for the same reason AgentCaptures resolves CaptureRegistry that way:
+            // this module must not require SLF4J. A JUL or Log4j2 project uses the listener
+            // with no SLF4J on the classpath at all, and that has to keep working.
+            Class<?> mdc = Class.forName("org.slf4j.MDC");
+            return MethodHandles.publicLookup().findStatic(
+                    mdc, "getCopyOfContextMap", MethodType.methodType(Map.class));
+        } catch (Throwable absent) {
+            return null;
+        }
+    }
+
+    /** The current MDC, or an empty map when SLF4J is absent or nothing is set. */
+    @SuppressWarnings("unchecked")
+    static Map<String, String> snapshot() {
+        if (GET_COPY_OF_CONTEXT_MAP == null) return Map.of();
+        try {
+            Map<String, String> current = (Map<String, String>) GET_COPY_OF_CONTEXT_MAP.invoke();
+            return current == null || current.isEmpty() ? Map.of() : Map.copyOf(current);
+        } catch (Throwable ignored) {
+            return Map.of(); // a story without the correlation key beats failing a test run
+        }
+    }
+
+    static void remember(String uniqueId, Map<String, String> mdc) {
+        if (uniqueId == null || mdc == null || mdc.isEmpty()) return;
+        BY_UNIQUE_ID.put(uniqueId, mdc);
+    }
+
+    /** Reads and clears — a snapshot belongs to exactly one report. */
+    static Map<String, String> take(String uniqueId) {
+        if (uniqueId == null) return Map.of();
+        Map<String, String> mdc = BY_UNIQUE_ID.remove(uniqueId);
+        return mdc == null ? Map.of() : mdc;
+    }
+
+    /** Whether SLF4J was found — reported in the extension's own failure mode, not guessed at. */
+    static boolean mdcAvailable() {
+        return GET_COPY_OF_CONTEXT_MAP != null;
+    }
+}

--- a/stacktale-junit/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/stacktale-junit/src/main/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,0 +1,1 @@
+io.github.gabrielbbaldez.stacktale.junit.StacktaleExtension

--- a/stacktale-junit/src/test/java/io/github/gabrielbbaldez/stacktale/junit/StoryFromRunningAppenderTest.java
+++ b/stacktale-junit/src/test/java/io/github/gabrielbbaldez/stacktale/junit/StoryFromRunningAppenderTest.java
@@ -70,7 +70,7 @@ class StoryFromRunningAppenderTest {
      * needs a Jupiter extension rather than a launcher listener.
      */
     @Test
-    void aCorrelationKeySetByTheTestStrandsTheStory(@TempDir Path dir) throws Exception {
+    void aCorrelationKeySetByTheTestStrandsTheStoryWithoutTheExtension(@TempDir Path dir) throws Exception {
         Path file = dir.resolve("errors-ai.log");
         startAppender(file);
         Holder.log = ctx.getLogger("com.acme.CheckoutService");
@@ -80,8 +80,30 @@ class StoryFromRunningAppenderTest {
         ctx.stop();
         String written = Files.readString(file);
 
+        // The listener alone still behaves exactly as it did: it is notified after the test
+        // method returned, so the MDC is unwound, the failure event carries no traceId, and it
+        // reads the thread bucket while the log line went to the traceId one. Kept as a test
+        // rather than deleted — the zero-config path is the headline feature and this is the
+        // shape of its one limitation.
         assertThat(written).contains("IllegalStateException: gateway refused");
         assertThat(written).doesNotContain("confirming order 889");
+    }
+
+    @Test
+    void theExtensionGivesTheCorrelatedTestItsStoryBack(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        startAppender(file);
+        Holder.log = ctx.getLogger("com.acme.CheckoutService");
+
+        runInOwnLauncher(ExtendedCorrelatedSample.class);
+
+        ctx.stop();
+        String written = Files.readString(file);
+
+        assertThat(written).contains("IllegalStateException: gateway refused");
+        // the whole point: the lead-up, not just the failure repeated back
+        assertThat(written).contains("confirming order 889");
+        assertThat(written).contains("traceId=9f3a");
     }
 
     @Test
@@ -138,6 +160,29 @@ class StoryFromRunningAppenderTest {
         void confirmsAnOrder() {
             Holder.log.info("confirming order {}", 889);
             Holder.log.warn("gateway timeout, retrying once");
+            throw new IllegalStateException("gateway refused");
+        }
+    }
+
+    /**
+     * The same, but with a correlation key in the MDC, and with the extension registered so
+     * the key survives long enough for the listener to use it.
+     */
+    @org.junit.jupiter.api.extension.ExtendWith(StacktaleExtension.class)
+    static class ExtendedCorrelatedSample {
+        // Teardown, the way a filter, a request scope or a Spring test fixture unwinds it —
+        // @AfterEach runs after afterTestExecution, so the key is still there to capture.
+        // A test that clears its own MDC in a finally inside the method body is out of reach
+        // for any hook: that block runs before the exception even leaves the method.
+        @org.junit.jupiter.api.AfterEach
+        void clearContext() {
+            MDC.remove("traceId");
+        }
+
+        @Test
+        void confirmsAnOrder() {
+            MDC.put("traceId", "9f3a");
+            Holder.log.info("confirming order {}", 889);
             throw new IllegalStateException("gateway refused");
         }
     }

--- a/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
+++ b/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
@@ -87,9 +87,29 @@ public final class StacktaleAppender extends AbstractAppender {
         }
     }
 
+    /**
+     * The event's ThreadContext as a map, without paying for one when there is nothing in it.
+     *
+     * <p>{@code ReadOnlyStringMap.toMap()} is {@code new HashMap<>(size())} plus a copy loop
+     * and it does that unconditionally — including for an empty context. {@code adapt()} runs
+     * on every event, error or not, so that was an allocation on the happy path for every
+     * application that never touches the ThreadContext, which is most of them.
+     *
+     * <p>CONTRIBUTING names the cheap happy path as an invariant, and the Logback adapter
+     * protects it explicitly (see {@code context(ILoggingEvent)} there). This adapter did not,
+     * so the README's ~110 ns per happy-path event — a Logback-only figure from
+     * {@code AppendBenchmark} — was not true for this backend.
+     */
+    // package-private so the allocation invariant can be asserted directly rather than
+    // inferred from a benchmark that CI does not run
+    static Map<String, String> contextData(LogEvent event) {
+        org.apache.logging.log4j.util.ReadOnlyStringMap data = event.getContextData();
+        return data == null || data.isEmpty() ? Map.of() : data.toMap();
+    }
+
     private LogEventData adapt(LogEvent event) {
         org.apache.logging.log4j.message.Message message = event.getMessage();
-        Map<String, String> mdc = event.getContextData() == null ? Map.of() : event.getContextData().toMap();
+        Map<String, String> mdc = contextData(event);
         Throwable thrown = event.getThrown();
         String formatted = message.getFormattedMessage();
         // non-parameterized Message types (MapMessage, ObjectMessage, StructuredData…)

--- a/stacktale-log4j2/src/test/java/io/github/gabrielbbaldez/stacktale/log4j2/HappyPathAllocationTest.java
+++ b/stacktale-log4j2/src/test/java/io/github/gabrielbbaldez/stacktale/log4j2/HappyPathAllocationTest.java
@@ -1,0 +1,71 @@
+package io.github.gabrielbbaldez.stacktale.log4j2;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.impl.Log4jLogEvent;
+import org.apache.logging.log4j.message.SimpleMessage;
+import org.apache.logging.log4j.util.SortedArrayStringMap;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The cheap happy path, which CONTRIBUTING names as a project invariant: a non-error event
+ * must not allocate.
+ *
+ * <p>{@code adapt()} runs for every event, and {@code ReadOnlyStringMap.toMap()} is
+ * {@code new HashMap<>(size())} plus a copy loop — done unconditionally, empty context or not.
+ * Every application that never touches the ThreadContext, which is most of them, paid for a
+ * map per event (#123).
+ *
+ * <p>Asserted here rather than left to {@code AppendBenchmark}, which is Logback-only and
+ * which CI does not run.
+ */
+class HappyPathAllocationTest {
+
+    private static LogEvent event(SortedArrayStringMap contextData) {
+        return Log4jLogEvent.newBuilder()
+                .setLoggerName("com.acme.OrderService")
+                .setLevel(Level.INFO)
+                .setMessage(new SimpleMessage("POST /orders/42/confirm"))
+                .setContextData(contextData)
+                .build();
+    }
+
+    @Test
+    void anEmptyThreadContextDoesNotAllocateAMap() {
+        Map<String, String> first = StacktaleAppender.contextData(event(new SortedArrayStringMap()));
+        Map<String, String> second = StacktaleAppender.contextData(event(new SortedArrayStringMap()));
+
+        // Map.of() returns the shared empty instance, so identity across two calls is a
+        // reliable stand-in for "nothing was allocated" — toMap() hands back a fresh HashMap
+        // every time, and two of those could never be the same object.
+        assertThat(first).isEmpty();
+        assertThat(first).isSameAs(second);
+    }
+
+    @Test
+    void aPopulatedThreadContextStillArrivesInFull() {
+        SortedArrayStringMap data = new SortedArrayStringMap();
+        data.putValue("traceId", "7b2c");
+        data.putValue("orderId", "42");
+
+        Map<String, String> mdc = StacktaleAppender.contextData(event(data));
+
+        // the skip must be the empty case only; a real context still has to reach the report
+        assertThat(mdc).containsEntry("traceId", "7b2c").containsEntry("orderId", "42");
+    }
+
+    @Test
+    void anAbsentContextDataIsTreatedAsEmptyRatherThanThrowing() {
+        LogEvent withoutContext = Log4jLogEvent.newBuilder()
+                .setLoggerName("com.acme.OrderService")
+                .setLevel(Level.INFO)
+                .setMessage(new SimpleMessage("hello"))
+                .build();
+
+        assertThat(StacktaleAppender.contextData(withoutContext)).isEmpty();
+    }
+}


### PR DESCRIPTION
Closes #124, closes #123, closes #134. One commit each; `mvn verify` green across all 8 modules.

## #124 — seven `logging.properties` keys were read by nobody

`settingsFromLogManager` handled 12 keys and dropped `zone`, `captureExceptionFields`, `truncateOnStart`, `reportErrorsWithoutThrowable`, `echoSuppressionMillis`, `containerLoggers` and `emitReportsToLogger`. From outside, a key nobody wired and a key typed wrong look identical — the default applies and nothing says why.

`captureExceptionFields` is the one that matters: it is a **privacy control**, deciding whether getters on the user's own exception types run and land in the report. A JUL user whose exceptions carry PII had no way to turn it off.

The mechanism was untested because all five existing tests build `Settings` programmatically. The new suite drives a real `LogManager.readConfiguration` and asserts behaviour — `captureExceptionFields=false` has a paired test proving capture works when on, so "no PII in the report" cannot pass by never having worked.

**Coverage 33.3% → 78.8%**, and it is no longer the thinnest module.

Two of the nine assertions were wrong when first written, both worth recording:

- `containerLoggers` does **not** exclude a logger from the story. It marks a logger whose re-log of a failure the app already reported, same thread, inside the echo window, is a duplicate.
- `Pacific/Kiritimati` is UTC+14 today but sat at **−10:40 until 1995**, so a zone test anchored at the epoch renders `1969-12-31` and reads as a bug. Anchored in 2024 instead.

## #123 — a map per event on the Log4j2 happy path

`ReadOnlyStringMap.toMap()` is `new HashMap<>(size())` plus a copy loop, run unconditionally — empty ThreadContext or not. `adapt()` runs for every event, so every app that never touches the ThreadContext paid for a map per log call.

Asserted in a test rather than left to `AppendBenchmark`, which is Logback-only and which CI never runs: `Map.of()` is a shared instance, so identity across two calls is a reliable stand-in for "nothing was allocated". Paired with a test that a populated context still arrives in full.

The README now says which backend the ~110 ns figure was measured on.

## #134 — a correlated test lost its story

`StoryBuffer` files an event under its correlation key **or** its thread, never both. The listener is notified after the test returns, MDC already unwound, so the failure event reads the thread bucket while the test's log lines went to the `traceId` one.

`StacktaleExtension` runs inside the test's lifecycle and snapshots the MDC while it is still there.

- `AfterTestExecutionCallback`, not `TestWatcher` — it runs **before** `@AfterEach`, so a suite that correctly clears the MDC in teardown still has something to capture.
- Handed over by unique id, not a `ThreadLocal`: the listener is not guaranteed to be on the thread that ran the test.
- SLF4J reached reflectively, as `AgentCaptures` reaches `CaptureRegistry`. A JUL or Log4j2 project uses the listener with no SLF4J at all, and that keeps working. `junit-jupiter-api` is `provided` for the same reason.
- Opt-in. The zero-config listener behaves identically without it.

**One case stays out of reach and is documented as such:** a test that clears its own MDC in a `finally` inside the method body has unwound it before the exception leaves the method — no hook runs earlier. The first draft of the test hit exactly that and looked like a broken extension. Clearing in `@AfterEach`, which is where a fixture or filter does it, works.

The old assertion is kept as `aCorrelationKeySetByTheTestStrandsTheStoryWithoutTheExtension`, pinning the listener's unchanged behaviour.
