### PR TITLE
fix(core): roll back the dedup decision when a storm line fails to write

### DIFF
--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportPipeline.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportPipeline.java
@@ -6,6 +6,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongSupplier;
 import java.util.regex.Pattern;
 
 /**
@@ -218,6 +219,11 @@ public final class ReportPipeline {
             };
 
     private ReportPipeline(Settings settings, Host host, ReportWriter writer, Renderer renderer) {
+        this(settings, host, writer, renderer, System::currentTimeMillis);
+    }
+
+    private ReportPipeline(Settings settings, Host host, ReportWriter writer, Renderer renderer,
+                           LongSupplier clock) {
         this.settings = settings;
         this.host = host;
         this.renderer = renderer;
@@ -225,9 +231,9 @@ public final class ReportPipeline {
         this.storyBuffer = new StoryBuffer(settings.storySize(), settings.storyWindowMillis(),
                 settings.correlationMdcKeys(), 200);
         this.distiller = new StackDistiller(settings.appPackages());
-        this.deduper = new Deduper(settings.dedupWindowMillis(), 60_000, System::currentTimeMillis);
+        this.deduper = new Deduper(settings.dedupWindowMillis(), 60_000, clock);
         this.stormLimiter = settings.maxReportsPerMinute() > 0
-                ? new StormLimiter(settings.maxReportsPerMinute(), 60_000, 10_000, System::currentTimeMillis)
+                ? new StormLimiter(settings.maxReportsPerMinute(), 60_000, 10_000, clock)
                 : StormLimiter.disabled();
         this.env = new EnvCollector(Thread.currentThread().getContextClassLoader(),
                 settings.appName(),
@@ -252,6 +258,24 @@ public final class ReportPipeline {
             writer = null;
         }
         return new ReportPipeline(settings, host, writer, renderer);
+    }
+
+    /**
+     * Test seam: a pipeline over a caller-supplied writer and renderer.
+     *
+     * <p>The rollback/confirm protocol's interesting branches are the ones where a write
+     * fails, and {@link #create} cannot produce a pipeline that is both active and unable to
+     * write — {@code ReportWriter}'s constructor probes the destination and a failed probe
+     * turns into {@code isActive() == false}. Injecting the collaborators is the only way to
+     * reach those branches from a unit test.
+     *
+     * <p>{@code clock} drives the {@link Deduper} and {@link StormLimiter} windows, which are
+     * minutes long — the same injection {@code DeduperTest} and {@code StormLimiterTest}
+     * already use, so a test can cross a window without sleeping through it.
+     */
+    static ReportPipeline forTesting(Settings settings, Host host, ReportWriter writer, Renderer renderer,
+                                     LongSupplier clock) {
+        return new ReportPipeline(settings, host, writer, renderer, clock);
     }
 
     /** False when configuration was broken at creation time and the pipeline is a no-op. */
@@ -317,9 +341,18 @@ public final class ReportPipeline {
                         return;
                     }
                     if (storm.action() == StormLimiter.Action.STORM_LINE) {
-                        writer.append(renderer.stormLine(storm.suppressed(), stormLimiter.maxPerWindow()));
-                        stormLimiter.confirmStormLine(storm.suppressed()); // #57: clear only once written
-                        deduper.rollback(fingerprint); // #51: this error's own report wasn't written
+                        try {
+                            writer.append(renderer.stormLine(storm.suppressed(), stormLimiter.maxPerWindow()));
+                            stormLimiter.confirmStormLine(storm.suppressed()); // #57: clear only once written
+                        } finally {
+                            // #51: this error's own report was never written — and that is true
+                            // whether or not the storm line itself made it. The rollback used to
+                            // sit after the append, so a failure here skipped it and left
+                            // reportPending=true; Deduper.decide then answers SILENT for this
+                            // fingerprint until the dedup window rolls over, i.e. the error stops
+                            // being reported for ~5 minutes. Unwind the decision either way.
+                            deduper.rollback(fingerprint);
+                        }
                         return;
                     }
                     String rendered;

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportPipelineTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportPipelineTest.java
@@ -1,0 +1,301 @@
+package io.github.gabrielbbaldez.stacktale;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The rollback/confirm protocol from #51/#57, driven directly rather than through a logging
+ * backend.
+ *
+ * <p>Why this class exists (#126): the protocol's failure mode is *silence*. When a report is
+ * decided but never written, {@link Deduper} must be told to unwind the decision — otherwise
+ * {@code reportPending} stays true and {@code decide()} answers {@code SILENT} for that
+ * fingerprint until the dedup window rolls over. An error simply stops being reported for
+ * minutes, and nothing goes red. Every test here asserts on what reached the file, because
+ * that is the only thing a user of stacktale can observe.
+ */
+class ReportPipelineTest {
+
+    /**
+     * Renderer that can be armed to fail on the next {@code stormLine}, standing in for a
+     * write that does not reach the file. The pipeline treats a throw from the render and a
+     * throw from the append identically — both leave {@code storm.action() == STORM_LINE}
+     * without the line on disk — and this is the one that needs no unwritable filesystem.
+     */
+    private static final class BreakableRenderer implements Renderer {
+        private final Renderer delegate;
+        private boolean failStormLine;
+
+        BreakableRenderer(Renderer delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public String render(Report report) {
+            return delegate.render(report);
+        }
+
+        @Override
+        public String renderSummary(String id, int count, long lastMillis) {
+            return delegate.renderSummary(id, count, lastMillis);
+        }
+
+        @Override
+        public String fileHeader() {
+            return delegate.fileHeader();
+        }
+
+        @Override
+        public String sessionMarker(long epochMillis, long pid) {
+            return delegate.sessionMarker(epochMillis, pid);
+        }
+
+        @Override
+        public String stormLine(int suppressed, int limit) {
+            if (failStormLine) {
+                failStormLine = false; // one-shot: the run after this one must be able to recover
+                throw new UncheckedIOException(new java.io.IOException("disk full"));
+            }
+            return delegate.stormLine(suppressed, limit);
+        }
+    }
+
+    /** Collects what the pipeline told its host, so a swallowed failure is still visible. */
+    private static final class RecordingHost implements ReportPipeline.Host {
+        final List<String> warnings = new ArrayList<>();
+        final List<String> selfLogs = new ArrayList<>();
+        final List<String> emitted = new ArrayList<>();
+
+        @Override
+        public void selfLog(String message) {
+            selfLogs.add(message);
+        }
+
+        @Override
+        public void warn(String message, Throwable t) {
+            warnings.add(message);
+        }
+
+        @Override
+        public void emitReport(String block) {
+            emitted.add(block);
+        }
+    }
+
+    /** A pipeline writing to {@code dir/errors-ai.log}, on a clock the test advances by hand. */
+    private record Fixture(ReportPipeline pipeline,
+                           BreakableRenderer renderer,
+                           RecordingHost host,
+                           AtomicLong clock,
+                           Path file) {
+
+        String contents() {
+            try {
+                return Files.exists(file) ? Files.readString(file) : "";
+            } catch (java.io.IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        /**
+         * Lines that *begin* with {@code prefix}.
+         *
+         * <p>Anchored to the line start on purpose: the file header documents its own
+         * delimiters, so it contains the literal strings {@code ━━━ ERROR #<id> ━━━},
+         * {@code ━ #<id> repeated N× ━} and {@code ━ storm: …} inside {@code #} comments. A
+         * plain substring search counts the documentation as an occurrence.
+         */
+        int linesStartingWith(String prefix) {
+            int n = 0;
+            for (String line : contents().split("\n", -1)) {
+                if (line.startsWith(prefix)) n++;
+            }
+            return n;
+        }
+
+        /** How many full st/1 report blocks reached the file. */
+        int reportCount() {
+            return linesStartingWith("━━━ ERROR #");
+        }
+
+        /** How many "same error repeated N×" lines reached the file. */
+        int summaryCount() {
+            return linesStartingWith("━ #");
+        }
+
+        /** How many storm (rate-limit) lines reached the file. */
+        int stormLineCount() {
+            return linesStartingWith("━ storm:");
+        }
+    }
+
+    private static Fixture fixture(Path dir, int maxReportsPerMinute) {
+        Path file = dir.resolve("errors-ai.log");
+        ReportPipeline.Settings settings = ReportPipeline.Settings.builder()
+                .file(file.toString())
+                .appName("test")
+                .appVersion("0")
+                // The container-echo guard reads System.currentTimeMillis() directly, not the
+                // injected clock; off, so it cannot swallow an event the test just fed in.
+                .echoSuppressionMillis(0)
+                .maxReportsPerMinute(maxReportsPerMinute)
+                .zone(ZoneId.of("UTC"))
+                .build();
+
+        AtomicLong clock = new AtomicLong(1_700_000_000_000L);
+        Renderer real = new ReportRenderer(settings.zone(), Redactor.disabled());
+        BreakableRenderer renderer = new BreakableRenderer(real);
+        RecordingHost host = new RecordingHost();
+        ReportWriter writer = new ReportWriter(file, settings.maxFileBytes(), real.fileHeader(),
+                null, false, settings.maxBackups(), host::warn);
+
+        return new Fixture(
+                ReportPipeline.forTesting(settings, host, writer, renderer, clock::get),
+                renderer, host, clock, file);
+    }
+
+    /** An error event whose fingerprint is stable for a given {@code marker}. */
+    private static LogEventData error(String marker, long epochMillis) {
+        Throwable t = new IllegalStateException(marker);
+        t.setStackTrace(new StackTraceElement[]{
+                new StackTraceElement("com.example." + marker, "run", marker + ".java", 42)
+        });
+        return new LogEventData(epochMillis, "ERROR", true, "com.example.Logger", "main",
+                "failed: " + marker, new Object[0], "failed: " + marker, Map.of(), t);
+    }
+
+    @Test
+    void aWrittenReportIsConfirmedAndTheRepeatBecomesASummary(@TempDir Path dir) {
+        Fixture f = fixture(dir, 0); // storm control off
+
+        f.pipeline().process(error("alpha", f.clock().get()));
+        f.pipeline().process(error("alpha", f.clock().get()));
+
+        // one report, then the second occurrence is a summary rather than a second report:
+        // confirmReport cleared reportPending, so decide() could answer SUMMARY
+        assertThat(f.reportCount()).isEqualTo(1);
+        assertThat(f.summaryCount()).isEqualTo(1);
+        assertThat(f.host().warnings).isEmpty();
+    }
+
+    @Test
+    void aStormSuppressedReportIsRolledBackSoTheWindowStillReportsIt(@TempDir Path dir) {
+        Fixture f = fixture(dir, 1);
+
+        f.pipeline().process(error("alpha", f.clock().get()));   // ALLOW -> written
+        f.pipeline().process(error("beta", f.clock().get()));    // over limit -> STORM_LINE
+        f.pipeline().process(error("gamma", f.clock().get()));   // over limit -> SUPPRESS
+
+        assertThat(f.reportCount()).isEqualTo(1);
+        assertThat(f.stormLineCount()).isEqualTo(1);
+
+        // Past the storm window, gamma is not stuck: SUPPRESS rolled its decision back, so a
+        // fresh REPORT is still available to it.
+        f.clock().addAndGet(61_000);
+        f.pipeline().process(error("gamma", f.clock().get()));
+
+        assertThat(f.reportCount()).isEqualTo(2);
+        assertThat(f.contents()).contains("IllegalStateException: gamma");
+    }
+
+    /**
+     * The gap #126 names: a storm-line write that throws used to skip both
+     * {@code confirmStormLine} and {@code rollback}, leaving the error's fingerprint pending
+     * and therefore SILENT until the dedup window rolled over.
+     */
+    @Test
+    void aFailedStormLineWriteStillLetsTheNextOccurrenceReport(@TempDir Path dir) {
+        Fixture f = fixture(dir, 1);
+
+        f.pipeline().process(error("alpha", f.clock().get())); // ALLOW -> written
+        assertThat(f.reportCount()).isEqualTo(1);
+
+        f.renderer().failStormLine = true;
+        f.pipeline().process(error("beta", f.clock().get()));  // STORM_LINE, and the write fails
+
+        // never throws out of process(), but the host is told once
+        assertThat(f.stormLineCount()).isZero();
+        assertThat(f.host().warnings).isNotEmpty();
+
+        // Past the storm window beta is allowed again. Before the fix, beta's fingerprint was
+        // still reportPending, decide() answered SILENT, and this stayed at 1 report -- the
+        // ~5-minute blind spot.
+        f.clock().addAndGet(61_000);
+        f.pipeline().process(error("beta", f.clock().get()));
+
+        assertThat(f.reportCount()).isEqualTo(2);
+        assertThat(f.contents()).contains("IllegalStateException: beta");
+    }
+
+    /** The suppressed count survives a failed storm line: #57 says clear it only once written. */
+    @Test
+    void aFailedStormLineKeepsItsSuppressedCountForTheNextLine(@TempDir Path dir) {
+        Fixture f = fixture(dir, 1);
+
+        f.pipeline().process(error("alpha", f.clock().get()));
+        f.renderer().failStormLine = true;
+        f.pipeline().process(error("beta", f.clock().get()));   // storm line lost
+
+        // Past the storm-line throttle, the next one carries both suppressions -- the lost
+        // line's and its own -- rather than having silently dropped the first.
+        f.clock().addAndGet(11_000);
+        f.pipeline().process(error("gamma", f.clock().get()));
+
+        assertThat(f.stormLineCount()).isEqualTo(1);
+        assertThat(f.contents()).contains("storm: 2 report(s) suppressed");
+    }
+
+    @Test
+    void closeDrainsThePendingSummaryCountsAndSuppressions(@TempDir Path dir) {
+        Fixture f = fixture(dir, 0);
+
+        f.pipeline().process(error("alpha", f.clock().get()));
+        f.pipeline().process(error("alpha", f.clock().get())); // count 2, written as a summary
+        f.pipeline().process(error("alpha", f.clock().get())); // count 3, throttled -> SILENT
+
+        int summariesBeforeClose = f.summaryCount();
+        f.pipeline().close();
+
+        // close() flushes the count that no summary line has reflected yet, so the last
+        // occurrences are not lost on shutdown
+        assertThat(f.summaryCount()).isGreaterThan(summariesBeforeClose);
+    }
+
+    @Test
+    void processNeverThrowsAndParksAfterRepeatedWriteFailures(@TempDir Path dir) {
+        Fixture f = fixture(dir, 0);
+        Path file = f.file();
+
+        f.pipeline().process(error("alpha", f.clock().get()));
+        assertThat(f.reportCount()).isEqualTo(1);
+
+        // Replace the report file with a directory: every subsequent append fails, and none of
+        // it may escape process() into the application.
+        String written = f.contents();
+        try {
+            Files.delete(file);
+            Files.createDirectory(file);
+        } catch (java.io.IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
+        for (int i = 0; i < 6; i++) {
+            f.pipeline().process(error("failure" + i, f.clock().get()));
+        }
+
+        assertThat(f.host().warnings).isNotEmpty();
+        assertThat(f.host().warnings.stream().anyMatch(w -> w.contains("parked"))).isTrue();
+        assertThat(written).isNotEmpty(); // the pre-failure report was real
+    }
+}


### PR DESCRIPTION
Refs #126

## The bug

The issue names a gap that's reachable today, and it is real:

```java
if (storm.action() == StormLimiter.Action.STORM_LINE) {
    writer.append(renderer.stormLine(...));   // throws
    stormLimiter.confirmStormLine(...);       // skipped
    deduper.rollback(fingerprint);            // skipped
    return;
}
```

With the rollback sitting *after* the append, a failing storm-line write skips it and leaves `reportPending = true` for that fingerprint. `Deduper.decide` then answers `SILENT` for it (`Deduper.java:66-68`) until the dedup window rolls over — **the error stops being reported for ~5 minutes on the default window, and nothing goes red.**

## The fix

Move the rollback into a `finally`:

```java
try {
    writer.append(renderer.stormLine(...));
    stormLimiter.confirmStormLine(storm.suppressed()); // #57: clear only once written
} finally {
    deduper.rollback(fingerprint);
}
```

That is the invariant #51 actually wanted. The rollback is about *this error's own* report, which was never written on this path whether or not the storm line itself made it — so it should be unconditional. `confirmStormLine` stays inside the `try`, so #57's "clear only once written" still holds. The throw still reaches the outer handler, so the never-throw guarantee and the consecutive-failure parking are unchanged.

## The tests

New `ReportPipelineTest` in `stacktale-core`, asserting on **what reached the file** — the only thing a user of stacktale can observe:

- a written report is confirmed, and the repeat becomes a summary
- a storm-suppressed report is rolled back and still reports after the window
- **a failed storm-line write still lets the next occurrence report** ← the gap
- a failed storm line keeps its suppressed count for the next line (#57)
- `close()` drains the pending summary counts
- `process()` never throws, and parks after repeated write failures

**Red-before-green, per the TDD rule in CONTRIBUTING:** with the rollback moved back after the append, `aFailedStormLineWriteStillLetsTheNextOccurrenceReport` fails (1 report on file, not 2) and the other five still pass.

One detail worth flagging for future test authors: assertions are anchored to line starts, because the file header *documents its own delimiters* — a plain `contains("━━━ ERROR #")` matches the header comment as well as a real report. I got that wrong first.

## Two seams, both package-private

- **`forTesting(...)`** — `create()` cannot build a pipeline that is both active and unable to write: `ReportWriter`'s constructor probes the destination, and a failed probe becomes `isActive() == false`. Injecting the collaborators is the only way to reach the failure branches.
- **an injectable clock**, threaded through to `Deduper` and `StormLimiter`. Their windows are minutes long. `DeduperTest` and `StormLimiterTest` already inject a clock, so this follows the existing convention rather than inventing one.

The failure is injected through a `Renderer` that throws on `stormLine`, not a subclassed `ReportWriter` — `ReportWriter` is `final`, and the pipeline can't tell the two apart: both leave `STORM_LINE` decided with nothing on disk. Say the word if you'd rather `ReportWriter` grew a seam instead.

## Verification — please read

**Maven is not installed in this environment.** I compiled and ran the suite against the JDK directly (JUnit 6.1.1 + AssertJ 3.27.7 from the local repository, against the pinned 6.1.3).

- **117 of the 122 runnable core tests pass.**
- 5 fail: `EnvCollectorTest` ×1, `ReportRendererTest` ×4. **These fail identically on an unmodified `main` in the same setup** — I built pristine `main` from `git archive` to confirm it. They need Maven's resource filtering and the pinned 6.1.3.
- `JsonReportRendererTest` couldn't be compiled at all without Jackson.

So: the new tests and every test that could run are green, and the 5 failures are artifacts of my environment, not of this change. **CI is the real check.** I also could not run PIT for the before/after mutation score the issue asks for.

## Scope

Deliberately limited to `stacktale-core`. The issue's second half — the six knobs `LogbackXmlConfigTest` omits (`echoSuppressionMillis`, `containerLogger`, `emitReportsToLogger`, `maxReportsPerMinute`, `format`, `redactionCorrelation`) — lives in the `stacktale` module and is a separate logical change per the one-change-per-PR rule. Logback isn't available here to run it against either. Marked `Refs` rather than `Closes` for that reason; happy to follow up.

## Note on process

`CONTRIBUTING.md` asks contributors to claim an issue and wait for a reply first, and I did not — apologies. Happy to close this if you'd rather it went to someone who claimed it.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)