### PR TITLE
fix: flush the trailing repeat counters when the JVM exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -645,6 +645,10 @@ Async work: wrap hops with [`StacktaleExecutors`](stacktale-core/src/main/java/i
   header teaches it to any AI. Format changes are deliberate and versioned.
 - **Nothing leaves the machine.** A local file, same trust boundary as your logs. No
   network, no phone-home. Redaction on by default anyway.
+- **The last count is the true count.** Repeated errors are summarised as
+  `━ #id repeated N× ━` rather than re-reported, and that line is flushed on JVM exit —
+  no `<shutdownHook/>` needed in `logback.xml`. Without it the file would end at whatever
+  the last flush wrote, which is worse than missing: a stale number reads as a real one.
 
 ## Limitations (honest ones)
 

--- a/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
+++ b/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
@@ -57,6 +57,8 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
     private boolean jsonFormat = false;
 
     private ReportPipeline pipeline;
+    /** The JVM hook that drains trailing repeat counters; null when not registered. */
+    Thread shutdownDrain;
     private org.slf4j.Logger selfLogger;
     private volatile boolean mdcUnavailable;
     private volatile boolean keyValuesUnavailable;
@@ -146,11 +148,60 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
                                 .getLogger(UncaughtHandler.UNCAUGHT_LOGGER);
                 UncaughtHandler.install(uncaught::error);
             }
+            installShutdownDrain();
+        }
+    }
+
+    /**
+     * Flushes the trailing repeat counters when the JVM exits.
+     *
+     * <p>{@link ReportPipeline#close()} is what drains them, and it runs from {@link #stop()},
+     * which Logback calls only on {@code LoggerContext.stop()}. Logback registers no shutdown
+     * hook of its own unless {@code <shutdownHook/>} is in the configuration — so for the exact
+     * quickstart this project documents, that drain never happened.
+     *
+     * <p>The counter is not merely missing then, it is <em>stale</em>, which is worse: the file
+     * ends with whatever the last burst flush wrote and a reader believes it. Fifty identical
+     * errors left {@code repeated 2×} as the final word (#127).
+     *
+     * <p>Log4j2 drains through {@code DefaultShutdownCallbackRegistry} and JUL through the
+     * {@code LogManager} reset, so plain Logback was the only backend where the number lied.
+     * Documenting {@code <shutdownHook/>} would have made that asymmetry the user's problem.
+     *
+     * <p>Safe to pair with Logback's own hook: {@code close()} is idempotent, because
+     * {@code drainPending()} advances {@code lastWrittenCount} and a second pass finds nothing.
+     */
+    private void installShutdownDrain() {
+        if (shutdownDrain != null) return; // start() can be called again on a re-configured appender
+        ReportPipeline forHook = pipeline;
+        Thread hook = new Thread(forHook::close, "stacktale-shutdown-drain");
+        try {
+            Runtime.getRuntime().addShutdownHook(hook);
+            shutdownDrain = hook;
+        } catch (IllegalStateException shuttingDown) {
+            // the JVM is already on its way out; there is nothing left to schedule
+        }
+    }
+
+    /**
+     * Removes the hook so a stopped context is not pinned by it — the same leak {@link
+     * UncaughtHandler} had. Does nothing when shutdown is already under way, which is the
+     * normal case: the hook is running, or Logback's own hook is stopping this context.
+     */
+    private void removeShutdownDrain() {
+        Thread hook = shutdownDrain;
+        shutdownDrain = null;
+        if (hook == null) return;
+        try {
+            Runtime.getRuntime().removeShutdownHook(hook);
+        } catch (IllegalStateException shuttingDown) {
+            // removeShutdownHook throws once shutdown has begun; the hook will simply run
         }
     }
 
     @Override
     public void stop() {
+        removeShutdownDrain();
         if (pipeline != null) {
             ActivePipeline.unregister(pipeline);
             pipeline.close(); // flush pending repeat counters

--- a/stacktale/src/test/java/io/github/gabrielbbaldez/stacktale/logback/ShutdownDrainTest.java
+++ b/stacktale/src/test/java/io/github/gabrielbbaldez/stacktale/logback/ShutdownDrainTest.java
@@ -1,0 +1,145 @@
+package io.github.gabrielbbaldez.stacktale.logback;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The trailing repeat counters on plain Logback (#127).
+ *
+ * <p>{@code close()} drains them and runs from {@code stop()}, which Logback calls only on
+ * {@code LoggerContext.stop()} — and Logback registers no shutdown hook unless
+ * {@code <shutdownHook/>} is configured. For the quickstart this project documents, that drain
+ * never happened, and the file ended with whatever the last burst flush wrote. The count was
+ * not missing but <em>stale</em>, which is worse: fifty identical errors left {@code repeated
+ * 2×} as the final word and a reader believes it.
+ *
+ * <p>The JVM-exit half is exercised in a forked process, because a shutdown hook cannot be
+ * observed from inside the JVM that is still running.
+ */
+class ShutdownDrainTest {
+
+    private static final Pattern REPEATED = Pattern.compile("repeated (\\d+)×");
+
+    /** The highest {@code repeated N×} in the file — the count a reader would end up believing. */
+    private static int finalRepeatCount(Path file) throws Exception {
+        String content = Files.readString(file, StandardCharsets.UTF_8);
+        Matcher m = REPEATED.matcher(content);
+        int last = 0;
+        while (m.find()) last = Integer.parseInt(m.group(1));
+        return last;
+    }
+
+    private static LoggerContext configure(Path file) throws Exception {
+        String xml = """
+                <configuration>
+                  <appender name="STACKTALE" class="io.github.gabrielbbaldez.stacktale.logback.StacktaleAppender">
+                    <file>%s</file>
+                    <appPackages>com.acme</appPackages>
+                    <installUncaughtHandler>false</installUncaughtHandler>
+                  </appender>
+                  <root level="info"><appender-ref ref="STACKTALE"/></root>
+                </configuration>
+                """.formatted(file.toString().replace("\\", "/"));
+        LoggerContext ctx = new LoggerContext();
+        JoranConfigurator configurator = new JoranConfigurator();
+        configurator.setContext(ctx);
+        configurator.doConfigure(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
+        return ctx;
+    }
+
+    private static StacktaleAppender appenderOf(LoggerContext ctx) {
+        return (StacktaleAppender) ctx.getLogger(ch.qos.logback.classic.Logger.ROOT_LOGGER_NAME)
+                .getAppender("STACKTALE");
+    }
+
+    @Test
+    void startRegistersTheDrainAndStopTakesItBackOff(@TempDir Path dir) throws Exception {
+        LoggerContext ctx = configure(dir.resolve("errors-ai.log"));
+        StacktaleAppender appender = appenderOf(ctx);
+
+        Thread hook = appender.shutdownDrain;
+        assertThat(hook).as("start() registers a drain").isNotNull();
+        // it really is with the JVM: removing it succeeds exactly once
+        assertThat(Runtime.getRuntime().removeShutdownHook(hook)).isTrue();
+        Runtime.getRuntime().addShutdownHook(hook); // put it back for stop() to remove
+
+        ctx.stop();
+
+        assertThat(appender.shutdownDrain).as("stop() clears the reference").isNull();
+        // A hook left behind pins the stopped context, which is the leak UncaughtHandler had.
+        // false here means stop() had already taken it off the JVM's list.
+        assertThat(Runtime.getRuntime().removeShutdownHook(hook)).isFalse();
+    }
+
+    @Test
+    void aContextStopStillDrainsWithoutWaitingForTheJvm(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        LoggerContext ctx = configure(file);
+        org.slf4j.Logger log = ctx.getLogger("com.acme.OrderService");
+        IllegalStateException boom = new IllegalStateException("gateway refused");
+        for (int i = 0; i < 50; i++) log.error("checkout failed for order {}", 42, boom);
+
+        int beforeStop = finalRepeatCount(file);
+        ctx.stop();
+
+        assertThat(finalRepeatCount(file))
+                .as("the drain writes the true total, not the last burst flush")
+                .isEqualTo(50)
+                .isGreaterThan(beforeStop);
+    }
+
+    @Test
+    void aJvmExitWithoutStoppingTheContextStillLeavesTheTrueCount(@TempDir Path dir) throws Exception {
+        Path file = dir.resolve("errors-ai.log");
+        Path source = dir.resolve("ExitsWithoutStopping.java");
+        // Deliberately never touches LoggerContext.stop() and configures no <shutdownHook/> —
+        // exactly the shape of the README's plain-Logback quickstart.
+        Files.writeString(source, """
+                import org.slf4j.LoggerFactory;
+                public class ExitsWithoutStopping {
+                    public static void main(String[] a) {
+                        var log = LoggerFactory.getLogger("com.acme.OrderService");
+                        var boom = new IllegalStateException("gateway refused");
+                        for (int i = 0; i < 50; i++) log.error("checkout failed for order {}", 42, boom);
+                    }
+                }
+                """);
+        Path config = dir.resolve("logback-test-exit.xml");
+        Files.writeString(config, """
+                <configuration>
+                  <appender name="STACKTALE" class="io.github.gabrielbbaldez.stacktale.logback.StacktaleAppender">
+                    <file>%s</file>
+                    <appPackages>com.acme</appPackages>
+                    <installUncaughtHandler>false</installUncaughtHandler>
+                  </appender>
+                  <root level="info"><appender-ref ref="STACKTALE"/></root>
+                </configuration>
+                """.formatted(file.toString().replace("\\", "/")));
+
+        String classpath = System.getProperty("java.class.path");
+        Process process = new ProcessBuilder(
+                Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+                "-cp", classpath,
+                "-Dlogback.configurationFile=" + config,
+                source.toString()) // single-file source mode: no separate compile step
+                .redirectErrorStream(true)
+                .start();
+        String output = new String(process.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+        assertThat(process.waitFor()).as("the forked JVM exited cleanly:%n%s", output).isZero();
+
+        // Without the hook this was 2 — the last burst flush, with 48 occurrences unaccounted
+        // for and nothing saying so.
+        assertThat(finalRepeatCount(file)).isEqualTo(50);
+    }
+}


### PR DESCRIPTION
Closes #127. Taking this one since @MahmoudYazid stepped away.

The issue offered two options and I went with the code one rather than the documented workaround, for a reason worth stating.

## The count is wrong, not missing

`ReportPipeline.close()` drains the counters and runs from `stop()`, which Logback calls only on `LoggerContext.stop()`. Logback registers no shutdown hook unless `<shutdownHook/>` is configured, and that element appears nowhere in this project's docs — so for the exact quickstart the README ships, the drain never happened.

Fifty identical errors, plain Logback, normal JVM exit:

| | last `repeated N×` in the file | truth |
|---|---|---|
| before | `repeated 2×` | 50 |
| after | `repeated 50×` | 50 |

The burst flush wrote 2 early; the remaining 48 were never accounted for and nothing said so. That is worse than an absent line — a stale number reads as a real one, and the repeat count is exactly what someone checks after a failing run.

## Why not the docs option

Log4j2 drains through `DefaultShutdownCallbackRegistry` and JUL through the `LogManager` reset. Plain Logback — the flagship backend — was the only one where the number lied. Documenting `<shutdownHook/>` makes that asymmetry the user's problem, and the user has no way to notice they have it.

It also would not have covered the Spring case the issue flags: a Boot user with a hand-written `logback.xml` declaring `STACKTALE` never goes through `stacktaleCleanup`, which guards on `AUTO_APPENDER_NAME`. The appender registering its own hook covers that too.

## Safety

- **Double drain is a no-op.** `close()` is idempotent — `drainPending()` advances `lastWrittenCount` and a second pass finds nothing. A project already configuring Logback's `<shutdownHook/>` gets the same result, not two lines.
- **`stop()` removes the hook**, guarding the leak #121 had: a hook left registered pins the stopped context.
- **Both add and remove tolerate `IllegalStateException`**, which the JVM throws once shutdown has begun. That is the ordinary path, not an edge case — the hook is running, or Logback's own hook is stopping the context.

## Tests

Three, and the JVM-exit one runs in a **forked process**, because a shutdown hook cannot be observed from inside the JVM still running it. Against the previous appender it reports `expected: 50 but was: 2` — the same number the manual repro produced.