### PR TITLE
Add standalone examples for JUL, Spring Boot MVC, and WebFlux

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -1,0 +1,36 @@
+name: Build Examples
+
+on:
+  pull_request:
+    paths:
+      - "examples/**"
+      - ".github/workflows/examples.yml"
+  push:
+    paths:
+      - "examples/**"
+      - ".github/workflows/examples.yml"
+
+jobs:
+  build-examples:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        example:
+          - examples/plain-java-jul
+          - examples/spring-boot-mvc
+          - examples/spring-boot-webflux
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: Compile example
+        working-directory: ${{ matrix.example }}
+        run: mvn -B -q compile

--- a/examples/plain-java-jul/README.md
+++ b/examples/plain-java-jul/README.md
@@ -1,0 +1,51 @@
+# Plain Java JUL (java.util.logging) Example
+
+A minimal, standalone plain Java project demonstrating direct `java.util.logging` (JUL) integration using `StacktaleJulHandler`.
+
+## What This Example Demonstrates
+
+- **Direct JUL Integration**: Uses the JDK's built-in `java.util.logging` framework directly via `StacktaleJulHandler` without requiring Spring Boot or Logback.
+- **Declarative `logging.properties`**: Demonstrates configuring the handler, package root markers, and output file declaratively using standard JUL `logging.properties`.
+- **Thread-Correlated Story**: Since JUL has no native MDC support, `stacktale` automatically correlates preceding `INFO` and `WARNING` logs on the executing thread into the `story` section when a `SEVERE` error occurs.
+
+## How to Run
+
+From this directory (`examples/plain-java-jul`):
+
+```bash
+mvn compile exec:java
+```
+
+Or using standard `java`:
+
+```bash
+mvn compile dependency:copy-dependencies
+java -Djava.util.logging.config.file=src/main/resources/logging.properties -cp "target/classes:target/dependency/*" com.example.demo.DemoApp
+```
+
+## What to Look For
+
+Open the generated report in `target/errors-ai.log`:
+
+```
+━━━ ERROR #... ━━━ ... thread=main ━━━
+IllegalArgumentException: Customer email cannot be null for notification dispatch
+at com.example.demo.DemoApp.processCustomer(DemoApp.java:34) ← YOUR CODE
+log: "Failed to process customer 404" logger=com.example.demo.DemoApp
+
+story (last 3 events):
+  08:54:00.100 INFO    com.example.demo.DemoApp  Starting order processing batch
+  08:54:00.101 INFO    com.example.demo.DemoApp  Fetching customer 404 from database
+  08:54:00.105 WARNING com.example.demo.DemoApp  Database returned empty record for customer 404
+  08:54:00.110 SEVERE  com.example.demo.DemoApp  Failed to process customer 404   ← this error
+
+stack (distilled):
+  com.example.demo.DemoApp.processCustomer(DemoApp.java:34) ← culprit
+  com.example.demo.DemoApp.main(DemoApp.java:27)
+```
+
+### Key Highlights
+
+- **`SEVERE` Level Trigger**: `SEVERE` JUL log events trigger report generation.
+- **Thread-Based Story**: Preceding `INFO` and `WARNING` events on the `main` thread are captured into the `story` block.
+- **Package Markers**: `StacktaleJulHandler.appPackages = com.example.demo` highlights user frames with `← YOUR CODE` and `← culprit`.

--- a/examples/plain-java-jul/pom.xml
+++ b/examples/plain-java-jul/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <stacktale.version>0.5.0</stacktale.version>
+        <stacktale.version>1.1.0</stacktale.version>
     </properties>
 
     <dependencies>

--- a/examples/plain-java-jul/pom.xml
+++ b/examples/plain-java-jul/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>plain-java-jul</artifactId>
+    <version>0.5.0</version>
+    <name>plain-java-jul</name>
+    <description>Stacktale Plain Java JUL Example</description>
+
+    <properties>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <stacktale.version>0.5.0</stacktale.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.gabrielbbaldez</groupId>
+            <artifactId>stacktale-jul</artifactId>
+            <version>${stacktale.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <mainClass>com.example.demo.DemoApp</mainClass>
+                    <systemProperties>
+                        <systemProperty>
+                            <key>java.util.logging.config.file</key>
+                            <value>src/main/resources/logging.properties</value>
+                        </systemProperty>
+                    </systemProperties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/plain-java-jul/src/main/java/com/example/demo/DemoApp.java
+++ b/examples/plain-java-jul/src/main/java/com/example/demo/DemoApp.java
@@ -1,0 +1,40 @@
+package com.example.demo;
+
+import java.io.InputStream;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
+
+public class DemoApp {
+
+    private static final Logger log = Logger.getLogger(DemoApp.class.getName());
+
+    public static void main(String[] args) {
+        // Fallback to classpath logging.properties if java.util.logging.config.file system property is not provided
+        if (System.getProperty("java.util.logging.config.file") == null) {
+            try (InputStream is = DemoApp.class.getResourceAsStream("/logging.properties")) {
+                if (is != null) {
+                    LogManager.getLogManager().readConfiguration(is);
+                }
+            } catch (Exception e) {
+                System.err.println("Could not load logging.properties: " + e.getMessage());
+            }
+        }
+
+        log.info("Starting order processing batch");
+        log.info("Fetching customer 404 from database");
+        log.warning("Database returned empty record for customer 404");
+
+        try {
+            processCustomer(null);
+        } catch (Exception e) {
+            log.log(Level.SEVERE, "Failed to process customer 404", e);
+        }
+    }
+
+    private static void processCustomer(String customerEmail) {
+        if (customerEmail == null) {
+            throw new IllegalArgumentException("Customer email cannot be null for notification dispatch");
+        }
+    }
+}

--- a/examples/plain-java-jul/src/main/resources/logging.properties
+++ b/examples/plain-java-jul/src/main/resources/logging.properties
@@ -1,0 +1,11 @@
+# Global logging configuration
+handlers = java.util.logging.ConsoleHandler, io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler
+.level = INFO
+
+# ConsoleHandler configuration
+java.util.logging.ConsoleHandler.level = INFO
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+
+# StacktaleJulHandler configuration
+io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.appPackages = com.example.demo
+io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler.file = target/errors-ai.log

--- a/examples/spring-boot-mvc/README.md
+++ b/examples/spring-boot-mvc/README.md
@@ -1,0 +1,60 @@
+# Spring Boot MVC Example
+
+A standalone runnable Spring Boot MVC (servlet) application demonstrating zero-configuration `stacktale` integration with `stacktale-spring-boot-starter`.
+
+## What This Example Demonstrates
+
+- **Zero-Config Integration**: Adding `stacktale-spring-boot-starter` automatically configures Logback to capture AI-ready error reports without extra XML configuration.
+- **Automatic Package Highlighting**: Packages matching `stacktale.app-packages` are marked with `← YOUR CODE` in stack traces.
+- **Context & Story Extraction**: Demonstrates how SLF4J MDC (`traceId`), preceding logger events (request `INFO` and cache miss `WARN`), and exception domain state get captured alongside errors.
+
+## How to Run
+
+From this directory (`examples/spring-boot-mvc`):
+
+```bash
+mvn spring-boot:run
+```
+
+The application will start on port `8081`.
+
+## How to Trigger the Error
+
+In another terminal, trigger the order confirmation endpoint:
+
+```bash
+curl -X POST http://localhost:8081/orders/123/confirm
+```
+
+This simulates fetching a customer, encountering a cache miss (`null`), and throwing a `NullPointerException` wrapped in a custom `OrderConfirmationException`.
+
+## What to Look For
+
+Open the generated report in `errors-ai.log`:
+
+```
+━━━ ERROR #... ━━━ ... thread=http-nio-8081-exec-1 ━━━
+NullPointerException: Cannot invoke "com.example.demo.model.Customer.getEmail()" because "customer" is null
+at com.example.demo.service.OrderService.confirmOrder(OrderService.java:20) ← YOUR CODE
+wrapped by: OrderConfirmationException("confirmation aborted for order 123") at com.example.demo.service.OrderService.confirmOrder(OrderService.java:23)
+log: "Failed to process order confirmation for order {}" args=[123] logger=c.e.d.s.OrderService
+mdc: traceId=a1b2c3d4
+fields: failedStep=send-confirmation-email orderId=123 retryable=false
+
+story (traceId=a1b2c3d4, last 4 events):
+  08:43:00.100 INFO  OrderController  POST /orders/123/confirm
+  08:43:00.105 INFO  OrderService     Processing order confirmation for order 123
+  08:43:00.106 WARN  OrderService     Cache miss for customer on order 123, returning null
+  08:43:00.110 ERROR OrderService     Failed to process order confirmation for order 123   ← this error
+
+stack (distilled):
+  com.example.demo.service.OrderService.confirmOrder(OrderService.java:20) ← culprit
+  ...
+```
+
+### Key Highlights
+
+- **Root Cause First**: Reports start with the underlying `NullPointerException` rather than outer wrapper noise.
+- **`← YOUR CODE` / `← culprit`**: Frame markers quickly highlight lines from your application.
+- **The `story` Section**: Displays preceding request events (`INFO`, `WARN` cache miss) bound to the MDC `traceId`.
+- **Captured Exception Fields**: Domain getters on `OrderConfirmationException` (`getOrderId()`, `isRetryable()`, `getFailedStep()`) automatically populate the `fields:` summary.

--- a/examples/spring-boot-mvc/pom.xml
+++ b/examples/spring-boot-mvc/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>spring-boot-mvc</artifactId>
+    <version>0.4.0</version>
+    <name>spring-boot-mvc</name>
+    <description>Stacktale Spring Boot MVC Example</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.gabrielbbaldez</groupId>
+            <artifactId>stacktale-spring-boot-starter</artifactId>
+            <version>0.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/spring-boot-mvc/pom.xml
+++ b/examples/spring-boot-mvc/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>io.github.gabrielbbaldez</groupId>
             <artifactId>stacktale-spring-boot-starter</artifactId>
-            <version>0.4.0</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-boot-mvc/src/main/java/com/example/demo/DemoApplication.java
+++ b/examples/spring-boot-mvc/src/main/java/com/example/demo/DemoApplication.java
@@ -1,0 +1,12 @@
+package com.example.demo;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DemoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(DemoApplication.class, args);
+    }
+}

--- a/examples/spring-boot-mvc/src/main/java/com/example/demo/controller/OrderController.java
+++ b/examples/spring-boot-mvc/src/main/java/com/example/demo/controller/OrderController.java
@@ -1,0 +1,37 @@
+package com.example.demo.controller;
+
+import com.example.demo.service.OrderService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+public class OrderController {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderController.class);
+
+    private final OrderService orderService;
+
+    public OrderController(OrderService orderService) {
+        this.orderService = orderService;
+    }
+
+    @PostMapping("/orders/{id}/confirm")
+    public ResponseEntity<Void> confirmOrder(@PathVariable int id) {
+        String traceId = UUID.randomUUID().toString().substring(0, 8);
+        MDC.put("traceId", traceId);
+        try {
+            log.info("POST /orders/{}/confirm", id);
+            orderService.confirmOrder(id);
+            return ResponseEntity.ok().build();
+        } finally {
+            MDC.clear();
+        }
+    }
+}

--- a/examples/spring-boot-mvc/src/main/java/com/example/demo/exception/OrderConfirmationException.java
+++ b/examples/spring-boot-mvc/src/main/java/com/example/demo/exception/OrderConfirmationException.java
@@ -1,0 +1,27 @@
+package com.example.demo.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+public class OrderConfirmationException extends RuntimeException {
+
+    private final int orderId;
+
+    public OrderConfirmationException(int orderId, Throwable cause) {
+        super("confirmation aborted for order " + orderId, cause);
+        this.orderId = orderId;
+    }
+
+    public int getOrderId() {
+        return orderId;
+    }
+
+    public boolean isRetryable() {
+        return false;
+    }
+
+    public String getFailedStep() {
+        return "send-confirmation-email";
+    }
+}

--- a/examples/spring-boot-mvc/src/main/java/com/example/demo/model/Customer.java
+++ b/examples/spring-boot-mvc/src/main/java/com/example/demo/model/Customer.java
@@ -1,0 +1,13 @@
+package com.example.demo.model;
+
+public class Customer {
+    private final String email;
+
+    public Customer(String email) {
+        this.email = email;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+}

--- a/examples/spring-boot-mvc/src/main/java/com/example/demo/service/OrderService.java
+++ b/examples/spring-boot-mvc/src/main/java/com/example/demo/service/OrderService.java
@@ -1,0 +1,33 @@
+package com.example.demo.service;
+
+import com.example.demo.exception.OrderConfirmationException;
+import com.example.demo.model.Customer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OrderService {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderService.class);
+
+    public void confirmOrder(int orderId) {
+        log.info("Processing order confirmation for order {}", orderId);
+        Customer customer = fetchCustomer(orderId);
+
+        try {
+            // Simulated bug: customer is null due to cache miss, causing NPE on getEmail()
+            String email = customer.getEmail();
+            log.info("Confirmation email sent to {} for order {}", email, orderId);
+        } catch (NullPointerException e) {
+            log.error("Failed to process order confirmation for order {}", orderId, e);
+            throw new OrderConfirmationException(orderId, e);
+        }
+    }
+
+    private Customer fetchCustomer(int orderId) {
+        log.info("Fetching customer for order {}", orderId);
+        log.warn("Cache miss for customer on order {}, returning null", orderId);
+        return null;
+    }
+}

--- a/examples/spring-boot-mvc/src/main/resources/application.properties
+++ b/examples/spring-boot-mvc/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=8081
+stacktale.app-packages=com.example.demo

--- a/examples/spring-boot-mvc/src/test/java/com/example/demo/DemoApplicationTests.java
+++ b/examples/spring-boot-mvc/src/test/java/com/example/demo/DemoApplicationTests.java
@@ -1,0 +1,27 @@
+package com.example.demo;
+
+import com.example.demo.exception.OrderConfirmationException;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class DemoApplicationTests {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void confirmOrderThrowsOrderConfirmationExceptionOnCacheMiss() throws Exception {
+        mockMvc.perform(post("/orders/123/confirm"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(result -> assertInstanceOf(OrderConfirmationException.class, result.getResolvedException()));
+    }
+}

--- a/examples/spring-boot-webflux/README.md
+++ b/examples/spring-boot-webflux/README.md
@@ -1,0 +1,59 @@
+# Spring Boot WebFlux Example
+
+A standalone runnable Spring Boot WebFlux (reactive, non-servlet) application demonstrating zero-configuration `stacktale` integration with `stacktale-spring-boot-starter`.
+
+## What This Example Demonstrates
+
+- **Reactive Context Propagation**: Demonstrates how `stacktale`'s WebFlux filter maintains log event context ("story") across multiple Project Reactor scheduler hops (`boundedElastic` and `parallel` threads).
+- **Zero-Config WebFlux Integration**: Adding `stacktale-spring-boot-starter` automatically sets up reactive WebFlux context tracking without manual Logback or Reactor configuration.
+- **Package Highlighting**: Packages matching `stacktale.app-packages` are flagged with `← YOUR CODE` in distilled stack traces.
+
+## How to Run
+
+From this directory (`examples/spring-boot-webflux`):
+
+```bash
+mvn spring-boot:run
+```
+
+The application will start on port `8082`.
+
+## How to Trigger the Error
+
+In another terminal, trigger the reactive quote endpoint:
+
+```bash
+curl http://localhost:8082/quotes/314
+```
+
+This request logs the initial request, schedules a pricing lookup on `boundedElastic()`, shifts to `parallel()`, and throws an `IllegalStateException("pricing feed disconnected")`.
+
+## What to Look For
+
+Open the generated report in `errors-ai.log`:
+
+```
+━━━ ERROR #... ━━━ ... thread=boundedElastic-1 ━━━
+IllegalStateException: pricing feed disconnected
+at com.example.webflux.controller.QuoteController.lambda$quote$1(QuoteController.java:27) ← YOUR CODE
+log: "quote failed for instrument {}" args=[314] logger=c.e.w.c.QuoteController
+mdc: traceId=c3d4e5f6
+
+story (traceId=c3d4e5f6, last 4 events):
+  08:50:00.100 INFO  QuoteController  GET /quotes/314
+  08:50:00.101 INFO  QuoteController  quote requested for instrument 314
+  08:50:00.105 INFO  QuoteController  pricing lookup for instrument 314
+  08:50:00.110 ERROR QuoteController  quote failed for instrument 314   ← this error
+
+stack (distilled):
+  com.example.webflux.controller.QuoteController.lambda$quote$1(QuoteController.java:27) ← culprit
+  ...
+```
+
+### Key Highlights
+
+- **Story Across Scheduler Hops**: Log events emitted on different thread pools (`boundedElastic` thread hop #1 and `parallel` thread hop #2) remain grouped in the `story` under the same reactive `traceId`.
+- **Root Cause & Culprit Highlight**: Pinpoints the `IllegalStateException` and marks your controller line with `← YOUR CODE`.
+//This example currently targets 1.1.0-SNAPSHOT because 
+- it depends on the WebFlux auto-configuration fix that 
+- has not yet been released to Maven Central.

--- a/examples/spring-boot-webflux/pom.xml
+++ b/examples/spring-boot-webflux/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.4.5</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.example</groupId>
+    <artifactId>spring-boot-webflux</artifactId>
+    <version>0.4.0</version>
+    <name>spring-boot-webflux</name>
+    <description>Stacktale Spring Boot WebFlux Example</description>
+
+    <properties>
+        <java.version>17</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.github.gabrielbbaldez</groupId>
+            <artifactId>stacktale-spring-boot-starter</artifactId>
+            <version>1.1.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.projectreactor</groupId>
+            <artifactId>reactor-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/examples/spring-boot-webflux/pom.xml
+++ b/examples/spring-boot-webflux/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>io.github.gabrielbbaldez</groupId>
             <artifactId>stacktale-spring-boot-starter</artifactId>
-            <version>1.1.0-SNAPSHOT</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-boot-webflux/src/main/java/com/example/webflux/ReactiveDemoApplication.java
+++ b/examples/spring-boot-webflux/src/main/java/com/example/webflux/ReactiveDemoApplication.java
@@ -1,0 +1,12 @@
+package com.example.webflux;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class ReactiveDemoApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(ReactiveDemoApplication.class, args);
+    }
+}

--- a/examples/spring-boot-webflux/src/main/java/com/example/webflux/controller/QuoteController.java
+++ b/examples/spring-boot-webflux/src/main/java/com/example/webflux/controller/QuoteController.java
@@ -1,0 +1,35 @@
+package com.example.webflux.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@RestController
+public class QuoteController {
+
+    private static final Logger log = LoggerFactory.getLogger(QuoteController.class);
+
+    @GetMapping("/quotes/{id}")
+    public Mono<String> quote(@PathVariable int id) {
+        log.info("quote requested for instrument {}", id);
+        return Mono.just(id)
+                .subscribeOn(Schedulers.boundedElastic())          // thread hop #1
+                .map(i -> {
+                    log.info("pricing lookup for instrument {}", i); // logged on boundedElastic thread
+                    return i;
+                })
+                .publishOn(Schedulers.parallel())                   // thread hop #2
+                .flatMap(i -> {
+                    try {
+                        throw new IllegalStateException("pricing feed disconnected");
+                    } catch (Exception e) {
+                        log.error("quote failed for instrument {}", i, e);
+                        return Mono.error(e);
+                    }
+                });
+    }
+}

--- a/examples/spring-boot-webflux/src/main/resources/application.properties
+++ b/examples/spring-boot-webflux/src/main/resources/application.properties
@@ -1,0 +1,2 @@
+server.port=8082
+stacktale.app-packages=com.example.webflux

--- a/examples/spring-boot-webflux/src/test/java/com/example/webflux/ReactiveDemoApplicationTests.java
+++ b/examples/spring-boot-webflux/src/test/java/com/example/webflux/ReactiveDemoApplicationTests.java
@@ -1,0 +1,24 @@
+package com.example.webflux;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+@SpringBootTest
+@AutoConfigureWebTestClient
+class ReactiveDemoApplicationTests {
+
+    @Autowired
+    private WebTestClient webTestClient;
+
+    @Test
+    void quoteEndpointReturns5xxErrorOnDisconnect() {
+        webTestClient.get()
+                .uri("/quotes/314")
+                .exchange()
+                .expectStatus()
+                .is5xxServerError();
+    }
+}


### PR DESCRIPTION
## Summary

This PR adds standalone examples demonstrating Stacktale with:

- Plain Java (JUL)
- Spring Boot MVC
- Spring Boot WebFlux

## Verification

- ✅ Plain Java example runs successfully.
- ✅ Spring Boot MVC generates AI-oriented error reports.
- ✅ Spring Boot WebFlux generates AI-oriented error reports, including errors across Reactor scheduler hops.

## Notes

The WebFlux example was tested against my locally built `1.1.0-SNAPSHOT`.

When using the published `0.4.0` artifact from Maven Central, the application fails to start because of the known servlet auto-configuration issue discussed in #62. With the current `main` branch build, the example runs successfully.