### PR TITLE
docs: add the missing seen: and story-omitted lines to the FORMAT grammar

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -58,8 +58,10 @@ log: "<message-pattern>" [args=[<v>, …]] logger=<abbreviated-logger>
 [fields: <k>=<v> …]
 [captured (method args at throw site, via stacktale-agent):
   <Type.method(arg=value, …)>                        (one or more)]
+[seen: N× this session, first at <HH:mm:ss.SSS>]
 <blank line>
 [story (<label>, last N events, <span>ms):
+  [… N earlier event(s) older than the story window omitted]
   <HH:mm:ss.SSS> <LEVEL> <logger>  <message>[   ← this error]]
 <blank line>
 [stack (distilled, X of Y frames):


### PR DESCRIPTION
## What & why

The §3 grammar block is the part someone writes a parser from, and it omitted `seen:` — which `ReportRenderer` emits, the golden fixture carries, and the field table below already describes. As the issue says, that is how the editor plugins ended up not parsing it.

Closes #139

**A second omission.** The issue asks to check the rest of `rich-report.txt` against the block and fix anything else missing. One more was: the `… N earlier event(s) older than the story window omitted` line inside `story`. Same shape of gap — the field table documents it ("A `… N earlier event(s) older than the story window omitted` line appears when events were dropped by age"), the fixture contains it, the grammar did not.

Both are marked optional with `[…]`, and `seen:` is placed after `captured:` and before the blank line preceding `story`, which is where it appears in the fixture.

To check I had them all rather than eyeballing it, I reduced every line in `rich-report.txt` to its identifying token and looked each one up in the grammar block. After this change all thirteen kinds resolve; the only unmatched lines are the headline, the indented `captured` argument line and the story event lines, which the grammar covers with placeholders rather than literal tokens.

## How it was verified

- [x] Documentation-only — nothing to build

`git status` shows `docs/FORMAT.md` as the only modified file, so the golden fixture is untouched — which is what the suggested `mvn -q -pl stacktale-core test` was there to confirm. I don't have Maven on this machine, so I checked it that way rather than claim a build I didn't run.

## Checklist

- [ ] The issue was claimed with a comment before starting — **no, I didn't**, and per CONTRIBUTING I'm saying so. Happy to follow the claim-first flow next time; I went straight to the PR here because the change is confined to a doc block the issue specifies exactly.
- [x] One logical change
- [x] Behavior changes arrive with the test that demanded them — n/a, no behaviour change
- [x] **No golden-file test changed**
- [x] New config property? — n/a

## AI assistance (optional)

Written with Claude Code (Claude Opus 5): it made the edit and drafted this description. The fixture cross-check described above was run against the real files.