### PR TITLE
fix(report): summarize st-json/1 logs in the report action

### DIFF
--- a/.github/actions/report/README.md
+++ b/.github/actions/report/README.md
@@ -42,7 +42,10 @@ Useful for gating later steps.
   line has not arrived rather than show half a report.
 - **A missing log is not a failure.** A green build has nothing to say, and the action
   exits quietly with `count=0`.
-- **No runtime dependency.** The extractor is awk, so it works on any runner.
+- **No runtime dependency for text logs.** The st/1 extractor is awk, so it works on any
+  runner. **st-json/1** logs (`format=json`) are summarized with `jq` when it is on the
+  PATH (GitHub-hosted runners include it). Without `jq`, the action prints a clear notice
+  and still uploads the log as an artifact.
 
 ## Where the reports come from
 

--- a/.github/actions/report/README.md
+++ b/.github/actions/report/README.md
@@ -52,3 +52,7 @@ Useful for gating later steps.
 The library writes them. A failing *test* only produces one if `stacktale-junit` is on the
 test classpath — without it, a red `mvn test` writes nothing and this action has nothing to
 show. See the [quickstart](../../../README.md#quickstart).
+
+Projects configured with `format=json` write **st-json/1** NDJSON (one JSON object per line)
+instead of the default **st/1** text blocks. The action summarizes both when `jq` is
+available.

--- a/.github/actions/report/action.yml
+++ b/.github/actions/report/action.yml
@@ -43,11 +43,11 @@ runs:
         fi
         count=$(bash "${{ github.action_path }}/summarize.sh" "$log" "${{ inputs.max-reports }}" "$RUNNER_TEMP/stacktale-summary.md")
         echo "count=$count" >> "$GITHUB_OUTPUT"
-        if [ "$count" -gt 0 ]; then
+        if [ -s "$RUNNER_TEMP/stacktale-summary.md" ]; then
           cat "$RUNNER_TEMP/stacktale-summary.md" >> "$GITHUB_STEP_SUMMARY"
         fi
 
-    - if: steps.summarize.outputs.count != '0' && inputs.upload-artifact == 'true'
+    - if: inputs.upload-artifact == 'true'
       uses: actions/upload-artifact@v4
       with:
         name: stacktale-errors

--- a/.github/actions/report/fixtures/sample-st-json.ndjson
+++ b/.github/actions/report/fixtures/sample-st-json.ndjson
@@ -1,0 +1,4 @@
+{"type":"header","format":"st-json/1","docs":"https://github.com/stacktale/stacktale/blob/main/docs/FORMAT.md"}
+{"type":"report","id":"json0001","ts":"2026-07-10T20:16:40.412Z","thread":"main","error":{"type":"IllegalStateException","message":"payment gateway refused"}}
+{"type":"report","id":"json0002","ts":"2026-07-10T20:17:01.000Z","thread":"worker-1","error":{"noException":true,"message":"checkout timed out"}}
+{"type":"repeat","id":"json0001","count":3,"last":"2026-07-10T20:17:30.000Z"}

--- a/.github/actions/report/summarize.sh
+++ b/.github/actions/report/summarize.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Extracts the first N complete st/1 reports from an errors-ai.log and writes a Markdown
-# summary. Pure awk on purpose: a composite action that needs node or python is one more
-# thing to break on a runner that has neither.
+# Extracts the first N complete st/1 or st-json/1 reports from an errors-ai.log and writes
+# a Markdown summary. Pure awk for the text format on purpose: a composite action that needs
+# node or python is one more thing to break on a runner that has neither. st-json/1 uses jq
+# when present (GitHub-hosted runners have it); otherwise we say so honestly.
 #
 #   summarize.sh <log-file> <max-reports> <out-file>
 #
@@ -11,6 +12,113 @@ set -euo pipefail
 log="$1"
 max="$2"
 out="$3"
+
+is_st_json_log() {
+  local first
+  first=$(grep -m1 -v '^[[:space:]]*$' "$log" 2>/dev/null || true)
+  [ -n "$first" ] || return 1
+  [[ "$first" == \{* ]] || return 1
+  if command -v jq >/dev/null 2>&1; then
+    echo "$first" | jq -e '.format == "st-json/1"' >/dev/null 2>&1
+  else
+    [[ "$first" == *"st-json/1"* ]]
+  fi
+}
+
+count_st_json_reports() {
+  local count=0 line type
+  while IFS= read -r line || [ -n "$line" ]; do
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [ -z "$line" ] || [[ "$line" != \{* ]] && continue
+    type=$(echo "$line" | jq -r '.type // empty' 2>/dev/null) || continue
+    if [ "$type" = "report" ]; then
+      count=$((count + 1))
+    fi
+  done < "$log"
+  echo "$count"
+}
+
+json_headline() {
+  echo "$1" | jq -r '
+    if .error.noException == true then
+      "ERROR (no exception): " + (.error.message // "")
+    else
+      (.error.type // "") as $t |
+      (.error.message // "") as $m |
+      if $m == "" then $t else $t + ": " + $m end
+    end
+  ' 2>/dev/null
+}
+
+summarize_st_json() {
+  local total="$1"
+  local shown
+  shown=$( [ "$total" -lt "$max" ] && echo "$total" || echo "$max" )
+
+  {
+    if [ "$total" -eq 1 ]; then
+      echo "### 🔥 1 error report"
+    else
+      echo "### 🔥 ${total} error reports"
+    fi
+    echo
+    if [ "$shown" -lt "$total" ]; then
+      echo "Showing the first ${shown}. The full \`$(basename "$log")\` is attached to this run as an artifact."
+      echo
+    fi
+    local count=0 line type headline
+    while IFS= read -r line || [ -n "$line" ]; do
+      line="${line#"${line%%[![:space:]]*}"}"
+      line="${line%"${line##*[![:space:]]}"}"
+      [ -z "$line" ] || [[ "$line" != \{* ]] && continue
+      type=$(echo "$line" | jq -r '.type // empty' 2>/dev/null) || continue
+      [ "$type" = "report" ] || continue
+      count=$((count + 1))
+      headline=$(json_headline "$line")
+      id=$(echo "$line" | jq -r '.id // empty' 2>/dev/null)
+      ts=$(echo "$line" | jq -r '.ts // empty' 2>/dev/null)
+      echo "#### ${headline}"
+      if [ -n "$id" ]; then
+        echo
+        echo "_id=${id}${ts:+, ${ts}}_"
+      fi
+      echo
+      echo '```json'
+      echo "$line" | jq .
+      echo '```'
+      echo
+      if [ "$count" -ge "$shown" ]; then
+        break
+      fi
+    done < "$log"
+    echo '<sub>Produced by <a href="https://github.com/stacktale/stacktale">stacktale</a> — root cause first, your culprit frame marked.</sub>'
+  } > "$out"
+}
+
+if is_st_json_log; then
+  if ! command -v jq >/dev/null 2>&1; then
+    {
+      echo "### stacktale report"
+      echo
+      echo "This log is **st-json/1** (NDJSON). This action cannot summarize it without \`jq\`."
+      echo "The full \`$(basename "$log")\` is still uploaded as an artifact when \`upload-artifact\` is enabled."
+      echo
+      echo '<sub>Produced by <a href="https://github.com/stacktale/stacktale">stacktale</a></sub>'
+    } > "$out"
+    echo "st-json/1 is not yet supported by this action without jq — the log is still uploaded as an artifact" >&2
+    echo 0
+    exit 0
+  fi
+
+  total=$(count_st_json_reports)
+  echo "$total"
+  if [ "$total" -eq 0 ]; then
+    exit 0
+  fi
+  summarize_st_json "$total"
+  exit 0
+fi
 
 start='━━━ ERROR #'
 end='━━━ END #'

--- a/.github/actions/report/summarize.sh
+++ b/.github/actions/report/summarize.sh
@@ -13,23 +13,58 @@ log="$1"
 max="$2"
 out="$3"
 
+trim_line() {
+  local line="$1"
+  line="${line#"${line%%[![:space:]]*}"}"
+  line="${line%"${line##*[![:space:]]}"}"
+  printf '%s' "$line"
+}
+
+first_non_blank_line() {
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    line=$(trim_line "$line")
+    [ -n "$line" ] && { printf '%s' "$line"; return 0; }
+  done < "$log"
+  return 1
+}
+
+looks_like_json_log() {
+  local first
+  first=$(first_non_blank_line || true)
+  [ -n "$first" ] || return 1
+  [[ "$first" == \{* ]]
+}
+
 is_st_json_log() {
   local first
-  first=$(grep -m1 -v '^[[:space:]]*$' "$log" 2>/dev/null || true)
+  first=$(first_non_blank_line || true)
   [ -n "$first" ] || return 1
   [[ "$first" == \{* ]] || return 1
   if command -v jq >/dev/null 2>&1; then
-    echo "$first" | jq -e '.format == "st-json/1"' >/dev/null 2>&1
-  else
-    [[ "$first" == *"st-json/1"* ]]
+    if echo "$first" | jq -e '.format == "st-json/1"' >/dev/null 2>&1; then
+      return 0
+    fi
   fi
+  [[ "$first" == *"st-json/1"* ]]
+}
+
+write_st_json_unsupported_notice() {
+  {
+    echo "### stacktale report"
+    echo
+    echo "This log is **st-json/1** (NDJSON). This action cannot summarize it without \`jq\`."
+    echo "The full \`$(basename "$log")\` is still uploaded as an artifact when \`upload-artifact\` is enabled."
+    echo
+    echo '<sub>Produced by <a href="https://github.com/stacktale/stacktale">stacktale</a></sub>'
+  } > "$out"
+  echo "cannot summarize st-json/1 without jq — the log is still uploaded as an artifact" >&2
 }
 
 count_st_json_reports() {
   local count=0 line type
   while IFS= read -r line || [ -n "$line" ]; do
-    line="${line#"${line%%[![:space:]]*}"}"
-    line="${line%"${line##*[![:space:]]}"}"
+    line=$(trim_line "$line")
     [ -z "$line" ] || [[ "$line" != \{* ]] && continue
     type=$(echo "$line" | jq -r '.type // empty' 2>/dev/null) || continue
     if [ "$type" = "report" ]; then
@@ -67,10 +102,9 @@ summarize_st_json() {
       echo "Showing the first ${shown}. The full \`$(basename "$log")\` is attached to this run as an artifact."
       echo
     fi
-    local count=0 line type headline
+    local count=0 line type headline id ts
     while IFS= read -r line || [ -n "$line" ]; do
-      line="${line#"${line%%[![:space:]]*}"}"
-      line="${line%"${line##*[![:space:]]}"}"
+      line=$(trim_line "$line")
       [ -z "$line" ] || [[ "$line" != \{* ]] && continue
       type=$(echo "$line" | jq -r '.type // empty' 2>/dev/null) || continue
       [ "$type" = "report" ] || continue
@@ -96,27 +130,38 @@ summarize_st_json() {
   } > "$out"
 }
 
-if is_st_json_log; then
+handle_st_json_log() {
   if ! command -v jq >/dev/null 2>&1; then
+    write_st_json_unsupported_notice
+    echo 0
+    return 0
+  fi
+
+  local total
+  total=$(count_st_json_reports)
+  if [ "$total" -eq 0 ] && grep -q '"type"[[:space:]]*:[[:space:]]*"report"' "$log" 2>/dev/null; then
     {
       echo "### stacktale report"
       echo
-      echo "This log is **st-json/1** (NDJSON). This action cannot summarize it without \`jq\`."
+      echo "This log looks like **st-json/1**, but the action could not parse it with \`jq\`."
       echo "The full \`$(basename "$log")\` is still uploaded as an artifact when \`upload-artifact\` is enabled."
       echo
       echo '<sub>Produced by <a href="https://github.com/stacktale/stacktale">stacktale</a></sub>'
     } > "$out"
-    echo "st-json/1 is not yet supported by this action without jq — the log is still uploaded as an artifact" >&2
+    echo "could not parse st-json/1 with jq — the log is still uploaded as an artifact" >&2
     echo 0
-    exit 0
+    return 0
   fi
 
-  total=$(count_st_json_reports)
   echo "$total"
   if [ "$total" -eq 0 ]; then
-    exit 0
+    return 0
   fi
   summarize_st_json "$total"
+}
+
+if is_st_json_log; then
+  handle_st_json_log
   exit 0
 fi
 
@@ -131,6 +176,9 @@ total=${total:-0}
 echo "$total"
 
 if [ "$total" -eq 0 ]; then
+  if looks_like_json_log; then
+    handle_st_json_log
+  fi
   exit 0
 fi
 

--- a/.github/workflows/report-action.yml
+++ b/.github/workflows/report-action.yml
@@ -73,3 +73,22 @@ jobs:
       - run: |
           [ '${{ steps.empty.outputs.count }}' = '0' ] || { echo "expected 0"; exit 1; }
           echo "ok"
+
+      - name: st-json/1 logs are summarized when jq is available
+        run: |
+          set -euo pipefail
+          cp .github/actions/report/fixtures/sample-st-json.ndjson errors-ai.log
+          count=$(bash .github/actions/report/summarize.sh errors-ai.log 1 /tmp/st-json-summary.md)
+          if [ "$count" != "2" ]; then
+            echo "expected 2 st-json reports, got '$count'"
+            exit 1
+          fi
+          grep -q '2 error reports' /tmp/st-json-summary.md
+          grep -q 'IllegalStateException: payment gateway refused' /tmp/st-json-summary.md
+          grep -q 'ERROR (no exception): checkout timed out' /tmp/st-json-summary.md
+          grep -q 'json0001' /tmp/st-json-summary.md
+          if grep -q '"type": "repeat"' /tmp/st-json-summary.md; then
+            echo "repeat entries should not appear as reports in the summary"
+            exit 1
+          fi
+          echo "ok"

--- a/.github/workflows/report-action.yml
+++ b/.github/workflows/report-action.yml
@@ -78,7 +78,10 @@ jobs:
         run: |
           set -euo pipefail
           cp .github/actions/report/fixtures/sample-st-json.ndjson errors-ai.log
-          count=$(bash .github/actions/report/summarize.sh errors-ai.log 1 /tmp/st-json-summary.md)
+          # 2, not 1: the assertions below cover both fixture entries, and the second one
+          # is what exercises the noException headline branch. With max=1 the summary
+          # legitimately stops after the first and the check three lines down fails.
+          count=$(bash .github/actions/report/summarize.sh errors-ai.log 2 /tmp/st-json-summary.md)
           if [ "$count" != "2" ]; then
             echo "expected 2 st-json reports, got '$count'"
             exit 1

--- a/.github/workflows/report-action.yml
+++ b/.github/workflows/report-action.yml
@@ -92,3 +92,43 @@ jobs:
             exit 1
           fi
           echo "ok"
+
+      - name: st-json/1 with leading whitespace on the header still parses
+        run: |
+          set -euo pipefail
+          printf '  {"type":"header","format":"st-json/1"}\n' > errors-ai.log
+          printf '{"type":"report","id":"ws0001","ts":"2026-07-10T20:16:40.412Z","thread":"main","error":{"type":"RuntimeException","message":"leading space header"}}\n' >> errors-ai.log
+          count=$(bash .github/actions/report/summarize.sh errors-ai.log 1 /tmp/st-json-ws-summary.md)
+          [ "$count" = "1" ] || { echo "expected 1 report, got '$count'"; exit 1; }
+          grep -q 'RuntimeException: leading space header' /tmp/st-json-ws-summary.md
+          echo "ok"
+
+      - name: st-json/1 without jq writes a notice instead of failing silently
+        run: |
+          set -euo pipefail
+          cp .github/actions/report/fixtures/sample-st-json.ndjson errors-ai.log
+          mkdir -p /tmp/no-jq-bin
+          for cmd in bash basename cat grep printf env; do
+            ln -sf "$(command -v "$cmd")" "/tmp/no-jq-bin/$cmd"
+          done
+          count=$(env PATH=/tmp/no-jq-bin bash .github/actions/report/summarize.sh errors-ai.log 1 /tmp/st-json-nojq-summary.md)
+          [ "$count" = "0" ] || { echo "expected 0 without jq, got '$count'"; exit 1; }
+          grep -q 'cannot summarize it without' /tmp/st-json-nojq-summary.md
+          echo "ok"
+
+      - name: st-json/1 end to end through the composite action
+        run: cp .github/actions/report/fixtures/sample-st-json.ndjson errors-ai.log
+      - id: json-report
+        uses: ./.github/actions/report
+        with:
+          max-reports: "2"
+          comment: "false"
+          upload-artifact: "false"
+      - run: |
+          set -euo pipefail
+          got='${{ steps.json-report.outputs.count }}'
+          [ "$got" = "2" ] || { echo "expected action count 2, got '$got'"; exit 1; }
+          summary="$RUNNER_TEMP/stacktale-summary.md"
+          grep -q '2 error reports' "$summary"
+          grep -q 'IllegalStateException: payment gateway refused' "$summary"
+          echo "ok"


### PR DESCRIPTION
## Summary

The report composite action now recognizes `st-json/1` NDJSON logs (`format=json`) and summarizes `report` entries instead of silently reporting zero results.

## Motivation

Fixes #141. When a project writes `errors-ai.log` as NDJSON, `summarize.sh` previously grepped for text-format `━━━ END #` delimiters that never exist in JSON output. A red build therefore looked identical to a green one: no PR comment, no job summary, and `count=0`.

## Changes

- Detect `st-json/1` from the first non-blank header line (with trim + substring fallback when `jq` cannot validate)
- Count and render `type=report` lines with `jq` when available
- When `jq` is absent or unusable, write a clear step-summary notice and keep artifact upload working
- Show the step summary whenever `summarize.sh` writes output, not only when `count > 0`
- Upload artifacts whenever `upload-artifact` is enabled (not gated on `count`)
- Add fixture + workflow self-tests (whitespace header, no-`jq` fallback, composite action e2e)

## Tests

- `bash .github/actions/report/summarize.sh .github/actions/report/fixtures/sample-st-json.ndjson 1 /tmp/out.md` → count `2`
- Text-format golden self-test path unchanged (still expects 3 complete reports)
- Workflow cases added in `.github/workflows/report-action.yml` for st-json/1

## Notes

- PR comments are still posted only when `count > 0` (unchanged); the jq-absent notice appears in the job summary only.
- Repeat/session/storm JSON lines are intentionally excluded from the inline summary, matching how the MCP server treats them.

Fixes #141