### PR TITLE
ci: stop a failed PR step from cancelling the release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -145,7 +145,12 @@ jobs:
           git tag -a "v${{ inputs.version }}" -m "stacktale ${{ inputs.version }}" "$RELEASE_SHA"
           git push origin "refs/tags/v${{ inputs.version }}"
 
+      # Not fatal, and that ordering was learned the hard way: this is the last step of
+      # `prepare`, `publish` is `needs: prepare`, so 1.3.0 tagged and then published nothing
+      # because opening a PR failed. The tag and the branch are already pushed by here — the
+      # release exists whether or not this succeeds, and a missing PR is a two-click fix.
       - name: Open the pull request
+        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,15 @@ on:
         description: The tag or commit to publish
         required: true
         type: string
+  # A tag pushed with GITHUB_TOKEN starts no workflow, so when `prepare-release` tags but
+  # does not reach `publish`, nothing here fires and the only recovery was deleting the tag
+  # and pushing it again by hand. This is that recovery, without touching the tag.
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: The tag or commit to publish
+        required: true
+        type: string
 
 jobs:
   publish:


### PR DESCRIPTION
Found by cutting 1.3.0.

`prepare-release` bumped, verified, stamped, committed, pushed the branch and created the tag — then died on its last step:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests
```

`publish` is `needs: prepare`, so it was skipped. **The release was tagged and nothing was published**, over a step that only opens a convenience PR. By the time it runs, the branch and tag are already pushed and the release exists; a missing PR is two clicks. It is now `continue-on-error`.

`release.yml` also gains `workflow_dispatch`. Recovering from the above meant deleting the tag and pushing it again, because a tag pushed with `GITHUB_TOKEN` starts no workflow — the same rule the prepare workflow's own header documents. There was no way to publish an existing tag without disturbing it. Now there is.

## Still needed, and only you can do it

The underlying block is an **organization** setting: *Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"*. The repo-level API refuses while the org forbids it:

```
gh: The organization does not allow GitHub Actions to create or approve pull requests (Conflict)
```

With this PR the release survives without it — the PR step just logs its failure and the next release still publishes. Flipping it restores the last piece of the automation.