### PR TITLE
ci: check links in all markdown files

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -30,9 +30,10 @@ jobs:
             --offline
             --no-progress
             --include-verbatim
-            README.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md CHANGELOG.md
-            'docs/**/*.md'
+            '**/*.md'
             docs/site/index.html
+            --exclude-path target
+            --exclude-path node_modules
           fail: true
           jobSummary: true
 
@@ -53,9 +54,10 @@ jobs:
             --include-verbatim
             --max-retries 3
             --retry-wait-time 5
-            README.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md CHANGELOG.md
-            'docs/**/*.md'
+            '**/*.md'
             docs/site/index.html
+            --exclude-path target
+            --exclude-path node_modules
           fail: true
           jobSummary: true
         env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,8 @@ that check fails after a dependency bump, update the table in `README.md`.
 
 Markdown links are checked too, by `.github/workflows/links.yml`:
 
-- **On every PR**, `lychee --offline` verifies the *relative* links in the
-  top-level docs and `docs/`. This is the one that blocks a merge — it is
+- **On every PR**, `lychee --offline` verifies the *relative* links in every
+  Markdown file in the repository. This is the one that blocks a merge — it is
   deterministic and fails only when a commit here actually broke a path (e.g.
   moving a file that the README points at).
 - **Weekly**, a separate job checks external links as well. Third-party outages
@@ -57,8 +57,8 @@ unreliable for a checker. To reproduce the PR gate locally:
 
 ```bash
 lychee --offline --no-progress --include-verbatim \
-  README.md CONTRIBUTING.md SECURITY.md CODE_OF_CONDUCT.md CHANGELOG.md \
-  'docs/**/*.md' docs/site/index.html
+  '**/*.md' docs/site/index.html \
+  --exclude-path target --exclude-path node_modules
 ```
 
 Keep that list in step with the `internal` job in `links.yml`. A shorter one here is


### PR DESCRIPTION
## Summary
- expand the relative and external link checks to every Markdown file in the repository
- exclude generated `target` output and local `node_modules` content from both jobs

Closes #181

## Validation
- YAML parsed successfully with Ruby
- verified the repository currently contains 19 Markdown files covered by the glob
- `git diff --check`

`lychee` is not installed locally; the workflow itself will run the authoritative check.
