### PR TITLE
Add JUnit Platform 1.10 compatibility floor

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -31,6 +31,8 @@ jobs:
             args: "-Dspring-boot.version=3.3.13"
           - name: "Spring Boot 3.5"
             args: "-Dspring-boot.version=3.5.6"
+          - name: "JUnit Platform 1.10 (floor)"
+            args: "-pl stacktale-core,stacktale-junit -am -Djunit.platform.version=1.10.0 -Djunit.jupiter.version=5.10.0"
     name: ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v7

--- a/README.md
+++ b/README.md
@@ -672,6 +672,7 @@ each backed by a passing build:
 | Logback | 1.4+ | 1.6.x |
 | Log4j2 | 2.20+ | 2.26.x |
 | Spring Boot *(starter)* | 3.2+ | 3.5.x |
+| JUnit Platform *(stacktale-junit)* | 1.10+ | 6.1.x |
 
 The Spring Boot starter follows Boot's own Logback version (1.5 on Boot 3.4+); the
 `stacktale` and `stacktale-log4j2` artifacts work down to Logback 1.4 on their own.

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,8 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <logback.version>1.6.1</logback.version>
     <junit.version>6.1.2</junit.version>
+    <junit.platform.version>${junit.version}</junit.platform.version>
+    <junit.jupiter.version>${junit.version}</junit.jupiter.version>
     <assertj.version>3.27.7</assertj.version>
     <spring-boot.version>3.5.16</spring-boot.version>
     <log4j2.version>2.26.1</log4j2.version>

--- a/scripts/check-readme-compat.sh
+++ b/scripts/check-readme-compat.sh
@@ -55,6 +55,7 @@ check_row() {
 check_row "Logback" 'Logback \|' "logback.version"
 check_row "Log4j2" 'Log4j2 \|' "log4j2.version"
 check_row "Spring Boot" 'Spring Boot ' "spring-boot.version"
+check_row "JUnit Platform" 'JUnit Platform ' "junit.platform.version"
 
 # Java: the floor ("17+") tracks the pom's compiler release; "Tested up to"
 # tracks the highest java-version in the CI matrices.

--- a/stacktale-junit/pom.xml
+++ b/stacktale-junit/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>org.junit.platform</groupId>
       <artifactId>junit-platform-launcher</artifactId>
-      <version>${junit.version}</version>
+      <version>${junit.platform.version}</version>
       <scope>provided</scope>
     </dependency>
 
@@ -45,14 +45,14 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
-      <version>${junit.version}</version>
+      <version>${junit.jupiter.version}</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>${junit.version}</version>
+      <version>${junit.jupiter.version}</version>
       <scope>test</scope>
     </dependency>
     <!--


### PR DESCRIPTION
<!-- Thanks for contributing. Keep this short — a sentence per box is plenty. -->

## What & why

<!-- What changes, and what problem it solves. The *why* is the part reviewers can't infer. -->

Adds JUnit Platform 1.10 as the compatibility floor for stacktale-junit, with separate Platform and Jupiter version properties so CI can verify the JUnit 5.10 runtime while preserving JUnit 6.1.2 as the default.

Adds the floor to the compatibility matrix and documents it in the README compatibility table.

Closes #155

## How it was verified

<!-- Pick one and delete the rest. -->

- [x] `mvn verify` is green (JDK 17+)

## Checklist

- [x] The issue was claimed with a comment before starting (see
      [CONTRIBUTING](https://github.com/stacktale/stacktale/blob/main/CONTRIBUTING.md#claim-the-issue-before-you-start)
      — didn't claim it? Open the PR anyway, just say so)
- [x] One logical change (unrelated fixes belong in their own PR)
- [ ] Behavior changes arrive with the test that demanded them; bug fixes start from a
      failing test
- [x] **No golden-file test changed** — `st/1` is a public API. If a golden test did
      change, that is a deliberate format change: say so below, and update
      [docs/FORMAT.md](https://github.com/stacktale/stacktale/blob/main/docs/FORMAT.md)
- [ ] New config property? It has a setter (Joran naming), a default that preserves
      current behavior, coverage in `LogbackXmlConfigTest`, and a row in the README
      config table

## AI assistance (optional)

<!-- If an AI tool helped with this change you're welcome to mention it here. Entirely
     optional — it is not required and makes no difference to the review. -->
     
AI assistance was used to understand the JUnit Platform/Jupiter versioning and reason through the compatibility-testing approach.


<!--
First time here? Everything above is explained in CONTRIBUTING.md:
https://github.com/stacktale/stacktale/blob/main/CONTRIBUTING.md

Don't worry about getting every box right — open the PR and we'll work through it.
-->
