### PR TITLE
docs: make the documented local link check match the CI gate

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,8 +56,14 @@ Add a pattern to `.lycheeignore` if a host is reachable in a browser but
 unreliable for a checker. To reproduce the PR gate locally:
 
 ```bash
-lychee --offline --include-verbatim README.md CONTRIBUTING.md 'docs/**/*.md'
+lychee --offline --no-progress --include-verbatim \
+  README.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md CHANGELOG.md \
+  'docs/**/*.md' docs/site/index.html
 ```
+
+Keep that list in step with the `internal` job in `links.yml`. A shorter one here is
+worse than no command at all: it goes green over the files it was given and says nothing
+about the ones CI is about to fail on.
 
 ## Reproducible builds
 


### PR DESCRIPTION
The `lychee` command CONTRIBUTING.md offers for reproducing the PR gate locally covered 3 of the 8 inputs the `internal` job actually checks — it left out `SECURITY.md`, `CODE_OF_CONDUCT.md`, `CHANGELOG.md` and `docs/site/index.html`.

Running it and seeing green told you nothing about whether CI would pass, which is worse than having no documented command: it looks like verification and isn't.

Also opening this to confirm the required status checks I just added to the ruleset resolve against the contexts CI really reports.