### PR TITLE
infra: fail when the examples stop pinning the current release

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -9,6 +9,15 @@ on:
     paths:
       - "examples/**"
       - ".github/workflows/examples.yml"
+  schedule:
+    # The drift this catches is caused by a *release*, not by a commit under
+    # examples/, so the path filters above would never fire for it. Weekly,
+    # Monday 07:00 UTC — after compat.yml (06:00) and codeql.yml (05:00).
+    - cron: "0 7 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   build-examples:
@@ -34,3 +43,58 @@ jobs:
       - name: Compile example
         working-directory: ${{ matrix.example }}
         run: mvn -B -q compile
+
+  version-drift:
+    name: Examples pin the current release
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: maven
+
+      - name: Compare pinned version against the latest release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          latest=$(gh api repos/${{ github.repository }}/releases/latest --jq .tag_name)
+          latest=${latest#v}
+          echo "Latest release: $latest"
+
+          failed=0
+          for example in examples/plain-java-jul examples/spring-boot-mvc examples/spring-boot-webflux; do
+            # Ask Maven rather than grepping: the version reaches the dependency
+            # through a property, so the literal is in one place per project and a
+            # grep would have to know which.
+            pinned=$(mvn -q -f "$example/pom.xml" help:evaluate \
+              -Dexpression=stacktale.version -DforceStdout)
+
+            if [ "$pinned" = "$latest" ]; then
+              echo "ok       $example pins $pinned"
+              continue
+            fi
+
+            # Which side of the release it sits on decides whether this is a
+            # problem. `sort -V` puts the older version first.
+            older=$(printf '%s\n%s\n' "$pinned" "$latest" | sort -V | head -n1)
+
+            if [ "$older" = "$pinned" ]; then
+              echo "::error file=$example/pom.xml::$example pins stacktale $pinned but the latest release is $latest"
+              failed=1
+            else
+              # Between a version bump on main and the tag being pushed, the
+              # examples legitimately point at a version that is ahead of the
+              # newest release. Failing here would make the release process fight
+              # this check, so it warns and moves on.
+              echo "::warning file=$example/pom.xml::$example pins stacktale $pinned, ahead of the latest release $latest — expected between a version bump and its tag"
+            fi
+          done
+
+          exit $failed

--- a/examples/plain-java-jul/pom.xml
+++ b/examples/plain-java-jul/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <stacktale.version>1.1.0</stacktale.version>
+        <stacktale.version>1.2.0</stacktale.version>
     </properties>
 
     <dependencies>

--- a/examples/spring-boot-mvc/pom.xml
+++ b/examples/spring-boot-mvc/pom.xml
@@ -19,6 +19,7 @@
 
     <properties>
         <java.version>17</java.version>
+        <stacktale.version>1.2.0</stacktale.version>
     </properties>
 
     <dependencies>
@@ -29,7 +30,7 @@
         <dependency>
             <groupId>io.github.gabrielbbaldez</groupId>
             <artifactId>stacktale-spring-boot-starter</artifactId>
-            <version>1.1.0</version>
+            <version>${stacktale.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/examples/spring-boot-webflux/pom.xml
+++ b/examples/spring-boot-webflux/pom.xml
@@ -19,6 +19,7 @@
 
     <properties>
         <java.version>17</java.version>
+        <stacktale.version>1.2.0</stacktale.version>
     </properties>
 
     <dependencies>
@@ -29,7 +30,7 @@
         <dependency>
             <groupId>io.github.gabrielbbaldez</groupId>
             <artifactId>stacktale-spring-boot-starter</artifactId>
-            <version>1.1.0</version>
+            <version>${stacktale.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Closes #161.

## The drift has already happened

Before adding any check: **the latest release is `v1.2.0`, and all three examples pinned `1.1.0`.** They have been demonstrating a version one minor behind. Bumped to `1.2.0`, with `stacktale-jul` and `stacktale-spring-boot-starter` both confirmed present on Maven Central at that version (HTTP 200 on the `.pom`).

Without this, the new check would land red on merge — which is the check working, but not a useful first impression.

## Normalising the pins

The two inline pins move to the same `stacktale.version` property `plain-java-jul` already used. That is what lets the check ask Maven for one expression instead of knowing which of two shapes each project uses, and it puts the literal in one place per project — worth doing on its own, as the issue notes.

## The two judgement calls

**Where the failure lands.** A new `version-drift` job in `examples.yml`, triggered `schedule` *as well as* the existing paths. The cause of this drift is a **release**, not a commit under `examples/` — so the existing path filters would never fire for it, and the check would sit silent until someone happened to touch an example. That is precisely the failure mode the issue describes. Weekly at 07:00 Monday, after `compat.yml` (06:00) and `codeql.yml` (05:00).

It does **not** open an issue. That needs `issues: write` plus dedupe logic to avoid filing the same one every week — more machinery than the signal warrants, when a red scheduled run is already visible in Actions. Happy to switch to the #132 approach if you'd rather they be consistent.

**A release that has not happened yet.** Compared with `sort -V`, treating the two sides differently:

| pinned vs latest | outcome | why |
|---|---|---|
| equal | pass | |
| **older** | **fail** | this is the bug |
| newer | warn | between a version bump on `main` and the tag being pushed, the examples legitimately point ahead — failing here would make the release process fight this check |

## Verification

Dry-run against the live repository (`latest = v1.2.0`):

```
  1.1.0 vs 1.2.0 -> FAIL (behind)
  1.0.0 vs 1.2.0 -> FAIL (behind)
  9.9.9 vs 1.2.0 -> warn (ahead)
```

The workflow parses as YAML and both jobs are present.

**Not tested:** Maven is not installed in my environment, so the `help:evaluate` step itself is unexercised — CI is the first real run of it. The issue's own verification (bump a pin below the latest and watch it object, then put it back) needs this on `main` first.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)