### PR TITLE
feat: ship a reproduction seed with the report

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,33 @@ io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler..level = ALL
 `SEVERE` records become reports; lower levels feed the story (which correlates by thread,
 since JUL has no MDC). No extra dependency — JUL is in the JDK.
 
+### A reproduction seed
+
+Agents write good reproduction tests for code they can see and poor ones for code they
+cannot. TDD-Bench-Java measured ~44% on public benchmarks against **4% on proprietary code
+with no hints — rising to 20% once given concrete class names and method signatures.**
+
+stacktale is standing at the throw site holding exactly that. With `stacktale-agent` attached
+and `repro=true`, the report carries it:
+
+```
+repro (throw site, via stacktale-agent):
+  com.acme.shop.PaymentService#charge(long orderId, java.math.BigDecimal amount)
+    orderId = 889
+    amount = 149.90
+  throws IllegalStateException: payment gateway refused
+```
+
+The fully-qualified class so a test can import it, the **declared** parameter types so the
+signature can be reconstructed, the values that produced the failure, and the expected
+throwable as the assertion.
+
+**Off by default, deliberately.** This is the only section that renders argument values
+against a named signature, which is a bigger privacy surface than the rest of a report
+together. Values are truncated by the agent and redacted by the core, and
+`renderToString=false` on the agent keeps non-value types to their type name — but the
+decision to emit them at all is yours to make.
+
 ### Failing tests
 
 A failing test never reaches an appender — the assertion error is caught by the JUnit
@@ -604,6 +631,7 @@ Everything is optional — as appender properties in `logback.xml`, or `stacktal
 | `installUncaughtHandler` | `true` | Report uncaught exceptions too |
 | `reportErrorsWithoutThrowable` | `true` | `log.error(...)` without exception still reports |
 | `captureExceptionFields` | `true` | Read exception getters into `fields:` |
+| `repro` | `false` | Add a `repro:` seed: the throw site's typed signature and argument values. Needs `stacktale-agent`. Off by default — it is the only section that renders values against a named signature |
 | `redactionEnabled` | `true` | Mask secrets/PII in report content |
 | `redactPattern` / `redactPatterns` | — | Extra redaction regexes (see note below) |
 | `redactionCorrelation` | `false` | Tag masked values with a stable keyed token (`███(a1b2)`) so an AI can see the same secret recurring |

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -58,6 +58,10 @@ log: "<message-pattern>" [args=[<v>, …]] logger=<abbreviated-logger>
 [fields: <k>=<v> …]
 [captured (method args at throw site, via stacktale-agent):
   <Type.method(arg=value, …)>                        (one or more)]
+[repro (throw site, via stacktale-agent):
+  <fqcn>#<method>(<declared-type> <name>, …)
+    <name> = <value>                                 (one per parameter)
+  throws <Type>[: <message>]]
 [seen: N× this session, first at <HH:mm:ss.SSS>]
 <blank line>
 [story (<label>, last N events, <span>ms):
@@ -156,6 +160,36 @@ A new application run began appending to an existing file. Separates sessions.
 ```
 A flood of **distinct** errors exceeded the report rate limit; `N` full reports were
 suppressed to protect the file. The errors still happened — this line is the acknowledgement.
+
+### `repro:` — the reproduction seed
+
+Off by default. Switched on with `repro=true` and only produced when `stacktale-agent` is
+attached, since the argument values come from the throw site.
+
+It answers "what call, with what inputs, produced this?" in a form a test can be written
+from. The declared parameter types are the point: `charge(orderId=889)` in `captured:` names
+neither the class the method lives on nor the type of 889, and a signature cannot be
+reconstructed from either.
+
+```
+repro (throw site, via stacktale-agent):
+  com.acme.shop.PaymentService#charge(long orderId, java.math.BigDecimal amount)
+    orderId = 889
+    amount = 149.90
+  throws IllegalStateException: payment gateway refused
+```
+
+- The class is **fully qualified**, because a test has to import it.
+- Types are the ones the method **declares**. When the method cannot be resolved
+  unambiguously — an overload of the same arity — the runtime class of the argument is used
+  instead; a wrong declared type is worse than an approximate one.
+- Only the **innermost** captured frame becomes a seed. Captures are appended as the
+  throwable unwinds, so the first is the closest to the throw. The frames above it remain in
+  `captured:`.
+- Values are truncated by the agent and **redacted** by the core, like every other rendered
+  value. This is the only section that renders values against a named signature, which is why
+  it is opt-in rather than default.
+- The `throws` line restates the root cause so the seed carries its own assertion.
 
 ## 6. Versioning & compatibility
 

--- a/stacktale-agent/src/main/java/io/github/gabrielbbaldez/stacktale/agent/CaptureRegistry.java
+++ b/stacktale-agent/src/main/java/io/github/gabrielbbaldez/stacktale/agent/CaptureRegistry.java
@@ -24,9 +24,21 @@ public final class CaptureRegistry {
     private static volatile int maxValueLength = 60;
     private static volatile boolean renderToString = true;
 
-    private static final Map<Throwable, Deque<String>> CAPTURES =
+    private static final Map<Throwable, Deque<Frame>> CAPTURES =
             Collections.synchronizedMap(new WeakHashMap<>());
     private static final Map<String, String[]> PARAMETER_NAMES = new ConcurrentHashMap<>();
+    private static final Map<String, String[]> PARAMETER_TYPES = new ConcurrentHashMap<>();
+
+    /**
+     * One instrumented frame, kept structured rather than pre-rendered.
+     *
+     * <p>The {@code captured:} section wants a compact line; a repro seed wants the
+     * fully-qualified class and the <em>declared</em> parameter types, which is what makes
+     * the signature reconstructable. Recording once and rendering per reader keeps the
+     * throw path doing no extra work — reads only happen when a report is written.
+     */
+    private record Frame(String className, String methodName,
+                         String[] types, String[] names, String[] values) {}
 
     private CaptureRegistry() {}
 
@@ -40,34 +52,94 @@ public final class CaptureRegistry {
     /** Called from instrumented methods (via advice) when they exit with a throwable. */
     public static void record(Throwable thrown, String className, String methodName, Object[] args) {
         try {
-            Deque<String> frames = CAPTURES.computeIfAbsent(thrown, k -> new ArrayDeque<>());
+            Deque<Frame> frames = CAPTURES.computeIfAbsent(thrown, k -> new ArrayDeque<>());
             synchronized (frames) {
                 if (frames.size() >= maxFrames) return;
-                frames.addLast(formatFrame(className, methodName, args));
+                frames.addLast(frameOf(className, methodName, args));
             }
         } catch (Throwable ignored) {
             // never make a failing app worse
         }
     }
 
-    /** Read by stacktale-core via reflection. */
+    /** Read by stacktale-core via reflection. Renders the compact {@code captured:} line. */
     public static List<String> get(Throwable thrown) {
-        Deque<String> frames = CAPTURES.get(thrown);
+        List<String> out = new ArrayList<>();
+        for (Frame f : snapshot(thrown)) {
+            String simple = f.className().substring(f.className().lastIndexOf('.') + 1);
+            StringBuilder sb = new StringBuilder(simple).append('.').append(f.methodName()).append('(');
+            for (int i = 0; i < f.values().length; i++) {
+                if (i > 0) sb.append(", ");
+                sb.append(f.names()[i]).append('=').append(f.values()[i]);
+            }
+            out.add(sb.append(')').toString());
+        }
+        return out;
+    }
+
+    /**
+     * Read by stacktale-core via reflection, separately from {@link #get}. A second method
+     * rather than a wider return type on the first: the core resolves each by name and
+     * signature, so an older agent paired with a newer core loses the repro seed and keeps
+     * its captures, instead of losing both to a failed lookup.
+     *
+     * <p>Wire format, one element per line, fields space-separated with the value taking
+     * the remainder — types and names never contain spaces, values may contain anything:
+     *
+     * <pre>
+     * m com.acme.shop.PaymentService charge
+     * p long orderId 889
+     * p java.math.BigDecimal amount 149.90
+     * </pre>
+     */
+    public static List<String> repro(Throwable thrown) {
+        List<String> out = new ArrayList<>();
+        for (Frame f : snapshot(thrown)) {
+            out.add("m " + f.className() + ' ' + f.methodName());
+            for (int i = 0; i < f.values().length; i++) {
+                out.add("p " + f.types()[i] + ' ' + f.names()[i] + ' ' + f.values()[i]);
+            }
+        }
+        return out;
+    }
+
+    private static List<Frame> snapshot(Throwable thrown) {
+        Deque<Frame> frames = CAPTURES.get(thrown);
         if (frames == null) return List.of();
         synchronized (frames) {
             return new ArrayList<>(frames);
         }
     }
 
-    private static String formatFrame(String className, String methodName, Object[] args) {
-        String simple = className.substring(className.lastIndexOf('.') + 1);
-        StringBuilder sb = new StringBuilder(simple).append('.').append(methodName).append('(');
-        String[] names = parameterNames(className, methodName, args == null ? 0 : args.length);
-        for (int i = 0; args != null && i < args.length; i++) {
-            if (i > 0) sb.append(", ");
-            sb.append(names != null && i < names.length ? names[i] : "arg" + i).append('=').append(render(args[i]));
+    private static Frame frameOf(String className, String methodName, Object[] args) {
+        int n = args == null ? 0 : args.length;
+        String[] names = parameterNames(className, methodName, n);
+        String[] types = parameterTypes(className, methodName, n);
+        String[] outNames = new String[n];
+        String[] outTypes = new String[n];
+        String[] outValues = new String[n];
+        for (int i = 0; i < n; i++) {
+            outNames[i] = names != null && i < names.length ? names[i] : "arg" + i;
+            // the declared type when reflection could resolve the method; otherwise the
+            // runtime class, which still names something an agent can write a call against
+            outTypes[i] = types != null && i < types.length ? types[i]
+                    : (args[i] == null ? "java.lang.Object" : args[i].getClass().getName());
+            outValues[i] = render(args[i]);
         }
-        return sb.append(')').toString();
+        return new Frame(className, methodName, outTypes, outNames, outValues);
+    }
+
+    /** Declared parameter types, so a repro seed can name a signature rather than guess it. */
+    private static String[] parameterTypes(String className, String methodName, int argCount) {
+        String key = className + '#' + methodName + '#' + argCount;
+        return PARAMETER_TYPES.computeIfAbsent(key, k -> {
+            Method match = resolve(className, methodName, argCount);
+            if (match == null) return new String[0];
+            Class<?>[] declared = match.getParameterTypes();
+            String[] types = new String[declared.length];
+            for (int i = 0; i < declared.length; i++) types[i] = declared[i].getTypeName();
+            return types;
+        });
     }
 
     private static String render(Object value) {
@@ -98,23 +170,34 @@ public final class CaptureRegistry {
     private static String[] parameterNames(String className, String methodName, int argCount) {
         String key = className + '#' + methodName + '#' + argCount;
         return PARAMETER_NAMES.computeIfAbsent(key, k -> {
-            try {
-                Class<?> cls = Class.forName(className, false, Thread.currentThread().getContextClassLoader());
-                Method match = null;
-                for (Method m : cls.getDeclaredMethods()) {
-                    if (m.getName().equals(methodName) && m.getParameterCount() == argCount) {
-                        if (match != null) return new String[0]; // overload ambiguity — fall back to argN
-                        match = m;
-                    }
-                }
-                if (match == null) return new String[0];
-                Parameter[] parameters = match.getParameters();
-                String[] names = new String[parameters.length];
-                for (int i = 0; i < parameters.length; i++) names[i] = parameters[i].getName();
-                return names;
-            } catch (Throwable t) {
-                return new String[0];
-            }
+            Method match = resolve(className, methodName, argCount);
+            if (match == null) return new String[0];
+            Parameter[] parameters = match.getParameters();
+            String[] names = new String[parameters.length];
+            for (int i = 0; i < parameters.length; i++) names[i] = parameters[i].getName();
+            return names;
         });
+    }
+
+    /**
+     * The declared method behind an instrumented frame, or {@code null} when it cannot be
+     * named unambiguously. An overload with the same arity is left unresolved on purpose:
+     * guessing between two signatures would put a wrong type in a repro seed, which is
+     * worse than putting none.
+     */
+    private static Method resolve(String className, String methodName, int argCount) {
+        try {
+            Class<?> cls = Class.forName(className, false, Thread.currentThread().getContextClassLoader());
+            Method match = null;
+            for (Method m : cls.getDeclaredMethods()) {
+                if (m.getName().equals(methodName) && m.getParameterCount() == argCount) {
+                    if (match != null) return null; // overload ambiguity
+                    match = m;
+                }
+            }
+            return match;
+        } catch (Throwable t) {
+            return null;
+        }
     }
 }

--- a/stacktale-agent/src/test/java/io/github/gabrielbbaldez/stacktale/agent/ReproWireFormatTest.java
+++ b/stacktale-agent/src/test/java/io/github/gabrielbbaldez/stacktale/agent/ReproWireFormatTest.java
@@ -1,0 +1,74 @@
+package io.github.gabrielbbaldez.stacktale.agent;
+
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The emitting half of the repro wire format (#135). Its parser lives in {@code
+ * stacktale-core}, in a different artifact — nothing compares the two at build time, so both
+ * sides assert against literal lines and a drift has to break one of them.
+ */
+class ReproWireFormatTest {
+
+    /** A method with declared types worth naming: a primitive, an object, and a boxed value. */
+    static final class Billing {
+        void charge(long orderId, BigDecimal amount, boolean express) {
+            throw new IllegalStateException("gateway refused");
+        }
+    }
+
+    @Test
+    void emitsTheFullyQualifiedCallAndDeclaredParameterTypes() {
+        Throwable thrown = new IllegalStateException("gateway refused");
+        CaptureRegistry.record(thrown, Billing.class.getName(), "charge",
+                new Object[]{889L, new BigDecimal("149.90"), true});
+
+        List<String> lines = CaptureRegistry.repro(thrown);
+
+        assertThat(lines.get(0))
+                .isEqualTo("m " + Billing.class.getName() + " charge");
+        // declared types, not runtime ones: `long` rather than java.lang.Long, and
+        // java.math.BigDecimal rather than whatever subclass arrived. A signature is only
+        // reconstructable from what the method declares.
+        assertThat(lines).contains(
+                "p long orderId 889",
+                "p java.math.BigDecimal amount 149.90",
+                "p boolean express true");
+    }
+
+    @Test
+    void theCompactCapturedLineIsUnchangedByAnyOfThis() {
+        Throwable thrown = new IllegalStateException("gateway refused");
+        CaptureRegistry.record(thrown, Billing.class.getName(), "charge",
+                new Object[]{889L, new BigDecimal("149.90"), true});
+
+        // The captured: section is pinned by golden files in stacktale-core. Recording
+        // structured frames and rendering per reader must not have moved it.
+        //
+        // Nested classes keep the Outer$Inner form: the compact line strips the package by
+        // cutting at the last dot, and a $ is not one. Long-standing behaviour, asserted here
+        // so the restructuring is shown not to have changed it either.
+        assertThat(CaptureRegistry.get(thrown)).containsExactly(
+                "ReproWireFormatTest$Billing.charge(orderId=889, amount=149.90, express=true)");
+    }
+
+    @Test
+    void anUnresolvableMethodStillNamesSomethingUsable() {
+        Throwable thrown = new IllegalStateException("boom");
+        // a class that does not exist here: reflection cannot find the declared types, so the
+        // runtime class is used rather than dropping the parameter
+        CaptureRegistry.record(thrown, "com.nowhere.Ghost", "vanish", new Object[]{"x"});
+
+        assertThat(CaptureRegistry.repro(thrown))
+                .containsExactly("m com.nowhere.Ghost vanish", "p java.lang.String arg0 x");
+    }
+
+    @Test
+    void nothingCapturedMeansNoSeedRatherThanAnEmptyOne() {
+        assertThat(CaptureRegistry.repro(new IllegalStateException("never recorded"))).isEmpty();
+    }
+}

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/AgentCaptures.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/AgentCaptures.java
@@ -19,19 +19,75 @@ import java.util.Set;
 final class AgentCaptures {
 
     private static final int MAX_LINES = 8;
-    private static final MethodHandle GET = resolve();
+    private static final MethodHandle GET = resolve("get");
+    private static final MethodHandle REPRO = resolve("repro");
 
     private AgentCaptures() {}
 
-    private static MethodHandle resolve() {
+    /**
+     * Each entry point is looked up by name, separately. An agent jar older than this core
+     * has no {@code repro} method, and resolving them together would cost the captures too —
+     * the two versions are released as one project but a user can pin them apart.
+     */
+    private static MethodHandle resolve(String name) {
         try {
             Class<?> registry = Class.forName(
                     "io.github.gabrielbbaldez.stacktale.agent.CaptureRegistry",
                     false, ClassLoader.getSystemClassLoader());
-            return MethodHandles.publicLookup().findStatic(registry, "get",
+            return MethodHandles.publicLookup().findStatic(registry, name,
                     MethodType.methodType(List.class, Throwable.class));
         } catch (Throwable absent) {
-            return null; // agent not attached — captures are simply empty
+            return null; // agent not attached, or too old for this entry point
+        }
+    }
+
+    /**
+     * The innermost captured frame as a reproduction seed, or {@code null} when the agent is
+     * absent, older, or captured nothing.
+     *
+     * <p>Parses the agent's wire format — {@code m <fqcn> <method>} then {@code p <type>
+     * <name> <value>} — stopping at the second {@code m}. Fields are space-separated with the
+     * value taking the remainder of the line, so a value containing spaces survives; types and
+     * names cannot contain any.
+     */
+    @SuppressWarnings("unchecked")
+    static ReproSeed seedFor(Throwable throwable) {
+        if (REPRO == null || throwable == null) return null;
+        try {
+            return parseSeed((List<String>) REPRO.invoke(throwable));
+        } catch (Throwable t) {
+            return null; // a seed is a bonus; never let it cost the report
+        }
+    }
+
+    /**
+     * Package-private and taking the lines directly, so the wire format can be tested without
+     * an agent attached — the parser is the half most likely to drift from the emitter, and
+     * the two live in different modules that a user can pin to different versions.
+     */
+    static ReproSeed parseSeed(List<String> lines) {
+        try {
+            if (lines == null || lines.isEmpty()) return null;
+            String className = null;
+            String methodName = null;
+            List<ReproSeed.Param> params = new ArrayList<>();
+            for (String line : lines) {
+                if (line.startsWith("m ")) {
+                    if (className != null) break; // second frame: the seed is the innermost
+                    String[] parts = line.split(" ", 3);
+                    if (parts.length < 3) return null;
+                    className = parts[1];
+                    methodName = parts[2];
+                } else if (line.startsWith("p ") && className != null) {
+                    String[] parts = line.split(" ", 4);
+                    // a parameter with an empty value still splits into 4 with a trailing ""
+                    if (parts.length < 4) continue;
+                    params.add(new ReproSeed.Param(parts[1], parts[2], parts[3]));
+                }
+            }
+            return className == null ? null : new ReproSeed(className, methodName, List.copyOf(params));
+        } catch (Throwable t) {
+            return null; // a seed is a bonus; never let it cost the report
         }
     }
 

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/Report.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/Report.java
@@ -18,5 +18,18 @@ public record Report(
         Story story,
         String envLine,
         int occurrences,
-        long firstSeenMillis
-) {}
+        long firstSeenMillis,
+        ReproSeed repro
+) {
+    /**
+     * Without a seed — the ordinary case. Only a throw site instrumented by
+     * {@code stacktale-agent}, with {@code repro} switched on, produces one.
+     */
+    public Report(String id, long epochMillis, String threadName, DistilledStack stack,
+                  String messagePattern, Object[] args, String loggerName,
+                  Map<String, String> mdc, Map<String, String> fields, List<String> captured,
+                  Story story, String envLine, int occurrences, long firstSeenMillis) {
+        this(id, epochMillis, threadName, stack, messagePattern, args, loggerName, mdc, fields,
+                captured, story, envLine, occurrences, firstSeenMillis, null);
+    }
+}

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportPipeline.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportPipeline.java
@@ -39,6 +39,7 @@ public final class ReportPipeline {
             boolean truncateOnStart,
             boolean reportErrorsWithoutThrowable,
             boolean captureExceptionFields,
+            boolean repro,
             boolean redactionEnabled,
             List<Pattern> redactPatterns,
             boolean redactionCorrelation,
@@ -101,6 +102,12 @@ public final class ReportPipeline {
             private boolean truncateOnStart = false;
             private boolean reportErrorsWithoutThrowable = true;
             private boolean captureExceptionFields = true;
+        /**
+         * Off by default, and it should stay that way for most projects. The repro seed is the
+         * only section that renders argument values against a named signature, which is a
+         * bigger privacy surface than the rest of a report put together.
+         */
+        private boolean repro = false;
             private boolean redactionEnabled = true;
             private List<Pattern> redactPatterns = List.of();
             private boolean redactionCorrelation = false;
@@ -131,6 +138,7 @@ public final class ReportPipeline {
             public Builder truncateOnStart(boolean v) { this.truncateOnStart = v; return this; }
             public Builder reportErrorsWithoutThrowable(boolean v) { this.reportErrorsWithoutThrowable = v; return this; }
             public Builder captureExceptionFields(boolean v) { this.captureExceptionFields = v; return this; }
+        public Builder repro(boolean v) { this.repro = v; return this; }
             public Builder redactionEnabled(boolean v) { this.redactionEnabled = v; return this; }
             public Builder redactPatterns(List<Pattern> v) { this.redactPatterns = v; return this; }
             public Builder redactionCorrelation(boolean v) { this.redactionCorrelation = v; return this; }
@@ -145,7 +153,7 @@ public final class ReportPipeline {
             public Settings build() {
                 return new Settings(file, appName,appVersion,appPackages, storySize, storyWindowMillis, dedupWindowMillis,
                         maxFileBytes, maxBackups, truncateOnStart, reportErrorsWithoutThrowable,
-                        captureExceptionFields, redactionEnabled, redactPatterns, redactionCorrelation,
+                        captureExceptionFields, repro, redactionEnabled, redactPatterns, redactionCorrelation,
                         correlationMdcKeys, zone,
                         echoSuppressionMillis, containerLoggers, emitReportsToLogger, maxReportsPerMinute,
                         jsonFormat);
@@ -323,7 +331,11 @@ public final class ReportPipeline {
                                 stack, event.messagePattern(), event.args(), event.loggerName(),
                                 event.mdc(), fields, AgentCaptures.forChain(throwable),
                                 storyBuffer.storyFor(event), env.envLine(),
-                                decision.totalOccurrences(), decision.firstSeenMillis());
+                                decision.totalOccurrences(), decision.firstSeenMillis(),
+                                // resolved only when asked for: the seed costs a reflective
+                                // call and carries argument values, so an app that has not
+                                // opted in never materialises one
+                                settings.repro() ? AgentCaptures.seedFor(throwable) : null);
                         rendered = renderer.render(report);
                         writer.append(rendered);
                     } catch (Throwable t) {

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportRenderer.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportRenderer.java
@@ -94,6 +94,8 @@ final class ReportRenderer implements Renderer {
             for (String line : r.captured()) sb.append("  ").append(clean(line)).append('\n');
         }
 
+        renderRepro(sb, r);
+
         // recurrence: only shown when the error is not brand new — "is this systemic or a
         // one-off?" changes the reader's urgency, and the answer was previously invisible
         // inside a fresh report (a window had expired since the last one)
@@ -131,6 +133,7 @@ final class ReportRenderer implements Renderer {
                 # Each report is delimited by "━━━ ERROR #<id> ━━━" ... "━━━ END #<id> ━━━".
                 # Sections: headline (root cause first), at (culprit frame), log, mdc,
                 # fields (state carried by the exception's own getters/fields),
+                # repro (opt-in: the throw site's typed signature and argument values),
                 # story (events leading up to and including the error, oldest first),
                 # stack (distilled; framework frames collapsed), env. "← YOUR CODE" marks app frames.
                 # Repeated errors append "━ #<id> repeated N× ━" lines instead of new reports.
@@ -148,6 +151,47 @@ final class ReportRenderer implements Renderer {
     @Override
     public String stormLine(int suppressed, int limit) {
         return "━ storm: " + suppressed + " report(s) suppressed (rate limit " + limit + "/min) ━\n";
+    }
+
+    /**
+     * The reproduction seed: the call that threw, typed, with the values it was given.
+     *
+     * <p>Off unless {@code repro} is switched on, because this is the only section that
+     * renders argument <em>values</em> against a named signature — a bigger privacy surface
+     * than anything else in a report, and the reason it is not a default. Values still go
+     * through redaction on the way out, like every other rendered value.
+     *
+     * <p>Rendered so an agent can write the test from it rather than run it unmodified. The
+     * declared types are what make the signature reconstructable; the values are the inputs;
+     * the {@code throws} line is the assertion.
+     */
+    private void renderRepro(StringBuilder sb, Report r) {
+        ReproSeed seed = r.repro();
+        if (seed == null) return;
+
+        sb.append("repro (throw site, via stacktale-agent):\n");
+        sb.append("  ").append(clean(seed.className())).append('#').append(clean(seed.methodName()))
+                .append('(');
+        for (int i = 0; i < seed.params().size(); i++) {
+            ReproSeed.Param p = seed.params().get(i);
+            if (i > 0) sb.append(", ");
+            sb.append(clean(p.type())).append(' ').append(clean(p.name()));
+        }
+        sb.append(")\n");
+        for (ReproSeed.Param p : seed.params()) {
+            // name and value cleaned as one string, for the same reason mdc: and fields: are:
+            // name-based redaction keys off "password=…", and a value cleaned in isolation has
+            // no name in front of it for the rule to match
+            sb.append("    ").append(clean(p.name() + " = " + p.value())).append('\n');
+        }
+        // the expected outcome, so the seed carries its own assertion rather than making the
+        // reader scroll back to the headline
+        if (r.stack() != null && r.stack().rootType() != null) {
+            sb.append("  throws ").append(clean(r.stack().rootType()));
+            String message = r.stack().rootMessage();
+            if (message != null && !message.isBlank()) sb.append(": ").append(clean(message));
+            sb.append('\n');
+        }
     }
 
     private void renderStory(StringBuilder sb, Report r) {

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReproSeed.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReproSeed.java
@@ -1,0 +1,42 @@
+package io.github.gabrielbbaldez.stacktale;
+
+import java.util.List;
+
+/**
+ * What a test needs to recreate one failure: the call that threw, with declared parameter
+ * types and the values it was given.
+ *
+ * <p>The point is the <em>signature</em>. TDD-Bench-Java measured agents writing reproduction
+ * tests at ~44% on public benchmarks and 4% on proprietary code with no hints — rising to 20%
+ * once given concrete class names and method signatures. stacktale is holding exactly that at
+ * the moment of failure, and until now rendered it as prose: {@code charge(orderId=889)} names
+ * neither the class it lives on nor the type of 889.
+ *
+ * <p>Only the innermost captured frame becomes a seed. Captures are appended as the throwable
+ * unwinds, so the first one is the closest to the throw — the culprit, and the call worth
+ * reconstructing. The frames above it are context the {@code captured:} section already shows.
+ *
+ * @param className fully qualified, because a test has to import it
+ * @param methodName the method that threw
+ * @param params declared type, name and value per argument, in declaration order
+ */
+public record ReproSeed(String className, String methodName, List<Param> params) {
+
+    /**
+     * One argument at the throw site.
+     *
+     * @param type the declared parameter type, or the runtime class when the method could not
+     *             be resolved unambiguously — an overload of the same arity is left unresolved
+     *             rather than guessed, since a wrong type is worse than none
+     * @param name the parameter name when compiled with {@code -parameters}, else {@code argN}
+     * @param value already truncated and privacy-filtered by the agent; redacted again by the
+     *              core before it reaches a report
+     */
+    public record Param(String type, String name, String value) {}
+
+    /** The simple class name, for a rendering that has already stated the package. */
+    public String simpleClassName() {
+        int dot = className.lastIndexOf('.');
+        return dot < 0 ? className : className.substring(dot + 1);
+    }
+}

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportRendererTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportRendererTest.java
@@ -116,4 +116,38 @@ class ReportRendererTest {
         String h = new ReportRenderer(ZoneOffset.UTC).fileHeader();
         assertThat(h).contains("format st/1").contains("━━━ ERROR #").contains("END #");
     }
+
+    @Test
+    void reproSeedMatchesGolden() throws Exception {
+        IllegalStateException boom = new IllegalStateException("payment gateway refused");
+        boom.setStackTrace(new StackTraceElement[]{
+                new StackTraceElement("com.acme.shop.PaymentService", "charge", "PaymentService.java", 118),
+        });
+        DistilledStack stack = new StackDistiller(List.of("com.acme")).distill(boom);
+        Story story = new Story(List.of(
+                new StoryEntry(1_000_412L, "ERROR", "PaymentService", "charge failed for order 889")
+        ), "traceId=7c2e");
+        ReproSeed seed = new ReproSeed("com.acme.shop.PaymentService", "charge", List.of(
+                new ReproSeed.Param("long", "orderId", "889"),
+                new ReproSeed.Param("java.math.BigDecimal", "amount", "149.90")));
+
+        Report r = new Report("5eed0001", 1_000_412L, "http-nio-8080-exec-2", stack,
+                "charge failed for order {}", new Object[]{889}, "com.acme.shop.PaymentService",
+                Map.of("traceId", "7c2e"), Map.of(),
+                java.util.List.of("PaymentService.charge(orderId=889, amount=149.90)"),
+                story, "app=shop 2.1.0 | java 21 | linux", 1, 0L, seed);
+
+        assertThat(new ReportRenderer(ZoneOffset.UTC).render(r)).isEqualTo(golden("repro-report.txt"));
+    }
+
+    @Test
+    void withoutASeedTheReproSectionIsAbsentEntirely() throws Exception {
+        Report r = new Report("cafe", 2_000_000L, "main", null,
+                "boom", null, "com.acme.Svc", Map.of(), Map.of(), java.util.List.of(),
+                new Story(List.of(), "thread main"), "app=? | java 21 | linux", 1, 0L);
+
+        // the default. A section that is off must leave no trace — not an empty header, which
+        // a parser would have to learn to skip.
+        assertThat(new ReportRenderer(ZoneOffset.UTC).render(r)).doesNotContain("repro");
+    }
 }

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReproSeedWireTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReproSeedWireTest.java
@@ -1,0 +1,96 @@
+package io.github.gabrielbbaldez.stacktale;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The core half of the agent wire format (#135).
+ *
+ * <p>The emitter is in {@code stacktale-agent} and the parser is here, in two artifacts a user
+ * can pin to different versions. Nothing else compares them, so these assertions are written
+ * against literal lines rather than against anything the agent produces — a drift on either
+ * side has to fail one of the two suites.
+ */
+class ReproSeedWireTest {
+
+    private static final List<String> ONE_FRAME = List.of(
+            "m com.acme.shop.PaymentService charge",
+            "p long orderId 889",
+            "p java.math.BigDecimal amount 149.90");
+
+    @Test
+    void parsesTheFullyQualifiedCallWithDeclaredTypes() {
+        ReproSeed seed = AgentCaptures.parseSeed(ONE_FRAME);
+
+        assertThat(seed).isNotNull();
+        assertThat(seed.className()).isEqualTo("com.acme.shop.PaymentService");
+        assertThat(seed.simpleClassName()).isEqualTo("PaymentService");
+        assertThat(seed.methodName()).isEqualTo("charge");
+        assertThat(seed.params()).extracting(ReproSeed.Param::type)
+                .containsExactly("long", "java.math.BigDecimal");
+        assertThat(seed.params()).extracting(ReproSeed.Param::name)
+                .containsExactly("orderId", "amount");
+    }
+
+    @Test
+    void onlyTheInnermostFrameBecomesTheSeed() {
+        // Captures are appended as the throwable unwinds, so the first frame is the closest to
+        // the throw. A seed naming the outer caller would describe a call that did not fail.
+        ReproSeed seed = AgentCaptures.parseSeed(List.of(
+                "m com.acme.shop.PaymentService charge",
+                "p long orderId 889",
+                "m com.acme.shop.OrderService confirm",
+                "p long id 42"));
+
+        assertThat(seed.methodName()).isEqualTo("charge");
+        assertThat(seed.params()).extracting(ReproSeed.Param::name).containsExactly("orderId");
+    }
+
+    @Test
+    void aValueContainingSpacesSurvives() {
+        // The value takes the remainder of the line for exactly this reason: exception
+        // messages and toString() output routinely contain spaces, types and names never do.
+        ReproSeed seed = AgentCaptures.parseSeed(List.of(
+                "m com.acme.Svc handle",
+                "p java.lang.String note some text with spaces"));
+
+        assertThat(seed.params().get(0).value()).isEqualTo("some text with spaces");
+    }
+
+    @Test
+    void aTruncatedOrForeignLineIsIgnoredRatherThanGuessed() {
+        assertThat(AgentCaptures.parseSeed(List.of("m com.acme.Svc"))).isNull();
+        assertThat(AgentCaptures.parseSeed(List.of("something else entirely"))).isNull();
+        assertThat(AgentCaptures.parseSeed(List.of())).isNull();
+        assertThat(AgentCaptures.parseSeed(null)).isNull();
+
+        // a malformed parameter drops that parameter, not the whole seed: a signature with one
+        // argument missing still names the method, which is most of the value
+        ReproSeed partial = AgentCaptures.parseSeed(List.of(
+                "m com.acme.Svc handle", "p broken", "p int ok 1"));
+        assertThat(partial.params()).extracting(ReproSeed.Param::name).containsExactly("ok");
+    }
+
+    @Test
+    void argumentValuesGoThroughRedaction() {
+        // The seed is the only section that renders values against a named signature. If
+        // redaction did not reach here it would be the easiest place in the report to leak.
+        ReproSeed seed = AgentCaptures.parseSeed(List.of(
+                "m com.acme.Auth login",
+                "p java.lang.String password hunter2",
+                "p java.lang.String email someone@example.com"));
+        Report r = new Report("dead", 1_000L, "main", null, "login failed", null, "com.acme.Auth",
+                java.util.Map.of(), java.util.Map.of(), List.of(),
+                new Story(List.of(), "thread main"), "app=? | java 21 | linux", 1, 0L, seed);
+
+        String rendered = new ReportRenderer(java.time.ZoneOffset.UTC).render(r);
+
+        assertThat(rendered).contains("com.acme.Auth#login");
+        assertThat(rendered).doesNotContain("hunter2");
+        assertThat(rendered).doesNotContain("someone@example.com");
+        assertThat(rendered).contains("███");
+    }
+}

--- a/stacktale-core/src/test/resources/golden/repro-report.txt
+++ b/stacktale-core/src/test/resources/golden/repro-report.txt
@@ -1,0 +1,21 @@
+━━━ ERROR #5eed0001 ━━━ 1970-01-01 00:16:40.412 thread=http-nio-8080-exec-2 ━━━
+IllegalStateException: payment gateway refused
+at PaymentService.charge(PaymentService.java:118) ← YOUR CODE
+log: "charge failed for order {}" args=[889] logger=c.a.s.PaymentService
+mdc: traceId=7c2e
+captured (method args at throw site, via stacktale-agent):
+  PaymentService.charge(orderId=889, amount=149.90)
+repro (throw site, via stacktale-agent):
+  com.acme.shop.PaymentService#charge(long orderId, java.math.BigDecimal amount)
+    orderId = 889
+    amount = 149.90
+  throws IllegalStateException: payment gateway refused
+
+story (traceId=7c2e, last 1 event, 0ms):
+  00:16:40.412 ERROR PaymentService  charge failed for order 889   ← this error
+
+stack (distilled, 1 of 1 frames):
+  PaymentService.charge(PaymentService.java:118) ← culprit
+
+env: app=shop 2.1.0 | java 21 | linux
+━━━ END #5eed0001 ━━━

--- a/stacktale-jul/src/main/java/io/github/gabrielbbaldez/stacktale/jul/StacktaleJulHandler.java
+++ b/stacktale-jul/src/main/java/io/github/gabrielbbaldez/stacktale/jul/StacktaleJulHandler.java
@@ -198,6 +198,9 @@ public final class StacktaleJulHandler extends Handler {
         Boolean captureFields = boolProp(m, p + "captureExceptionFields");
         if (captureFields != null) b.captureExceptionFields(captureFields);
 
+        Boolean repro = boolProp(m, p + "repro");
+        if (repro != null) b.repro(repro);
+
         Boolean truncate = boolProp(m, p + "truncateOnStart");
         if (truncate != null) b.truncateOnStart(truncate);
 

--- a/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
+++ b/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
@@ -162,6 +162,7 @@ public final class StacktaleAppender extends AbstractAppender {
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private boolean installUncaughtHandler = true;
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private boolean reportErrorsWithoutThrowable = true;
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private boolean captureExceptionFields = true;
+        @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private boolean repro = false;
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private boolean redactionEnabled = true;
         /** Extra redaction regexes, separated by {@code ;;} (regexes may contain commas). */
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private String redactPatterns = "";
@@ -217,6 +218,7 @@ public final class StacktaleAppender extends AbstractAppender {
                     .truncateOnStart(truncateOnStart)
                     .reportErrorsWithoutThrowable(reportErrorsWithoutThrowable)
                     .captureExceptionFields(captureExceptionFields)
+                    .repro(repro)
                     .redactionEnabled(redactionEnabled)
                     .redactPatterns(compiled)
                     .redactionCorrelation(redactionCorrelation)

--- a/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
+++ b/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
@@ -44,6 +44,7 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
     private boolean installUncaughtHandler = true;
     private boolean reportErrorsWithoutThrowable = true;
     private boolean captureExceptionFields = true;
+    private boolean repro = false;
     private boolean redactionEnabled = true;
     private final List<String> redactPatterns = new java.util.ArrayList<>();
     private boolean redactionCorrelation = false;
@@ -101,6 +102,7 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
                 .truncateOnStart(truncateOnStart)
                 .reportErrorsWithoutThrowable(reportErrorsWithoutThrowable)
                 .captureExceptionFields(captureExceptionFields)
+                .repro(repro)
                 .redactionEnabled(redactionEnabled)
                 .redactPatterns(compiled)
                 .redactionCorrelation(redactionCorrelation)


### PR DESCRIPTION
Refs #135 — the report half. The MCP tool `repro_for(id)` the issue also describes is **not** in this change.

## What it does

```
repro (throw site, via stacktale-agent):
  com.acme.shop.PaymentService#charge(long orderId, java.math.BigDecimal amount)
    orderId = 889
    amount = 149.90
  throws IllegalStateException: payment gateway refused
```

Fully-qualified so a test can import it. **Declared** types so the signature is reconstructable. Values as the inputs. The throwable as the assertion.

The gap this closes is narrow and specific: `captured:` already renders `charge(orderId=889)`, which names neither the class the method lives on nor the type of 889. TDD-Bench-Java is the number in the issue — ~44% on public benchmarks, **4% on proprietary code with no hints, 20% once given concrete class names and method signatures**. The signature was the missing ingredient, and it was already in the process.

**Off by default**, on all three adapters via `repro=true`. It is the only section that renders argument values against a named signature, which is a larger privacy surface than the rest of a report together.

## How it is put together

**The types cost nothing new.** The agent already resolved each instrumented method reflectively to get parameter *names*; the same `Method` carries the declared types. An overload of the same arity stays unresolved and falls back to the runtime class — a wrong declared type is worse than an approximate one.

**`captured:` is unchanged.** `CaptureRegistry` now stores frames structured and renders per reader rather than pre-rendering one string. Asserted from both sides: the core golden files, and a new agent-side test pinning the compact line exactly.

**The bridge is a second entry point, not a wider one.** `repro` is resolved separately from `get`, so an agent jar older than the core loses the seed and keeps its captures rather than losing both to one failed lookup. The two artifacts release together but a user can pin them apart.

**Only the innermost frame becomes a seed.** Captures are appended as the throwable unwinds, so the first is closest to the throw. A seed naming the outer caller would describe a call that did not fail.

## Two things worth recording

**Redaction had to be applied to `name = value` as one string, not to each.** Name-based redaction keys off `password=…`; a value cleaned in isolation has no name in front of it for the rule to fire. This is the mistake `ReportRenderer` already warns about two sections above, and I made it anyway — the test that caught it asserts `hunter2` never reaches the report:

```
argumentValuesGoThroughRedaction   FAILED  →  fixed  →  passes
```

**The wire format is asserted from both ends, against literal lines.** The emitter is in `stacktale-agent` and the parser in `stacktale-core`; nothing at build time compares them. A drift on either side now has to break one of the two suites.

## Verified

`mvn verify` green across all 8 modules, coverage 81.0%. New tests:

| | |
|---|---|
| `repro-report.txt` | golden, pinning the rendering |
| `withoutASeedTheReproSectionIsAbsentEntirely` | the default leaves no trace — not an empty header a parser must learn to skip |
| `ReproSeedWireTest` (5) | parsing, innermost-frame rule, values with spaces, malformed input, redaction |
| `ReproWireFormatTest` (4) | the agent's emission, and that `captured:` did not move |

Additive per FORMAT.md §6, so `st/1` stands — a conforming parser skips the section. Grammar block, prose section and the self-describing file header all updated.
