### PR TITLE
docs: pin the st-json/1 ↔ st/1 correspondences in FORMAT §7

### DIFF
--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -230,3 +230,24 @@ Rules:
   (a crash or a full disk mid-write) must never abort parsing the rest of the file.
 - Same version discipline as §6: additive members don't bump the major; a breaking change
   bumps to `st-json/2`.
+
+### Correspondence with `st/1`
+
+Both formats carry the same information. Where a member is named after its `st/1`
+counterpart the mapping needs no explanation — `mdc`, `fields`, `captured`, `env`, `id`,
+`thread`, `log.pattern`/`log.args`/`log.logger`, `story.label`, `story.events[].level`,
+`stack.suppressed`. Every member whose name does **not** match its `st/1` token is listed
+below, so the mapping never has to be inferred from the example above.
+
+| `st-json/1` | `st/1` (§3) |
+|---|---|
+| `ts` | the `<timestamp>` in the `━━━ ERROR #<id> ━━━` line |
+| `error.type` + `error.message` | the `<headline>` line |
+| `error.culprit.frame` | the `at <culprit-frame>` line |
+| `error.culprit.appCode` | whether that line ends with `← YOUR CODE` |
+| `error.wrappedBy[]` | one entry per `wrapped by:` line, same order |
+| `recurrence` | the `seen:` line — `count` is `N×`, `firstSeen` is `first at …`. Omitted when the error is a first occurrence, exactly as `seen:` is absent then |
+| `story.omittedByAge` | the `… N earlier event(s) older than the story window omitted` line |
+| `story.events[].thisError` | the `   ← this error` suffix on the error's own event |
+| `stack.shown` / `stack.total` | the `X of Y frames` in the `stack (distilled, …)` header |
+| `stack.frames[]` | the frame lines, including the `… N collapsed (…)` markers |


### PR DESCRIPTION
## What & why

§7 showed `recurrence` only inside the example, leaving the reader to infer that it is the JSON form of `seen:`. Added a **Correspondence with `st/1`** subsection after the rules list.

Closes #143

## The other implicit pairings

The issue asks to read §7's rules against §3's field table and fix any *other* pairing left implicit. `recurrence` was not the only one — four more members have names that don't match their `st/1` token and appeared nowhere but the example:

| member | `st/1` counterpart | was documented |
|---|---|---|
| `recurrence` | the `seen:` line | example only |
| `error.culprit.appCode` | whether the `at …` line ends with `← YOUR CODE` | example only |
| `story.omittedByAge` | the `… N earlier event(s) older than the story window omitted` line | example only |
| `story.events[].thisError` | the `   ← this error` suffix | example only |
| `stack.shown` / `stack.total` | the `X of Y frames` in the `stack (distilled, …)` header | example only |

The table also covers `ts`, `error.type`/`error.message`, `error.culprit.frame`, `error.wrappedBy[]` and `stack.frames[]` for completeness, since the point is that *every* member resolves from the prose.

The intro sentence names the members that match by name (`mdc`, `fields`, `captured`, `env`, `id`, `thread`, `log.*`, `story.label`, `story.events[].level`, `stack.suppressed`) so their absence from the table reads as deliberate rather than as another gap.

## How it was verified

- [x] Documentation-only — nothing to build

I ran the issue's own test rather than eyeballing it: parse the example JSON in §7, walk every member path, and check each one appears in §7's prose **after** the example block — i.e. reachable with the example covered up.

- Before: 8 unreachable, of which 5 were real gaps (the other 3 were `mdc.traceId` / `fields.orderId` / `fields.retryable`, which are sample data, not schema).
- After: **0 unreachable across all 35 schema members.**

Related to #63 (JSON Schema for `st-json/1`) — a schema needs these same correspondences pinned, which is why the issue mentions it.

## Checklist

- [ ] The issue was claimed with a comment before starting — **no, I didn't**, flagging it per CONTRIBUTING.
- [x] One logical change
- [x] Behavior changes arrive with the test that demanded them — n/a
- [x] **No golden-file test changed**
- [x] New config property? — n/a

## AI assistance (optional)

Written with Claude Code (Claude Opus 5): it wrote the table and this description. The member-coverage check above was run against the real file.