### PR TITLE
feat: add Quarkus extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,14 +30,21 @@ that way deliberately.
   arguments — `long` stays `long` instead of becoming `java.lang.Long`. Where the method
   can't be resolved unambiguously (overloads with the same arity), it falls back to the
   runtime class, which still names something a call can be written against. Only the
-  innermost frame becomes the seed:
-  a seed naming the outer caller would describe a call that did not fail. **Off by
-  default**, and worth leaving off for most projects — it is the only section that renders
+  innermost frame becomes the seed: a seed naming the outer caller would describe a call
+  that did not fail. **Off by default**, and worth leaving off for most projects — it is the only section that renders
   argument values against a named signature, which is a larger privacy surface than the
   rest of a report combined. Values go through the same redaction as everything else, and
   the name and value are cleaned as one string so a secret-named parameter masks its value.
   An older agent paired with a newer core loses the seed and keeps `captured:`, rather than
   failing. Additive under the FORMAT §6 rules, so `st/1` does not change version. (#135)
+- **`stacktale-quarkus`** — a Quarkus extension, so a Quarkus app gets reports by adding the
+  dependency, with no `logging.properties` to edit. Quarkus logs through the JBoss LogManager,
+  which is a `java.util.logging` implementation, so the extension reuses the `stacktale-jul`
+  handler and adds only the Quarkus wiring: a runtime/deployment split that decides the
+  configuration at build time and stays native-image friendly, `stacktale.*` keys through
+  `@ConfigMapping`, and a `@ServerRequestFilter` that opens each request's story with its HTTP
+  line — the counterpart of the Spring starter's servlet and WebFlux filters. Thanks
+  @DenizAltunkapan. (#82)
 - **Reproducible builds.** Two clean builds of the same commit now produce byte-identical
   jars, so a tag can be rebuilt and checked against what is on Maven Central. CI packages
   twice and diffs the checksums on every PR. (#178)

--- a/README.md
+++ b/README.md
@@ -433,6 +433,7 @@ One `stacktale-core`, every entry point — add only the ones your stack uses:
 | **Log4j2** | `stacktale-log4j2` |
 | **java.util.logging / `System.Logger`** | `stacktale-jul` |
 | **Spring Boot** | `stacktale-spring-boot-starter` — zero-config, auto-registered |
+| **Quarkus** | `stacktale-quarkus` — zero-config extension, build-time wiring ([module README](stacktale-quarkus/README.md)) |
 | **Failing tests** | `stacktale-junit` — a test-scoped JUnit listener; a red test becomes a report ([below](#failing-tests)) |
 
 | Where the report is consumed | |
@@ -445,7 +446,7 @@ One `stacktale-core`, every entry point — add only the ones your stack uses:
 
 Every library module is Java 17+, [JPMS](#java-modules-jpms)-ready and [GraalVM-native](docs/native.md)-ready.
 API docs are on [javadoc.io](https://javadoc.io/doc/io.github.gabrielbbaldez/stacktale-core).
-On the roadmap: idiomatic starters for **Micronaut** (#81) and **Quarkus** (#82) — both already usable today through the Logback / JUL adapters — plus a **`stacktale` CLI** (#71).
+On the roadmap: an idiomatic starter for **Micronaut** (#81) — already usable today through the Logback / JUL adapters — plus a **`stacktale` CLI** (#71).
 
 ## What gets captured
 
@@ -720,6 +721,8 @@ path as well as the classpath — a resolution smoke test in CI pins this:
 | `stacktale-spring-boot-starter` | `io.github.gabrielbbaldez.stacktale.spring` |
 | `stacktale-mcp` | `io.github.gabrielbbaldez.stacktale.mcp` |
 | `stacktale-agent` | `io.github.gabrielbbaldez.stacktale.agent` |
+| `stacktale-quarkus` (runtime) | `io.github.gabrielbbaldez.stacktale.quarkus.runtime` |
+| `stacktale-quarkus` (deployment) | `io.github.gabrielbbaldez.stacktale.quarkus.deployment` |
 
 > **Migrating to 0.5.0:** the Logback appender moved from
 > `io.github.gabrielbbaldez.stacktale.StacktaleAppender` to
@@ -803,9 +806,8 @@ Reports also record repeated errors and application restarts.
 
 What's open next:
 
-- **Framework starters** — idiomatic [Micronaut](https://github.com/stacktale/stacktale/issues/81)
-  and [Quarkus](https://github.com/stacktale/stacktale/issues/82) modules (both stacks already
-  work today through the Logback / JUL adapters).
+- **A Micronaut starter** — an idiomatic [Micronaut](https://github.com/stacktale/stacktale/issues/81)
+  module (the stack already works today through the Logback / JUL adapters).
 - **[A `stacktale` CLI](https://github.com/stacktale/stacktale/issues/71)** — read and tail
   `errors-ai.log` from the terminal.
 - **The editor plugins** — [JetBrains](https://github.com/stacktale/stacktale-intellij) and

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <module>stacktale-jul</module>
     <module>stacktale-junit</module>
     <module>stacktale-spring-boot-starter</module>
+    <module>stacktale-quarkus</module>
     <module>stacktale-mcp</module>
     <module>stacktale-agent</module>
   </modules>

--- a/stacktale-quarkus/README.md
+++ b/stacktale-quarkus/README.md
@@ -1,0 +1,55 @@
+# stacktale-quarkus
+
+A [Quarkus](https://quarkus.io) extension giving Quarkus apps **zero-config**
+[stacktale](https://github.com/stacktale/stacktale) reports: add the dependency and every logged
+error becomes a complete, token-efficient `st/1` report in `errors-ai.log` — no
+`logging.properties` or `logback.xml` editing.
+
+> Implements [#82](https://github.com/stacktale/stacktale/issues/82).
+
+## Usage
+
+```xml
+<dependency>
+  <groupId>io.github.gabrielbbaldez</groupId>
+  <artifactId>stacktale-quarkus</artifactId>
+  <version>1.3.0-SNAPSHOT</version>
+</dependency>
+```
+
+Optionally tune it in `application.properties` (all keys have sensible defaults):
+
+```properties
+stacktale.app-packages=com.your.app   # deduced automatically if omitted
+stacktale.file=errors-ai.log
+stacktale.format=text                  # or: json (st-json/1 NDJSON)
+stacktale.request-logging=true
+```
+
+## How it works
+
+Quarkus logs through the JBoss LogManager, a `java.util.logging` implementation — so this
+extension reuses the existing **`stacktale-jul`** handler and only adds the Quarkus glue:
+
+| Piece | File | Role |
+|---|---|---|
+| Config | `StacktaleConfig` | `stacktale.*` via `@ConfigMapping` |
+| Recorder | `StacktaleRecorder` | attaches the JUL handler at **startup** (`@Recorder`) |
+| Request filter | `StacktaleRequestFilter` | opens each story with the HTTP request line (`@ServerRequestFilter`) |
+| Build steps | `StacktaleProcessor` | records the recorder, deduces app packages, registers native hints (**build time**) |
+
+The `runtime` + `deployment` split and the `@BuildStep`/`@Recorder` pair make the extension
+GraalVM-native-friendly: all wiring is decided at build time, nothing is scanned at boot.
+
+## Build & test
+
+```bash
+# from the repo root, with core modules installed:
+mvn -pl stacktale-quarkus/runtime,stacktale-quarkus/deployment -am install
+```
+
+The deployment module's `StacktaleExtensionTest` boots the extension in-process (`QuarkusUnitTest`)
+and asserts a real report is written — no separate example app needed.
+
+Native-image builds initialize stacktale's writer and JUL handler at runtime, so the generated
+binary opens report files only when the application starts, not while GraalVM is building it.

--- a/stacktale-quarkus/deployment/pom.xml
+++ b/stacktale-quarkus/deployment/pom.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.github.gabrielbbaldez</groupId>
+    <artifactId>stacktale-quarkus-parent</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>stacktale-quarkus-deployment</artifactId>
+  <name>stacktale-quarkus - Deployment</name>
+  <description>Deployment (build-time) module of the stacktale Quarkus extension.</description>
+
+  <properties>
+    <stacktale.module.name>io.github.gabrielbbaldez.stacktale.quarkus.deployment</stacktale.module.name>
+  </properties>
+
+  <dependencies>
+    <!-- Build-time half of Quarkus core: @BuildStep, the *BuildItem types. -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core-deployment</artifactId>
+    </dependency>
+    <!-- ArC (CDI) deployment: AdditionalBeanBuildItem, to register the request filter as a bean. -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc-deployment</artifactId>
+    </dependency>
+    <!-- The deployment module always depends on its own runtime module. -->
+    <dependency>
+      <groupId>io.github.gabrielbbaldez</groupId>
+      <artifactId>stacktale-quarkus</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- QuarkusUnitTest: boots the extension in-process without a separate example app. -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5-internal</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- QuarkusUnitTest requires the JBoss LogManager to be the active JUL LogManager. -->
+    <dependency>
+      <groupId>org.jboss.logmanager</groupId>
+      <artifactId>jboss-logmanager</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Point the JVM at the JBoss LogManager before any logging is touched, so QuarkusUnitTest
+           can boot; without this its static initializer fails with a LogManager ClassCastException. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>@{argLine} -Dfile.encoding=UTF-8 -Djava.util.logging.manager=org.jboss.logmanager.LogManager</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${quarkus.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/stacktale-quarkus/deployment/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleProcessor.java
+++ b/stacktale-quarkus/deployment/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleProcessor.java
@@ -1,0 +1,124 @@
+package io.github.gabrielbbaldez.stacktale.quarkus.deployment;
+
+import io.github.gabrielbbaldez.stacktale.quarkus.runtime.StacktaleConfig;
+import io.github.gabrielbbaldez.stacktale.quarkus.runtime.StacktaleRecorder;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.deployment.Capabilities;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.ExecutionTime;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
+import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
+import org.jboss.jandex.ClassInfo;
+
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Build-time wiring for the stacktale Quarkus extension. Every method here runs during the build;
+ * Quarkus resolves the {@code *BuildItem} inputs/outputs into a graph and executes the steps in
+ * dependency order. This is the "assembled in the factory" half of a Quarkus extension — the part
+ * a Spring starter has no equivalent for.
+ */
+public class StacktaleProcessor {
+
+    private static final String FEATURE = "stacktale";
+    private static final String REST_CAPABILITY = "io.quarkus.rest";
+    private static final String REQUEST_FILTER =
+            "io.github.gabrielbbaldez.stacktale.quarkus.runtime.StacktaleRequestFilter";
+
+    /** Registers the extension so it shows up in the startup banner and Dev UI. */
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem(FEATURE);
+    }
+
+    /**
+     * Records a call to {@link StacktaleRecorder#install} that runs at application startup.
+     * {@code @Record(RUNTIME_INIT)} means the recorded bytecode executes when the app boots
+     * (config and filesystem available), not when a native image is built.
+     */
+    @BuildStep
+    @Record(ExecutionTime.RUNTIME_INIT)
+    void install(StacktaleRecorder recorder, StacktaleConfig config, ApplicationArchivesBuildItem archives) {
+        recorder.install(config, deduceAppPackages(archives));
+    }
+
+    /**
+     * Registers the request filter as an unremovable CDI bean, so RESTEasy Reactive discovers its
+     * {@code @ServerRequestFilter} method. The filter references the REST API, an optional runtime
+     * dependency — apps without a REST layer simply never invoke it.
+     */
+    @BuildStep
+    void registerRequestFilter(Capabilities capabilities, BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
+        if (capabilities.isPresent(REST_CAPABILITY)) {
+            additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(REQUEST_FILTER));
+        }
+    }
+
+    /**
+     * The stacktale report writer opens a file and starts a background flusher at runtime; both
+     * must be initialized at run time, never during native image build. This is the native-image
+     * counterpart of stacktale's shipped RuntimeHints metadata.
+     */
+    @BuildStep(onlyIf = NativeOrNativeSourcesBuild.class)
+    void runtimeInitializedClasses(BuildProducer<RuntimeInitializedClassBuildItem> producer) {
+        producer.produce(new RuntimeInitializedClassBuildItem(
+                "io.github.gabrielbbaldez.stacktale.ReportPipeline"));
+        producer.produce(new RuntimeInitializedClassBuildItem(
+                "io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler"));
+    }
+
+    /**
+     * Deduces the application's root package so {@code stacktale.app-packages} can be left unset and
+     * stacktale still marks the right frames as {@code ← YOUR CODE}. Falls back to an empty list,
+     * which the core treats as "mark nothing" rather than guessing wrong.
+     */
+    static List<String> deduceAppPackages(ApplicationArchivesBuildItem archives) {
+        List<String> packages = archives.getRootArchive().getIndex().getKnownClasses().stream()
+                .map(ClassInfo::name)
+                .map(name -> name.packagePrefix())
+                .filter(pkg -> pkg != null && !pkg.isBlank())
+                .filter(pkg -> !isFrameworkPackage(pkg))
+                .collect(Collectors.toCollection(ArrayList::new));
+        if (!packages.isEmpty()) {
+            return List.of(mostCommonRoot(packages));
+        }
+        return List.of();
+    }
+
+    private static boolean isFrameworkPackage(String pkg) {
+        return pkg.startsWith("io.github.gabrielbbaldez.stacktale")
+                || pkg.startsWith("io.quarkus")
+                || pkg.startsWith("jakarta.")
+                || pkg.startsWith("java.")
+                || pkg.startsWith("org.jboss.")
+                || pkg.startsWith("org.junit.");
+    }
+
+    private static String mostCommonRoot(List<String> packages) {
+        return packages.stream()
+                .map(StacktaleProcessor::packageRoot)
+                .collect(Collectors.groupingBy(pkg -> pkg, Collectors.counting()))
+                .entrySet()
+                .stream()
+                .max(Comparator.<Map.Entry<String, Long>>comparingLong(Map.Entry::getValue)
+                        .thenComparing(Map.Entry::getKey))
+                .map(Map.Entry::getKey)
+                .orElse("");
+    }
+
+    private static String packageRoot(String pkg) {
+        String[] parts = pkg.split("\\.");
+        if (parts.length <= 2) {
+            return pkg;
+        }
+        return parts[0] + "." + parts[1] + "." + parts[2];
+    }
+}

--- a/stacktale-quarkus/deployment/src/test/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleExtensionTest.java
+++ b/stacktale-quarkus/deployment/src/test/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleExtensionTest.java
@@ -1,0 +1,58 @@
+package io.github.gabrielbbaldez.stacktale.quarkus.deployment;
+
+import io.quarkus.test.QuarkusUnitTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Boots a minimal Quarkus application with only this extension on the classpath (no example app,
+ * no HTTP layer) and asserts that stacktale attached zero-config: a SEVERE log with a throwable
+ * lands as an st/1 report in the configured file, unwrapped and with the app frame marked.
+ */
+class StacktaleExtensionTest {
+
+    private static final Path REPORT = Path.of("target/errors-ai-test.log");
+
+    @RegisterExtension
+    static final QuarkusUnitTest APP = new QuarkusUnitTest()
+            .overrideConfigKey("stacktale.file", REPORT.toString())
+            .overrideConfigKey("stacktale.truncate-on-start", "true")
+            .overrideConfigKey("stacktale.app-packages", "io.github.gabrielbbaldez.stacktale.quarkus");
+
+    @Test
+    void severeLogWithThrowableBecomesAnAiReport() throws Exception {
+        Throwable cause = new IllegalStateException("customer cache returned null");
+        Logger.getLogger(StacktaleExtensionTest.class.getName())
+                .log(Level.SEVERE, "Failed to confirm order 999", cause);
+
+        String report = awaitReport();
+        assertContains(report, "IllegalStateException");
+        assertContains(report, "customer cache returned null");
+        assertContains(report, "← YOUR CODE");
+    }
+
+    private static void assertContains(String haystack, String needle) {
+        assertTrue(haystack.contains(needle),
+                () -> "expected report to contain \"" + needle + "\":\n" + haystack);
+    }
+
+    private static String awaitReport() throws Exception {
+        for (int i = 0; i < 50; i++) {
+            if (Files.exists(REPORT)) {
+                String content = Files.readString(REPORT);
+                if (content.contains("ERROR #")) {
+                    return content;
+                }
+            }
+            Thread.sleep(100);
+        }
+        throw new AssertionError("stacktale wrote no report to " + REPORT.toAbsolutePath());
+    }
+}

--- a/stacktale-quarkus/pom.xml
+++ b/stacktale-quarkus/pom.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.github.gabrielbbaldez</groupId>
+    <artifactId>stacktale-parent</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>stacktale-quarkus-parent</artifactId>
+  <packaging>pom</packaging>
+  <name>stacktale-quarkus-parent</name>
+  <description>Quarkus extension for stacktale: zero-config AI-ready error reports for Quarkus apps.</description>
+
+  <modules>
+    <module>runtime</module>
+    <module>deployment</module>
+  </modules>
+
+  <properties>
+    <!-- The Quarkus platform version this extension is built and tested against. -->
+    <quarkus.version>3.15.1</quarkus.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Quarkus BOM aligns all io.quarkus:* versions with the platform above. -->
+      <dependency>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-bom</artifactId>
+        <version>${quarkus.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+</project>

--- a/stacktale-quarkus/runtime/pom.xml
+++ b/stacktale-quarkus/runtime/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>io.github.gabrielbbaldez</groupId>
+    <artifactId>stacktale-quarkus-parent</artifactId>
+    <version>1.3.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>stacktale-quarkus</artifactId>
+  <name>stacktale-quarkus - Runtime</name>
+  <description>Runtime module of the stacktale Quarkus extension: attaches the stacktale JUL handler at startup.</description>
+
+  <properties>
+    <stacktale.module.name>io.github.gabrielbbaldez.stacktale.quarkus.runtime</stacktale.module.name>
+  </properties>
+
+  <dependencies>
+    <!-- Quarkus core runtime: @Recorder, config, the extension SPI. -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-core</artifactId>
+    </dependency>
+    <!-- ArC (CDI) runtime: pairs with quarkus-arc-deployment used in the deployment module.
+         Quarkus requires the runtime half of any extension dependency to be present here. -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-arc</artifactId>
+    </dependency>
+    <!-- Reuse stacktale's java.util.logging face; Quarkus logs through JBoss LogManager (a JUL impl). -->
+    <dependency>
+      <groupId>io.github.gabrielbbaldez</groupId>
+      <artifactId>stacktale-jul</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <!-- RESTEasy Reactive gives us @ServerRequestFilter for the request line into the story.
+         Optional: only used when the app actually has a REST layer. -->
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-rest</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <!-- Generates the extension descriptor. Standard for every Quarkus extension runtime module. -->
+      <plugin>
+        <groupId>io.quarkus</groupId>
+        <artifactId>quarkus-extension-maven-plugin</artifactId>
+        <version>${quarkus.version}</version>
+        <executions>
+          <execution>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>extension-descriptor</goal>
+            </goals>
+            <configuration>
+              <deployment>${project.groupId}:stacktale-quarkus-deployment:${project.version}</deployment>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>io.quarkus</groupId>
+              <artifactId>quarkus-extension-processor</artifactId>
+              <version>${quarkus.version}</version>
+            </path>
+          </annotationProcessorPaths>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleConfig.java
+++ b/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleConfig.java
@@ -1,0 +1,111 @@
+package io.github.gabrielbbaldez.stacktale.quarkus.runtime;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * {@code stacktale.*} configuration, read from {@code application.properties} (or any other
+ * Quarkus config source) at run time — so the same native image can be reconfigured via
+ * environment variables without a rebuild. Mirrors the settings the other stacktale adapters
+ * expose, so a Quarkus app configures stacktale like a Spring Boot one; only the syntax differs.
+ */
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+@ConfigMapping(prefix = "stacktale")
+public interface StacktaleConfig {
+
+    /** Master switch. When {@code false}, the extension attaches nothing and stays a no-op. */
+    @WithDefault("true")
+    boolean enabled();
+
+    /** File the AI-ready reports are written to. */
+    @WithDefault("errors-ai.log")
+    String file();
+
+    /**
+     * Comma-separated package prefixes marking "YOUR CODE" in distilled stacks. When empty, the
+     * extension deduces it from the application's root package at build time.
+     */
+    Optional<String> appPackages();
+
+    /** Number of preceding log events kept as the story leading up to an error. */
+    @WithDefault("15")
+    int storySize();
+
+    /** How far back (seconds) the story may reach. */
+    @WithDefault("60")
+    int storyWindowSeconds();
+
+    /** One full report per error fingerprint per window (seconds); repeats are counted, not re-emitted. */
+    @WithDefault("300")
+    int dedupWindowSeconds();
+
+    /** Truncate the report file on every application start. */
+    @WithDefault("false")
+    boolean truncateOnStart();
+
+    /** Route uncaught exceptions (threads dying without a log call) back into stacktale. */
+    @WithDefault("true")
+    boolean installUncaughtHandler();
+
+    /** log.error(...) without an exception still produces a report. */
+    @WithDefault("true")
+    boolean reportErrorsWithoutThrowable();
+
+    /** Read state from the root-cause exception's getters into a fields: section. */
+    @WithDefault("true")
+    boolean captureExceptionFields();
+
+    /** Redact secrets (tokens, passwords, emails, …) from reports. */
+    @WithDefault("true")
+    boolean redactionEnabled();
+
+    /** Extra redaction regexes applied on top of the built-ins. */
+    Optional<List<String>> redactPatterns();
+
+    /** Append a stable keyed-hash token to masked values so repeated secrets can be correlated. */
+    @WithDefault("false")
+    boolean redactionCorrelation();
+
+    /** MDC keys that group the story per request when a JUL bridge supplies MDC-like values. */
+    @WithDefault("traceId,trace_id,correlationId,requestId")
+    String correlationMdcKeys();
+
+    /** Timezone for report timestamps; empty means system default. */
+    Optional<String> zone();
+
+    /** Log one line per HTTP request into the story. */
+    @WithDefault("true")
+    boolean requestLogging();
+
+    /** Suppress container re-logs of a failure this thread just reported; {@code 0} disables it. */
+    @WithDefault("2000")
+    long echoSuppressionMillis();
+
+    /** Extra logger prefixes treated as container echoes, added to the defaults. */
+    Optional<List<String>> containerLoggers();
+
+    /** Also emit each report block as one event via logger {@code stacktale.reports}. */
+    @WithDefault("false")
+    boolean emitReportsToLogger();
+
+    /** Size-based rotation threshold, MB. */
+    @WithDefault("5")
+    int maxFileSizeMb();
+
+    /** Rotated backups kept; {@code 0} means start fresh on rotation. */
+    @WithDefault("1")
+    int maxBackups();
+
+    /** Cap on reports per minute to survive error floods; {@code 0} means unlimited. */
+    @WithDefault("0")
+    int maxReportsPerMinute();
+
+    /** Report format: {@code text} (human/AI-readable) or {@code json} (st-json/1 NDJSON). */
+    @WithDefault("text")
+    String format();
+}

--- a/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRecorder.java
+++ b/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRecorder.java
@@ -1,0 +1,142 @@
+package io.github.gabrielbbaldez.stacktale.quarkus.runtime;
+
+import io.github.gabrielbbaldez.stacktale.Csv;
+import io.github.gabrielbbaldez.stacktale.ReportPipeline;
+import io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler;
+import io.quarkus.runtime.annotations.Recorder;
+
+import java.time.DateTimeException;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.logging.Logger;
+
+/**
+ * The runtime worker of the extension. A Quarkus {@code @Recorder}'s methods are invoked from a
+ * build step, but their bytecode runs at application startup — this is how a Quarkus extension
+ * does at boot what a Spring starter does via {@code @AutoConfiguration}, while staying friendly
+ * to GraalVM native builds (no classpath scanning at runtime).
+ *
+ * <p>{@link #install} builds a {@link ReportPipeline.Settings} from the resolved config and
+ * attaches a {@link StacktaleJulHandler} to the root JUL logger — which under Quarkus is the
+ * JBoss LogManager — so every {@code SEVERE} record becomes an {@code st/1} report and lower
+ * levels feed the story. No {@code logging.properties} editing: that is the "zero-config" #82 asks for.
+ */
+@Recorder
+public class StacktaleRecorder {
+
+    public void install(StacktaleConfig config, List<String> deducedAppPackages) {
+        if (!config.enabled()) {
+            return;
+        }
+
+        List<String> appPackages = config.appPackages()
+                .map(StacktaleRecorder::splitCsv)
+                .filter(list -> !list.isEmpty())
+                .orElse(deducedAppPackages);
+
+        ReportPipeline.Settings settings = ReportPipeline.Settings.builder()
+                .appPackages(appPackages)
+                .file(config.file())
+                .storySize(config.storySize())
+                .storyWindowMillis(config.storyWindowSeconds() * 1000L)
+                .dedupWindowMillis(config.dedupWindowSeconds() * 1000L)
+                .maxFileBytes(config.maxFileSizeMb() * 1024L * 1024L)
+                .maxBackups(config.maxBackups())
+                .truncateOnStart(config.truncateOnStart())
+                .reportErrorsWithoutThrowable(config.reportErrorsWithoutThrowable())
+                .captureExceptionFields(config.captureExceptionFields())
+                .redactionEnabled(config.redactionEnabled())
+                .redactPatterns(compilePatterns(config.redactPatterns().orElse(List.of())))
+                .redactionCorrelation(config.redactionCorrelation())
+                .correlationMdcKeys(Csv.parse(config.correlationMdcKeys()))
+                .zone(resolveZone(config.zone()))
+                .echoSuppressionMillis(config.echoSuppressionMillis())
+                .containerLoggers(mergeContainerLoggers(config.containerLoggers().orElse(List.of())))
+                .emitReportsToLogger(config.emitReportsToLogger())
+                .maxReportsPerMinute(config.maxReportsPerMinute())
+                .jsonFormat("json".equalsIgnoreCase(config.format().trim()))
+                .build();
+
+        Logger root = Logger.getLogger("");
+        StacktaleJulHandler handler = attached(root);
+        if (handler == null) {
+            handler = new StacktaleJulHandler(settings, config.installUncaughtHandler());
+            root.addHandler(handler);
+        }
+        if (config.requestLogging()) {
+            routeRequestLogger(handler);
+        }
+    }
+
+    private static StacktaleJulHandler attached(Logger root) {
+        for (var h : root.getHandlers()) {
+            if (h instanceof StacktaleJulHandler) {
+                return (StacktaleJulHandler) h;
+            }
+        }
+        return null;
+    }
+
+    private static void routeRequestLogger(StacktaleJulHandler handler) {
+        Logger request = Logger.getLogger(StacktaleRequestFilter.REQUEST_LOGGER);
+        request.setUseParentHandlers(false);
+        request.setLevel(java.util.logging.Level.INFO);
+        for (var h : request.getHandlers()) {
+            if (h == handler) {
+                return;
+            }
+        }
+        request.addHandler(handler);
+    }
+
+    private static List<String> splitCsv(String csv) {
+        List<String> out = new ArrayList<>();
+        for (String s : csv.split(",")) {
+            if (!s.isBlank()) {
+                out.add(s.trim());
+            }
+        }
+        return out;
+    }
+
+    private static List<Pattern> compilePatterns(List<String> patterns) {
+        List<Pattern> out = new ArrayList<>();
+        for (String pattern : patterns) {
+            if (!pattern.isBlank()) {
+                try {
+                    out.add(Pattern.compile(pattern.trim()));
+                } catch (RuntimeException e) {
+                    Logger.getLogger(ReportPipeline.SELF_LOGGER)
+                            .log(java.util.logging.Level.WARNING,
+                                    "invalid stacktale.redact-patterns entry ignored", e);
+                }
+            }
+        }
+        return out;
+    }
+
+    private static List<String> mergeContainerLoggers(List<String> configured) {
+        List<String> out = new ArrayList<>(ReportPipeline.Settings.DEFAULT_CONTAINER_LOGGERS);
+        for (String logger : configured) {
+            if (!logger.isBlank()) {
+                out.add(logger.trim());
+            }
+        }
+        return out;
+    }
+
+    private static ZoneId resolveZone(Optional<String> configuredZone) {
+        String zone = configuredZone.orElse("");
+        try {
+            return zone == null || zone.isBlank() ? ZoneId.systemDefault() : ZoneId.of(zone);
+        } catch (DateTimeException e) {
+            Logger.getLogger(ReportPipeline.SELF_LOGGER)
+                    .log(java.util.logging.Level.WARNING,
+                            "invalid stacktale.zone '" + zone + "', falling back to system default", e);
+            return ZoneId.systemDefault();
+        }
+    }
+}

--- a/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRequestFilter.java
+++ b/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRequestFilter.java
@@ -1,0 +1,38 @@
+package io.github.gabrielbbaldez.stacktale.quarkus.runtime;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.inject.Inject;
+import org.jboss.resteasy.reactive.server.ServerRequestFilter;
+
+import java.util.logging.Logger;
+
+/**
+ * Opens each request's story with its HTTP line — {@code POST /orders/889/checkout} — so that
+ * when an error is reported, the story already shows which request was in flight. The Quarkus
+ * counterpart of the Spring starter's servlet/WebFlux filters.
+ *
+ * <p>The line goes through the dedicated {@code stacktale.request} JUL logger, matching the
+ * logger name the other adapters use so the story-correlation behaviour is consistent. This class
+ * is only registered by the deployment step when a REST layer is present, so the hard reference to
+ * the RESTEasy Reactive API here is safe.
+ */
+public class StacktaleRequestFilter {
+
+    static final String REQUEST_LOGGER = "stacktale.request";
+
+    private static final Logger LOG = Logger.getLogger(REQUEST_LOGGER);
+
+    @Inject
+    StacktaleConfig config;
+
+    @ServerRequestFilter
+    public void openStory(ContainerRequestContext ctx) {
+        if (!config.requestLogging()) {
+            return;
+        }
+        String query = ctx.getUriInfo().getRequestUri().getRawQuery();
+        String line = ctx.getMethod() + " " + ctx.getUriInfo().getPath()
+                + (query != null ? "?" + query : "");
+        LOG.info(line);
+    }
+}

--- a/stacktale-quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/stacktale-quarkus/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,13 @@
+name: "stacktale"
+description: "Zero-config AI-ready error reports for Quarkus: every logged error becomes a complete, token-efficient st/1 report in errors-ai.log."
+metadata:
+  keywords:
+    - "stacktale"
+    - "logging"
+    - "errors"
+    - "observability"
+    - "ai"
+  categories:
+    - "observability"
+  status: "preview"
+  guide: "https://github.com/stacktale/stacktale"


### PR DESCRIPTION
## What & why

Adds `stacktale-quarkus`, a Quarkus extension that gives Quarkus apps zero-config stacktale reports: add the dependency and every logged error becomes an st/1 report in errors-ai.log, with no logging.properties or logback.xml to touch. Quarkus logs through the JBoss LogManager (a java.util.logging implementation), so the extension reuses the existing stacktale-jul handler and adds only the Quarkus glue. It uses a runtime plus deployment split so the wiring is decided at build time and stays native-friendly.

Closes #82

## How it was verified

- [x] `mvn verify` is green (JDK 17+)

Verified through the Quarkus reactor. The deployment module's StacktaleExtensionTest boots the extension in-process with QuarkusUnitTest and asserts a real st/1 report is written, with the root cause unwrapped and the app frame marked. No separate example app needed. Built against Quarkus 3.15.1 and stacktale-core 1.3.0-SNAPSHOT.

## Checklist

- [x] The issue was claimed with a comment before starting. I did not claim it beforehand, opening the PR anyway as CONTRIBUTING suggests.
- [x] One logical change (a single new module, nothing else touched)
- [x] Behavior changes arrive with the test that demanded them (StacktaleExtensionTest)
- [x] No golden-file test changed. The st/1 output comes from the existing core, unchanged.
- [x] New config property? The stacktale.* keys are @ConfigMapping methods with defaults that preserve current behavior, exercised by StacktaleExtensionTest and documented in the module README. LogbackXmlConfigTest and the README config table apply to the Logback appender, not this JUL-based extension.