### PR TITLE
docs: add stacktale-junit to the JPMS module table

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ path as well as the classpath — a resolution smoke test in CI pins this:
 | `stacktale` (Logback) | `io.github.gabrielbbaldez.stacktale.logback` |
 | `stacktale-log4j2` | `io.github.gabrielbbaldez.stacktale.log4j2` |
 | `stacktale-jul` | `io.github.gabrielbbaldez.stacktale.jul` |
+| `stacktale-junit` | `io.github.gabrielbbaldez.stacktale.junit` |
 | `stacktale-spring-boot-starter` | `io.github.gabrielbbaldez.stacktale.spring` |
 | `stacktale-mcp` | `io.github.gabrielbbaldez.stacktale.mcp` |
 | `stacktale-agent` | `io.github.gabrielbbaldez.stacktale.agent` |


### PR DESCRIPTION
## What & why

`stacktale-junit` was missing from the README's JPMS table. Added after `stacktale-jul`, matching the table's convention of following module order in the parent `pom.xml` (where `stacktale-junit` sits at line 44, between `stacktale-jul` and `stacktale-spring-boot-starter`).

Closes #140

## How it was verified

- [x] Documentation-only — nothing to build

The issue is explicit that confirming the string is the point, not copying it. I don't have Maven on this machine, so I couldn't run `unzip -p …/MANIFEST.MF | grep Automatic-Module-Name`. Rather than claim a check I didn't run, I traced the value through the build instead:

1. `stacktale-junit/pom.xml:20` — `<stacktale.module.name>io.github.gabrielbbaldez.stacktale.junit</stacktale.module.name>`
2. `pom.xml:117` — `<Automatic-Module-Name>${stacktale.module.name}</Automatic-Module-Name>` in the jar plugin's `pluginManagement`
3. `pom.xml:132` — the jar plugin is activated in `<plugins>`, so that config applies to `default-jar`

So the manifest value is the property verbatim, and the property matches the row. Happy for a reviewer with a build to confirm the manifest directly if you'd rather not take the trace.

## A related finding, not fixed here

The sentence immediately above the table says the module names are pinned by *"a resolution smoke test in CI"*. That test is `JpmsModulePathIT`, and it covers **`stacktale-core` and `stacktale` (Logback) only** — the two that had the split-package problem #44 was about. The other six rows, `stacktale-junit` included, are not pinned by anything.

That is the same class of gap as this issue: the table can drift and nothing notices. It seemed worth saying, since the sentence is the reason a reader would trust the table — but extending the IT is a behaviour change and belongs in its own PR under "one logical change". Happy to open an issue for it, or a PR if you'd rather go straight there.

## Checklist

- [ ] The issue was claimed with a comment before starting — **no, I didn't**, and per CONTRIBUTING I'm flagging it.
- [x] One logical change
- [x] Behavior changes arrive with the test that demanded them — n/a
- [x] **No golden-file test changed**
- [x] New config property? — n/a

## AI assistance (optional)

Written with Claude Code (Claude Opus 5): it made the edit and drafted this description. The pom trace and the `JpmsModulePathIT` coverage check above were done against the real files.