### PR TITLE
infra: guard the plugin manifests against release drift

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "stacktale",
       "source": "./plugins/stacktale",
       "description": "Read your Java app's AI-ready error reports, and run a fix-run-check loop until the app is clean.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "Gabriel Baldez"
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: README compatibility table guard
         if: matrix.java == 21
         run: bash scripts/check-readme-compat.sh
+      - name: Plugin manifest version guard
+        if: matrix.java == 21
+        run: bash scripts/check-plugin-versions.sh
       - name: Coverage summary
         if: matrix.java == 21
         run: |

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -80,12 +80,19 @@ jobs:
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
-      - name: Update README versions
+      - name: Update README and plugin manifest versions
         run: |
           set -euo pipefail
           sed -i -E 's|(<artifactId>stacktale[a-z0-9-]*</artifactId>[[:space:]]*<version>)[0-9.]+(</version>)|\1${{ inputs.version }}\2|g' README.md
           sed -i -E 's|(io\.github\.gabrielbbaldez:stacktale[a-z0-9-]*:)[0-9.]+|\1${{ inputs.version }}|g' README.md
           bash scripts/check-readme-compat.sh
+          # The plugin manifests pin the released version too, and were the one set of
+          # files the bump did not reach (#142). The guard runs straight after, so a sed
+          # that matched nothing fails here rather than shipping a stale marketplace entry.
+          sed -i -E 's|(io\.github\.gabrielbbaldez:stacktale-mcp:)[0-9.]+|\1${{ inputs.version }}|' plugins/stacktale/.mcp.json
+          sed -i -E 's|("version"[[:space:]]*:[[:space:]]*")[0-9.]+(")|\1${{ inputs.version }}\2|' .claude-plugin/marketplace.json
+          sed -i -E 's|("version"[[:space:]]*:[[:space:]]*")[0-9.]+(")|\1${{ inputs.version }}\2|' plugins/stacktale/.claude-plugin/plugin.json
+          bash scripts/check-plugin-versions.sh
 
       - name: Commit the release, then the next snapshot
         run: |

--- a/plugins/stacktale/.claude-plugin/plugin.json
+++ b/plugins/stacktale/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stacktale",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Read your Java app's AI-ready error reports, and run a fix-run-check loop until the app is clean.",
   "author": {
     "name": "Gabriel Baldez",

--- a/plugins/stacktale/.mcp.json
+++ b/plugins/stacktale/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "stacktale": {
       "command": "jbang",
-      "args": ["run", "io.github.gabrielbbaldez:stacktale-mcp:1.1.0"]
+      "args": ["run", "io.github.gabrielbbaldez:stacktale-mcp:1.2.0"]
     }
   }
 }

--- a/scripts/check-plugin-versions.sh
+++ b/scripts/check-plugin-versions.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Guard the Claude plugin / marketplace manifests against drifting from the release.
+#
+# Three files hard-pin a version and are not touched by the version bump:
+#   plugins/stacktale/.mcp.json                  -> the stacktale-mcp coordinate jbang runs
+#   .claude-plugin/marketplace.json              -> the version the marketplace advertises
+#   plugins/stacktale/.claude-plugin/plugin.json -> the version the installed plugin reports
+#
+# THE RULE: they pin the most recent *released* version, which is the newest version
+# heading in CHANGELOG.md.
+#
+# Not the parent pom's version, because those differ on purpose for most of a cycle. On
+# `main` between releases the parent is 1.3.0-SNAPSHOT while the plugin must still install
+# 1.2.0 — the only version a user can actually resolve from Maven Central. At release the
+# bump sets the parent to 1.2.0 and adds the `## [1.2.0]` heading in the same commit, so
+# the two agree again. Keying on the changelog is therefore correct in both states, where
+# plain equality with the pom is wrong in one of them.
+#
+# On mismatch, update the three JSON files to the version named in the failure message.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+fail=0
+
+# Newest `## [X.Y.Z]` heading. `[Unreleased]`, if it is ever added, is skipped by the
+# version pattern rather than by position.
+latest_release() {
+  grep -oE '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' CHANGELOG.md \
+    | head -n1 | tr -d '#[] '
+}
+
+# The parent's own <version>, read without invoking Maven so this runs on a bare checkout.
+pom_version() {
+  sed -n '/<artifactId>stacktale-parent<\/artifactId>/,/<\/version>/p' pom.xml \
+    | grep -oE '<version>[^<]+</version>' | head -n1 | sed 's/<[^>]*>//g'
+}
+
+# First version-shaped string in a file, which is the pinned one in all three.
+pinned() {
+  grep -oE '[0-9]+\.[0-9]+\.[0-9]+' "$1" | head -n1
+}
+
+expected=$(latest_release)
+if [ -z "$expected" ]; then
+  echo "check-plugin-versions: no '## [X.Y.Z]' heading found in CHANGELOG.md" >&2
+  exit 1
+fi
+
+for file in \
+  plugins/stacktale/.mcp.json \
+  .claude-plugin/marketplace.json \
+  plugins/stacktale/.claude-plugin/plugin.json
+do
+  actual=$(pinned "$file")
+  if [ "$actual" != "$expected" ]; then
+    echo "$file pins $actual, expected $expected (the latest release, per CHANGELOG.md)" >&2
+    fail=1
+  fi
+done
+
+# A release commit sets the parent to the version it is releasing. If the parent is not a
+# SNAPSHOT and disagrees with the changelog, one of the two was not updated -- and the
+# check above would have compared against the wrong number without noticing.
+pom=$(pom_version)
+case "$pom" in
+  *-SNAPSHOT) ;;
+  "$expected") ;;
+  *)
+    echo "pom.xml is $pom but CHANGELOG.md's latest release is $expected" >&2
+    echo "  a release bumps both; fix whichever is behind before trusting the pins above" >&2
+    fail=1
+    ;;
+esac
+
+if [ "$fail" -eq 0 ]; then
+  echo "plugin manifests pin $expected"
+fi
+
+exit "$fail"


### PR DESCRIPTION
## What & why

The three manifests were pinning **1.1.0** — two releases behind — so the Claude plugin has been installing `stacktale-mcp:1.1.0` and the marketplace advertising 1.1.0 since 1.2.0 shipped. Fixed, and guarded.

Closes #142

I did **both** halves the issue offers, because they cover different failures: the bump stops the release path from creating drift, and the check catches drift from any other source — which is the one that actually happened here.

## The rule (as the issue asks, decided and written down)

> The manifests pin the newest version heading in `CHANGELOG.md`.

Not the parent pom's version. Those differ on purpose for most of a cycle: on `main` the parent is `1.3.0-SNAPSHOT` while the plugin must still install `1.2.0`, the only version a user can resolve from Central. At release, the bump sets the parent to `1.2.0` and the `## [1.2.0]` heading is already required by the existing pre-flight check, so the two agree in the same commit.

Plain equality with the pom would be wrong for most of every cycle. Keying on the changelog is correct in both states. That reasoning is in the script header, not just here.

The script has a second assertion for the case that would silently break the first: if the pom is **not** a SNAPSHOT and disagrees with the changelog, one of them wasn't updated, and the version comparison above would be measuring against the wrong number. It says which two disagree.

## Verification — the issue's own steps

**"Change one pinned version to something wrong and confirm CI goes red with a message that names the file."**

The check was written before the fix, so its first run was against the real drift:

```
$ bash scripts/check-plugin-versions.sh
plugins/stacktale/.mcp.json pins 1.1.0, expected 1.2.0 (the latest release, per CHANGELOG.md)
.claude-plugin/marketplace.json pins 1.1.0, expected 1.2.0 (the latest release, per CHANGELOG.md)
plugins/stacktale/.claude-plugin/plugin.json pins 1.1.0, expected 1.2.0 (the latest release, per CHANGELOG.md)
exit=1
```

After fixing the three files it prints `plugin manifests pin 1.2.0` and exits 0. Re-breaking one file individually goes red again naming only that file. The pom/changelog assertion was checked separately by setting the pom to a non-SNAPSHOT `1.4.0`:

```
pom.xml is 1.4.0 but CHANGELOG.md's latest release is 1.2.0
  a release bumps both; fix whichever is behind before trusting the pins above
```

**"Run the release workflow's bump step locally with a dummy version and confirm every pinned file moves together."**

Ran the three `sed` expressions verbatim from the workflow against a simulated 1.9.0 release (changelog section added, pom set to 1.9.0):

```
stacktale-mcp:1.9.0
.claude-plugin/marketplace.json:"version": "1.9.0"
plugins/stacktale/.claude-plugin/plugin.json:"version": "1.9.0"
plugin manifests pin 1.9.0   ← guard green at the dummy version
```

All three moved, and the guard agreed. Working tree restored afterwards.

## Notes

- The guard runs in `ci.yml` beside `check-readme-compat.sh`, same `matrix.java == 21` condition — that script is the existing precedent for this kind of check.
- In `prepare-release.yml` the seds sit in the step that already updates the README, and `check-plugin-versions.sh` runs immediately after them — so a sed that silently matched nothing fails the release rather than shipping a stale marketplace entry. Same shape as the existing `check-readme-compat.sh` call one line above.
- No Maven needed: the script reads the pom version with `sed` rather than `mvn help:evaluate`, so it runs on a bare checkout. (`check-readme-compat.sh` needs Maven for a different reason — it resolves dependency properties.)

I could not run `mvn verify` — no Maven toolchain on this machine — but nothing here touches the build. The shell above was all run for real.

## Checklist

- [ ] The issue was claimed with a comment before starting — **no**, flagging it per CONTRIBUTING.
- [x] One logical change — keeping the manifests in step with the release; the bump and the guard are the two halves of it
- [x] Behavior changes arrive with the test that demanded them — the check was written before the fix and failed on the real drift
- [x] **No golden-file test changed**
- [x] New config property? — n/a

## AI assistance (optional)

Written with Claude Code (Claude Opus 5): it wrote the script, the workflow edits and this description. Every command quoted above was run against the real repository.