### PR TITLE
fix(ci): make the external link job actually run

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -50,7 +50,6 @@ jobs:
         with:
           args: >-
             --no-progress
-            --exclude-mail
             --include-verbatim
             --max-retries 3
             --retry-wait-time 5

--- a/.lycheeignore
+++ b/.lycheeignore
@@ -13,3 +13,7 @@ https://central\.sonatype\.com/.*
 
 # GitHub renders these; a checker following them gets rate-limited for no signal.
 https://github\.com/.*/labels/.*
+
+# The sample apps' own endpoints, written as curl targets in examples/*/README.md.
+# Nothing listens on them in CI and nothing should — they are instructions, not links.
+^http://localhost:\d+/


### PR DESCRIPTION
The `external` job has never run since it was added in #179. It is gated to `schedule` and `workflow_dispatch`, the first cron was still days away, and nobody had dispatched it — so it went through two of my reviews and a widening in #184 while being broken from the first commit.

I dispatched it today and it died before checking a single link:

```
error: unexpected argument '--exclude-mail' found
  tip: a similar argument exists: '--include-mail'
exit code 2
```

`--exclude-mail` was removed in lychee v2. Mail links are already excluded unless `--include-mail` is passed, so dropping the flag preserves the intent rather than changing it.

With that fixed the job ran and found two failures, both real consequences of #184 widening the glob to `**/*.md`: `examples/*/README.md` document `curl http://localhost:8081/...` against the sample apps. Those are instructions, not links, and nothing listens on them in CI. Added to `.lycheeignore`.

Verified by dispatching on this branch rather than assuming:

```
External links     🔍 102   ✅ 88   👻 14   🚫 0
Relative links     🔍 102   ✅ 31   👻 71   🚫 0
```

88 external links reachable, no rot anywhere — which is the first time that has actually been measured.

Worth noting for the next scheduled-only job: a green history means nothing when the history is empty. This one would have failed every Monday, and a failing cron only sends mail.