### PR TITLE
infra: add CodeQL and dependency-review workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly, so a newly published query finds existing code rather than waiting
+    # for someone to touch the file it applies to. Offset from compat.yml's 06:00.
+    - cron: "0 5 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Java
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # The upload at the end of `analyze` goes through the code-scanning API.
+      # Without this the scan itself succeeds and only the upload fails, which
+      # reads as a flaky job rather than a missing permission.
+      security-events: write
+      # Read-only, and only so CodeQL can look up the workflow run it belongs to.
+      actions: read
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: java-kotlin
+          build-mode: manual
+
+      # `autobuild` would run the full reactor, tests included, duplicating what
+      # CI already does on every PR. The analysis only needs class files, so this
+      # compiles and stops. It must sit between init and analyze: manual mode
+      # traces this build, and an empty trace analyses nothing while still
+      # reporting success.
+      - name: Build classes for analysis
+        run: mvn -B -DskipTests compile
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:java-kotlin"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+name: Dependency review
+
+# Pull requests only: the action diffs the dependency graph of the base against
+# the head, so it has nothing to compare on a push to main.
+on: pull_request
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    name: Review dependency changes
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/dependency-review-action@v5
+        with:
+          # Block a bump that introduces a known vulnerability at this severity or
+          # above. Left at `moderate` rather than `low` so the many dependabot PRs
+          # this repo takes do not stall on advisories against code paths the
+          # library never reaches; anything below still appears in the PR summary.
+          fail-on-severity: moderate
+          # No `comment-summary-in-pr`: that needs `pull-requests: write`, and a PR
+          # from a fork gets a read-only token, so it would fail on exactly the
+          # contributions this repo most wants to check. The findings are in the
+          # job summary either way.


### PR DESCRIPTION
Closes #156.

Two small workflows, as the issue describes.

## CodeQL (`.github/workflows/codeql.yml`)

Runs on push to `main`, on PRs, and weekly. The weekly run is the one that matters for a library this size — without it, a newly published query only reaches code somebody happens to touch. Scheduled at 05:00 Monday, an hour ahead of `compat.yml` so the two don't land together.

**Build mode is `manual`, not `autobuild`.** Autobuild runs the full reactor including tests, duplicating what CI already does on every PR; the analysis only needs class files, so the step is `mvn -B -DskipTests compile`. It has to sit between `init` and `analyze` — manual mode analyses whatever that build traces, and an empty trace reports success having examined nothing, which is the quiet failure mode worth avoiding here.

`security-events: write` is declared on the job, as the issue notes is now possible. Without it the scan completes and only the upload fails, which reads as flakiness rather than a missing permission.

## Dependency review (`.github/workflows/dependency-review.yml`)

`pull_request` only — the action diffs the base's dependency graph against the head's, so a push to `main` gives it nothing to compare.

Two judgement calls, both written into the file:

- **`fail-on-severity: moderate`**, not `low`. Given how many dependabot PRs this repo takes, `low` would hold them up on advisories against code paths the library never reaches. Lower findings still appear in the job summary.
- **`comment-summary-in-pr` deliberately unset.** It needs `pull-requests: write`, and a PR from a fork gets a read-only token — so it would fail on exactly the external contributions this check is most useful for. The findings are in the job summary either way.

## Verification

Both files parse as YAML. Action majors are current as of today — `codeql-action@v4`, `dependency-review-action@v5`, `checkout@v7`, `setup-java@v5` — matching the pins already used across the other workflows, and `java-version: 21` / `distribution: temurin` / `cache: maven` follow `ci.yml`.

I could not run `mvn` locally (not installed on this machine), so the compile step is unexercised here; it is the same reactor `ci.yml` already builds with `mvn -B verify`. The real check is the issue's own: the Security tab showing a completed scan, and a CVE-bearing bump getting blocked — both of which need this merged to `main` first.

## Scope

Not #40 — that is SBOM and build provenance, about proving what the artifact *is*. This is finding problems in the source before it ships. Adjacent, not overlapping.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)