### PR TITLE
chore(ci): catch up the actions Dependabot was never going to reach

### DIFF
--- a/.github/actions/report/action.yml
+++ b/.github/actions/report/action.yml
@@ -48,7 +48,7 @@ runs:
         fi
 
     - if: steps.summarize.outputs.count != '0' && inputs.upload-artifact == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: stacktale-errors
         path: ${{ inputs.file }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,3 +24,17 @@ updates:
         update-types:
           - minor
           - patch
+  # A second entry, because the first does not cover this. For github-actions,
+  # `directory: "/"` means .github/workflows only — a composite action's own
+  # action.yml needs the directory it lives in named explicitly. Without this,
+  # .github/actions/report pinned actions/upload-artifact@v4 while every workflow
+  # had moved to v7, and nothing was ever going to say so.
+  - package-ecosystem: github-actions
+    directory: "/.github/actions/report"
+    schedule:
+      interval: weekly
+    groups:
+      report-action-minor-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -22,7 +22,7 @@ jobs:
           - examples/spring-boot-webflux
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/configure-pages@v6
       - uses: actions/upload-pages-artifact@v5
         with:

--- a/.github/workflows/report-action.yml
+++ b/.github/workflows/report-action.yml
@@ -21,7 +21,7 @@ jobs:
   selftest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build a log from the golden fixtures
         run: |


### PR DESCRIPTION
Merging #166 left `actions/checkout` at v4 in three workflows and v7 in the rest.

## The three that were only early

`examples.yml`, `pages.yml`, `report-action.yml`. Dependabot would have caught these on its next weekly run; they are bumped here so the repo stops disagreeing with itself in the meantime.

## The one that was stuck

`.github/actions/report/action.yml` pinned `actions/upload-artifact@v4` with **no path to ever moving**.

For the `github-actions` ecosystem, `directory: "/"` means `.github/workflows` and nothing else. A composite action's own `action.yml` is scanned only when the directory it lives in is named explicitly. So that pin was frozen, and nothing was going to say so — it surfaced only because merging #166 made the version spread visible enough to notice.

A second `github-actions` entry now covers it:

```yaml
- package-ecosystem: github-actions
  directory: "/.github/actions/report"
```

## Verified

```
maven          -> /
github-actions -> /
github-actions -> /.github/actions/report
```

No `@v4` left anywhere under `.github/`, and all five touched files parse as YAML.