### PR TITLE
fix(examples): pin 1.3.0, and let the release do it next time

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -115,6 +115,10 @@ jobs:
           sed -i -E 's|(<artifactId>stacktale[a-z0-9-]*</artifactId>[[:space:]]*<version>)[0-9.]+(</version>)|\1${{ inputs.version }}\2|g' README.md
           sed -i -E 's|(io\.github\.gabrielbbaldez:stacktale[a-z0-9-]*:)[0-9.]+|\1${{ inputs.version }}|g' README.md
           bash scripts/check-readme-compat.sh
+          # The examples pin the released version and examples.yml fails when they drift.
+          # Nothing bumped them, so 1.3.0 left `main` red until they were fixed by hand:
+          # the same shape as the timestamp above, found one release later.
+          sed -i -E 's|(<stacktale.version>)[0-9.]+(</stacktale.version>)|\1${{ inputs.version }}\2|' examples/*/pom.xml
           # The plugin manifests pin the released version too, and were the one set of
           # files the bump did not reach (#142). The guard runs straight after, so a sed
           # that matched nothing fails here rather than shipping a stale marketplace entry.

--- a/examples/plain-java-jul/pom.xml
+++ b/examples/plain-java-jul/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <stacktale.version>1.2.0</stacktale.version>
+        <stacktale.version>1.3.0</stacktale.version>
     </properties>
 
     <dependencies>

--- a/examples/spring-boot-mvc/pom.xml
+++ b/examples/spring-boot-mvc/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <stacktale.version>1.2.0</stacktale.version>
+        <stacktale.version>1.3.0</stacktale.version>
     </properties>
 
     <dependencies>

--- a/examples/spring-boot-webflux/pom.xml
+++ b/examples/spring-boot-webflux/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <stacktale.version>1.2.0</stacktale.version>
+        <stacktale.version>1.3.0</stacktale.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
`main` is red on **Build Examples**:

```
examples/plain-java-jul pins stacktale 1.2.0 but the latest release is 1.3.0
examples/spring-boot-mvc pins stacktale 1.2.0 but the latest release is 1.3.0
examples/spring-boot-webflux pins stacktale 1.2.0 but the latest release is 1.3.0
```

The guard from #176 is correct; nothing had told the release to bump them. `prepare-release` updates the poms, the README and the plugin manifests, and the examples were never added — this is the first release since that guard landed, so it is the first time it bites.

Fixed on both sides: the three examples move to 1.3.0, and the bump step now covers `examples/*/pom.xml` so the next release does it without anyone remembering.

Verified rather than assumed:

- the sed rewrites every matching pom (tested against throwaway files — one that matched nothing would be silently green here);
- `mvn clean package` in `examples/plain-java-jul` succeeds resolving **stacktale 1.3.0 from Maven Central**, so the pin points at something real and the artifacts published yesterday are consumable.

Same family as the `outputTimestamp` gap fixed in #189 — a file the release has to touch that nobody had told it about. Worth assuming there are more; each one surfaces exactly one release late.