### PR TITLE
ci: unblock the 1.3.0 release, and write its notes

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -49,13 +49,23 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: The CHANGELOG must already describe this version
+      - name: The CHANGELOG must have something to release
         run: |
           set -euo pipefail
           # Checked before anything is built or pushed. Finding out afterwards means either
           # an empty release or deleting a published tag, and 1.2.0 did both.
-          if ! grep -q "^## \[${{ inputs.version }}\]" CHANGELOG.md; then
-            echo "::error::CHANGELOG.md has no '## [${{ inputs.version }}]' section — write it first"
+          #
+          # The gate is on `[Unreleased]`, not on a `[<version>]` heading, and that is not a
+          # detail. check-plugin-versions.sh keys the plugin manifests to the newest version
+          # heading, so writing that heading before the release commit makes `main` red: the
+          # guard starts demanding manifests that pin a version Central cannot resolve yet.
+          # The heading is stamped below, in the release commit, where the manifests move too.
+          if ! grep -q '^## \[Unreleased\]$' CHANGELOG.md; then
+            echo "::error::CHANGELOG.md has no '## [Unreleased]' section"
+            exit 1
+          fi
+          if ! awk '/^## \[Unreleased\]$/{u=1;next} /^## \[/{u=0} u&&/^- /{found=1} END{exit !found}' CHANGELOG.md; then
+            echo "::error::'## [Unreleased]' has no entries — write the release notes first"
             exit 1
           fi
 
@@ -79,6 +89,25 @@ jobs:
         run: mvn -B -Prelease verify
         env:
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
+      - name: Stamp the changelog and the build timestamp
+        run: |
+          set -euo pipefail
+          V='${{ inputs.version }}'
+          DATE=$(date -u +%Y-%m-%d)
+          # `[Unreleased]` becomes this version, and the link reference goes where the older
+          # ones sit: at the end of its own section, just above the previous heading.
+          sed -i "0,/^## \[Unreleased\]$/s||## [$V] — $DATE|" CHANGELOG.md
+          awk -v ref="[$V]: https://github.com/stacktale/stacktale/releases/tag/v$V" '
+            /^## \[/ { n++; if (n==2) { print ref; print "" } }
+            { print }
+          ' CHANGELOG.md > CHANGELOG.tmp && mv CHANGELOG.tmp CHANGELOG.md
+          # Reproducible builds pin every archive entry to this instant. It has to move with
+          # the release or the jars carry the previous one — still reproducible, just wrong.
+          # CONTRIBUTING asked a human to remember; nobody was going to.
+          sed -i -E "s|(<project.build.outputTimestamp>)[^<]+|\1${DATE}T00:00:00Z|" pom.xml
+          grep -q "^## \[$V\] — $DATE" CHANGELOG.md
+          grep -q "<project.build.outputTimestamp>${DATE}T00:00:00Z" pom.xml
 
       - name: Update README and plugin manifest versions
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,12 @@ and pinned by golden-file tests.
 
 ## [Unreleased]
 
-The headline is `repro:` — a report section that names the failing call with its declared
-signature and the argument values it was given, so the first thing a reader gets is the
-call to re-run rather than a stack to reconstruct one from. It is off by default and stays
-that way deliberately.
+Two headline additions. `repro:` turns the top of a report into the call that failed — the
+fully-qualified signature and the argument values it was given — so a reader starts with
+something to re-run instead of a stack to reconstruct one from; it is off by default and
+stays that way deliberately, being the one section that renders values against a named
+signature. And `stacktale-quarkus` makes Quarkus the fourth stack that reports with nothing
+to configure.
 
 ### Added
 
@@ -31,9 +33,9 @@ that way deliberately.
   can't be resolved unambiguously (overloads with the same arity), it falls back to the
   runtime class, which still names something a call can be written against. Only the
   innermost frame becomes the seed: a seed naming the outer caller would describe a call
-  that did not fail. **Off by default**, and worth leaving off for most projects — it is the only section that renders
-  argument values against a named signature, which is a larger privacy surface than the
-  rest of a report combined. Values go through the same redaction as everything else, and
+  that did not fail. **Off by default**, and worth leaving off for most projects — it is the
+  only section that renders argument values against a named signature, which is a larger
+  privacy surface than the rest of a report combined. Values go through the same redaction as everything else, and
   the name and value are cleaned as one string so a secret-named parameter masks its value.
   An older agent paired with a newer core loses the seed and keeps `captured:`, rather than
   failing. Additive under the FORMAT §6 rules, so `st/1` does not change version. (#135)
@@ -70,6 +72,14 @@ that way deliberately.
   member whose name differs from its `st/1` counterpart, so the mapping never has to be
   inferred from an example (#172).
 - `stacktale-junit` joins the JPMS module table. (#171)
+
+Contributions this cycle from **[@dchaudhari7177](https://github.com/dchaudhari7177)** (the
+link checker #179, reproducible builds #178, the dedup rollback #180, and the CodeQL,
+examples-pinning and plugin-manifest guards), **[@DenizAltunkapan](https://github.com/DenizAltunkapan)**
+(the Quarkus extension #187), **[@dongyikuan919](https://github.com/dongyikuan919)** (widening
+the link check to every Markdown file #184), **[@Sarthak-Vatsa](https://github.com/Sarthak-Vatsa)**
+(the JUnit Platform 1.10 floor #164) and **[@syf2211](https://github.com/syf2211)**
+(`st-json/1` summaries in the report action #167). Thank you.
 
 ## [1.2.0] — 2026-08-03
 
@@ -147,6 +157,8 @@ ended up wrong rather than absent.
   in a real configuration — but a hand-written config relying on the default will now fail
   to start rather than start wrong. (#122)
 - `containerLoggers` is configurable on JUL, which the README previously said it was not.
+
+[1.2.0]: https://github.com/stacktale/stacktale/releases/tag/v1.2.0
 
 ## [1.1.0] — 2026-07-29
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,9 +76,10 @@ is on Maven Central. That comes from a single parent-pom property:
 ```
 
 Maven feeds it to the jar, source, javadoc and shade plugins, which pin every
-archive entry's timestamp instead of stamping the current time. **Bump it to the
-release date when cutting a release** — any fixed ISO-8601 instant works, what
-matters is that it doesn't move between builds of one commit.
+archive entry's timestamp instead of stamping the current time. Any fixed ISO-8601
+instant works; what matters is that it doesn't move between builds of one commit.
+`prepare-release` moves it to the release date as part of the release commit, so
+there is nothing to remember here — leave it alone between releases.
 
 CI enforces this in the `Reproducible build` job: it packages twice and diffs
 the jar checksums. To check locally:


### PR DESCRIPTION
Preparing 1.3.0 turned out to be blocked by a contradiction between two things I wrote, so this fixes that first.

## The contradiction

`prepare-release.yml` refused to run unless `CHANGELOG.md` already had a `## [1.3.0]` heading. But `scripts/check-plugin-versions.sh` keys the three plugin manifests to **the newest version heading**, and its own comment spells out the intended sequence:

> At release the bump sets the parent to 1.2.0 and adds the `## [1.2.0]` heading **in the same commit**, so the two agree again.

So writing the heading ahead of the release commit turns `main` red: the guard immediately starts demanding manifests that pin a version Maven Central cannot resolve yet. Verified rather than assumed — with the heading renamed and nothing else changed:

```
plugins/stacktale/.mcp.json pins 1.2.0, expected 1.3.0 (the latest release, per CHANGELOG.md)
.claude-plugin/marketplace.json pins 1.2.0, expected 1.3.0
plugins/stacktale/.claude-plugin/plugin.json pins 1.2.0, expected 1.3.0
exit 1
```

The guard is right and the gate was wrong. `[Unreleased]` is what accumulates during a cycle — the guard even skips it deliberately — and the heading belongs to the release commit.

## What changed

- **The gate** now requires `## [Unreleased]` to exist *and* to have entries. That preserves what it was for (1.2.0 shipped with nothing to announce) without forcing the heading to be written early.
- **The release commit stamps the changelog**: `[Unreleased]` becomes `## [<version>] — <date>` and the link reference is inserted where the older ones sit. It runs before the manifest bump, so the guard sees both halves updated together.
- **`project.build.outputTimestamp` moves to the release date** in that same step. Nothing automated this before — CONTRIBUTING asked a human to remember it, which is why it still reads `2026-08-11`. Forgetting it doesn't break reproducibility, it just stamps the jars with a stale date.
- CONTRIBUTING no longer asks for that manual bump.

## The 1.3.0 notes themselves

`[Unreleased]` now reads as a release: an intro covering both headline items, the `stacktale-quarkus` entry, and the contributor thanks paragraph the 1.1.0 section has. Also adds the `[1.2.0]` link reference, which was never added — 1.2.0 was finished by hand after #153 and that got missed.

## Verification

The stamping logic can't be dry-run through the workflow, since a real run publishes to Central. Ran it as plain shell against copies instead:

- Stamping the real changelog changes exactly two lines — the heading, and the link reference in the correct place with the right blank-line spacing.
- The gate accepts this changelog, rejects an `[Unreleased]` with no entries, and rejects a file with no `[Unreleased]` at all.
- Applying the full sequence (stamp → bump manifests) in the working tree makes the guard report `plugin manifests pin 1.3.0`, exit 0 — the state the release commit will be in.
- Reverted all of it; this PR touches three files.

## After this merges

`prepare-release` is dispatched with version `1.3.0`. It bumps, verifies, stamps, commits, tags, **publishes to Central in the same run**, and opens a PR bringing the tagged commit back into `main` — which must be merged with a merge commit, not a squash.
