### PR TITLE
release: 1.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "stacktale",
       "source": "./plugins/stacktale",
       "description": "Read your Java app's AI-ready error reports, and run a fix-run-check loop until the app is clean.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "Gabriel Baldez"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to stacktale are documented here. The format follows
 [SemVer](https://semver.org/). The report format (`st/1`) is versioned independently
 and pinned by golden-file tests.
 
-## [Unreleased]
+## [1.3.0] — 2026-08-20
 
 Two headline additions. `repro:` turns the top of a report into the call that failed — the
 fully-qualified signature and the argument values it was given — so a reader starts with
@@ -80,6 +80,8 @@ examples-pinning and plugin-manifest guards), **[@DenizAltunkapan](https://githu
 the link check to every Markdown file #184), **[@Sarthak-Vatsa](https://github.com/Sarthak-Vatsa)**
 (the JUnit Platform 1.10 floor #164) and **[@syf2211](https://github.com/syf2211)**
 (`st-json/1` summaries in the report action #167). Thank you.
+
+[1.3.0]: https://github.com/stacktale/stacktale/releases/tag/v1.3.0
 
 ## [1.2.0] — 2026-08-03
 

--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ All artifacts are on Maven Central.
 **Gradle (Groovy)**
 
 ```groovy
-implementation 'io.github.gabrielbbaldez:stacktale-spring-boot-starter:1.2.0'
+implementation 'io.github.gabrielbbaldez:stacktale-spring-boot-starter:1.3.0'
 ```
 
 **Gradle (Kotlin DSL)**
 
 ```kotlin
-implementation("io.github.gabrielbbaldez:stacktale-spring-boot-starter:1.2.0")
+implementation("io.github.gabrielbbaldez:stacktale-spring-boot-starter:1.3.0")
 ```
 
 That's it — no logback.xml editing. The starter registers the appender on the root
@@ -170,13 +170,13 @@ written in Kotlin or Java.
 **Gradle (Groovy)**
 
 ```groovy
-implementation 'io.github.gabrielbbaldez:stacktale:1.2.0'
+implementation 'io.github.gabrielbbaldez:stacktale:1.3.0'
 ```
 
 **Gradle (Kotlin DSL)**
 
 ```kotlin
-implementation("io.github.gabrielbbaldez:stacktale:1.2.0")
+implementation("io.github.gabrielbbaldez:stacktale:1.3.0")
 ```
 
 ```xml
@@ -212,13 +212,13 @@ itself on startup, and the file header explains the format to any AI that opens 
 **Gradle (Groovy)**
 
 ```groovy
-implementation 'io.github.gabrielbbaldez:stacktale-log4j2:1.2.0'
+implementation 'io.github.gabrielbbaldez:stacktale-log4j2:1.3.0'
 ```
 
 **Gradle (Kotlin DSL)**
 
 ```kotlin
-implementation("io.github.gabrielbbaldez:stacktale-log4j2:1.2.0")
+implementation("io.github.gabrielbbaldez:stacktale-log4j2:1.3.0")
 ```
 
 ```xml
@@ -251,13 +251,13 @@ by default — with no SLF4J bridge:
 **Gradle (Groovy)**
 
 ```groovy
-implementation 'io.github.gabrielbbaldez:stacktale-jul:1.2.0'
+implementation 'io.github.gabrielbbaldez:stacktale-jul:1.3.0'
 ```
 
 **Gradle (Kotlin DSL)**
 
 ```kotlin
-implementation("io.github.gabrielbbaldez:stacktale-jul:1.2.0")
+implementation("io.github.gabrielbbaldez:stacktale-jul:1.3.0")
 ```
 
 ```properties
@@ -338,7 +338,7 @@ an agent: told to "fix it, re-run the tests, then check what changed", it would 
 ```
 
 ```groovy
-testImplementation 'io.github.gabrielbbaldez:stacktale-junit:1.2.0'
+testImplementation 'io.github.gabrielbbaldez:stacktale-junit:1.3.0'
 ```
 
 **If your tests set a correlation key**, add `StacktaleExtension`. The listener is notified

--- a/plugins/stacktale/.claude-plugin/plugin.json
+++ b/plugins/stacktale/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stacktale",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Read your Java app's AI-ready error reports, and run a fix-run-check loop until the app is clean.",
   "author": {
     "name": "Gabriel Baldez",

--- a/plugins/stacktale/.mcp.json
+++ b/plugins/stacktale/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "stacktale": {
       "command": "jbang",
-      "args": ["run", "io.github.gabrielbbaldez:stacktale-mcp:1.2.0"]
+      "args": ["run", "io.github.gabrielbbaldez:stacktale-mcp:1.3.0"]
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.gabrielbbaldez</groupId>
   <artifactId>stacktale-parent</artifactId>
-  <version>1.3.0</version>
+  <version>1.4.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>stacktale-parent</name>
@@ -61,7 +61,7 @@
       Bump it to the release date when cutting a release. Any fixed ISO-8601 instant works;
       what matters is that it does not move between builds of one commit.
     -->
-    <project.build.outputTimestamp>2026-08-20T00:00:00Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-08-20T00:56:02Z</project.build.outputTimestamp>
     <logback.version>1.6.1</logback.version>
     <junit.version>6.1.3</junit.version>
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.gabrielbbaldez</groupId>
   <artifactId>stacktale-parent</artifactId>
-  <version>1.3.0-SNAPSHOT</version>
+  <version>1.3.0</version>
   <packaging>pom</packaging>
 
   <name>stacktale-parent</name>
@@ -61,7 +61,7 @@
       Bump it to the release date when cutting a release. Any fixed ISO-8601 instant works;
       what matters is that it does not move between builds of one commit.
     -->
-    <project.build.outputTimestamp>2026-08-11T00:00:00Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-08-20T00:00:00Z</project.build.outputTimestamp>
     <logback.version>1.6.1</logback.version>
     <junit.version>6.1.3</junit.version>
     <!--

--- a/stacktale-agent/pom.xml
+++ b/stacktale-agent/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>stacktale-agent</artifactId>

--- a/stacktale-agent/pom.xml
+++ b/stacktale-agent/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-agent</artifactId>

--- a/stacktale-core/pom.xml
+++ b/stacktale-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-core</artifactId>

--- a/stacktale-core/pom.xml
+++ b/stacktale-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>stacktale-core</artifactId>

--- a/stacktale-jul/pom.xml
+++ b/stacktale-jul/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-jul</artifactId>

--- a/stacktale-jul/pom.xml
+++ b/stacktale-jul/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>stacktale-jul</artifactId>

--- a/stacktale-junit/pom.xml
+++ b/stacktale-junit/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-junit</artifactId>

--- a/stacktale-junit/pom.xml
+++ b/stacktale-junit/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>stacktale-junit</artifactId>

--- a/stacktale-log4j2/pom.xml
+++ b/stacktale-log4j2/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-log4j2</artifactId>

--- a/stacktale-log4j2/pom.xml
+++ b/stacktale-log4j2/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>stacktale-log4j2</artifactId>

--- a/stacktale-mcp/pom.xml
+++ b/stacktale-mcp/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-mcp</artifactId>

--- a/stacktale-mcp/pom.xml
+++ b/stacktale-mcp/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>stacktale-mcp</artifactId>

--- a/stacktale-quarkus/deployment/pom.xml
+++ b/stacktale-quarkus/deployment/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-quarkus-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>stacktale-quarkus-deployment</artifactId>

--- a/stacktale-quarkus/deployment/pom.xml
+++ b/stacktale-quarkus/deployment/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-quarkus-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-quarkus-deployment</artifactId>

--- a/stacktale-quarkus/pom.xml
+++ b/stacktale-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>stacktale-quarkus-parent</artifactId>

--- a/stacktale-quarkus/pom.xml
+++ b/stacktale-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-quarkus-parent</artifactId>

--- a/stacktale-quarkus/runtime/pom.xml
+++ b/stacktale-quarkus/runtime/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-quarkus-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-quarkus</artifactId>

--- a/stacktale-quarkus/runtime/pom.xml
+++ b/stacktale-quarkus/runtime/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-quarkus-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>stacktale-quarkus</artifactId>

--- a/stacktale-spring-boot-starter/pom.xml
+++ b/stacktale-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>stacktale-spring-boot-starter</artifactId>

--- a/stacktale-spring-boot-starter/pom.xml
+++ b/stacktale-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-spring-boot-starter</artifactId>

--- a/stacktale/pom.xml
+++ b/stacktale/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale</artifactId>

--- a/stacktale/pom.xml
+++ b/stacktale/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>1.3.0</version>
   </parent>
 
   <artifactId>stacktale</artifactId>


### PR DESCRIPTION
Version bumps for **1.3.0**.

`prepare-release` produced the `release:` commit, pushed the branch and created the tag `v1.3.0`, then failed on its last step:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests
```

So this PR is the missing step, opened by hand. Nothing was published when the run died — `publish` is `needs: prepare`, so it was skipped, and the tag was pushed with `GITHUB_TOKEN`, which does not start workflows. Publishing is being triggered separately.

**Merge with a merge commit, not a squash.** A squash creates a new commit and would leave `v1.3.0` pointing at one reachable from nowhere — the exact state #153 had to clean up.
