### PR TITLE
test(logback): cover the six XML properties the config test omitted (#126)

### DIFF
--- a/stacktale/src/test/java/io/github/gabrielbbaldez/stacktale/LogbackXmlConfigTest.java
+++ b/stacktale/src/test/java/io/github/gabrielbbaldez/stacktale/LogbackXmlConfigTest.java
@@ -2,6 +2,7 @@ package io.github.gabrielbbaldez.stacktale;
 
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.core.status.Status;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -11,6 +12,7 @@ import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,8 +49,12 @@ class LogbackXmlConfigTest {
                     <captureExceptionFields>true</captureExceptionFields>
                     <redactionEnabled>true</redactionEnabled>
                     <redactPattern>BR\\d{2}-\\d{4}</redactPattern>
+                    <redactionCorrelation>true</redactionCorrelation>
                     <correlationMdcKeys>traceId</correlationMdcKeys>
                     <zone>UTC</zone>
+                    <echoSuppressionMillis>250</echoSuppressionMillis>
+                    <containerLogger>com.acme.container</containerLogger>
+                    <maxReportsPerMinute>50</maxReportsPerMinute>
                   </appender>
                   <root level="INFO">
                     <appender-ref ref="STACKTALE"/>
@@ -70,9 +76,120 @@ class LogbackXmlConfigTest {
                 .withFailMessage("XML-configured appender produced no report file — Joran/setter wiring is broken. Context status: %s",
                         ctx.getStatusManager().getCopyOfStatusList())
                 .isTrue();
+        assertNoJoranComplaints(ctx);
+
         String content = Files.readString(file, StandardCharsets.UTF_8);
         assertThat(content).contains("IllegalStateException: gateway timeout");
         assertThat(content).contains("charging card for order 42");   // story flowed through XML config too
         assertThat(content).contains("← YOUR CODE");                  // appPackages applied
+    }
+
+    /**
+     * The point of this file: a setter-name or type typo must fail here.
+     *
+     * <p>Joran does not throw on an element it cannot bind — it records a WARN or ERROR on
+     * the context and carries on with the property unset. So a test that only asserts on the
+     * report file passes happily while a knob silently does nothing, which is exactly how the
+     * six properties this test used to omit could have rotted unnoticed.
+     *
+     * <p>Asserting on the status list rather than on each property's behaviour also means a
+     * property added later is covered the moment it appears in the XML above, without anyone
+     * having to invent an observable effect for it.
+     */
+    private static void assertNoJoranComplaints(LoggerContext ctx) {
+        List<Status> bad = ctx.getStatusManager().getCopyOfStatusList().stream()
+                .filter(s -> s.getEffectiveLevel() >= Status.WARN)
+                .toList();
+        assertThat(bad)
+                .withFailMessage("Joran could not bind part of the XML — a setter name or type is wrong: %s", bad)
+                .isEmpty();
+    }
+
+    @Test
+    void jsonFormatIsSelectableFromXml(@TempDir Path dir) throws Exception {
+        // `format` is set apart from the block above because it changes the shape of every
+        // line, so it cannot share assertions with the text-format test.
+        Path file = dir.resolve("errors-ai.log");
+        String xml = """
+                <configuration>
+                  <appender name="STACKTALE" class="io.github.gabrielbbaldez.stacktale.logback.StacktaleAppender">
+                    <file>%s</file>
+                    <appPackages>com.acme</appPackages>
+                    <format>json</format>
+                  </appender>
+                  <root level="INFO">
+                    <appender-ref ref="STACKTALE"/>
+                  </root>
+                </configuration>
+                """.formatted(file.toString().replace("\\", "/"));
+
+        configure(xml);
+        ctx.getLogger("com.acme.CheckoutService")
+                .error("charge failed", new IllegalStateException("gateway timeout"));
+
+        assertNoJoranComplaints(ctx);
+        String content = Files.readString(file, StandardCharsets.UTF_8);
+        assertThat(content)
+                .withFailMessage("<format>json</format> did not select the JSON renderer: %s", content)
+                .startsWith("{");
+        assertThat(content).contains("gateway timeout");
+    }
+
+    @Test
+    void emitReportsToLoggerIsSettableFromXml(@TempDir Path dir) throws Exception {
+        // Also apart: this one routes the report back through logback, so it would appear in
+        // the sibling appenders of any test it shared a context with.
+        Path file = dir.resolve("errors-ai.log");
+        String xml = """
+                <configuration>
+                  <appender name="STACKTALE" class="io.github.gabrielbbaldez.stacktale.logback.StacktaleAppender">
+                    <file>%s</file>
+                    <appPackages>com.acme</appPackages>
+                    <emitReportsToLogger>true</emitReportsToLogger>
+                  </appender>
+                  <root level="INFO">
+                    <appender-ref ref="STACKTALE"/>
+                  </root>
+                </configuration>
+                """.formatted(file.toString().replace("\\", "/"));
+
+        configure(xml);
+        ctx.getLogger("com.acme.CheckoutService")
+                .error("charge failed", new IllegalStateException("gateway timeout"));
+
+        assertNoJoranComplaints(ctx);
+        assertThat(Files.readString(file, StandardCharsets.UTF_8)).contains("gateway timeout");
+    }
+
+    @Test
+    void anUnknownPropertyIsReportedByJoran(@TempDir Path dir) throws Exception {
+        // The control. Without this, assertNoJoranComplaints could be passing because Joran
+        // never complains about anything, and every assertion above would be vacuous.
+        Path file = dir.resolve("errors-ai.log");
+        String xml = """
+                <configuration>
+                  <appender name="STACKTALE" class="io.github.gabrielbbaldez.stacktale.logback.StacktaleAppender">
+                    <file>%s</file>
+                    <thisPropertyDoesNotExist>true</thisPropertyDoesNotExist>
+                  </appender>
+                  <root level="INFO">
+                    <appender-ref ref="STACKTALE"/>
+                  </root>
+                </configuration>
+                """.formatted(file.toString().replace("\\", "/"));
+
+        configure(xml);
+
+        assertThat(ctx.getStatusManager().getCopyOfStatusList())
+                .withFailMessage("Joran accepted an unknown property, so the guard above proves nothing")
+                .anyMatch(s -> s.getEffectiveLevel() >= Status.WARN);
+    }
+
+    private void configure(String xml) throws Exception {
+        ctx = new LoggerContext();
+        ctx.setMDCAdapter(MDC.getMDCAdapter());
+        JoranConfigurator joran = new JoranConfigurator();
+        joran.setContext(ctx);
+        joran.doConfigure(new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8)));
     }
 }


### PR DESCRIPTION
Re #126 — the second half of it.

## Scope: why only half

The first half of #126 is **already done on `main`**. `ReportPipelineTest` exists with the four cases the issue lists, and the storm-line gap it describes (`writer.append` throwing at the `STORM_LINE` branch, skipping both `confirmStormLine` and `rollback`) is fixed — the `rollback` now sits in a `finally`, with a comment naming #51. So there was nothing left to add there.

What is still open is the paragraph at the end:

> `LogbackXmlConfigTest.configuresEveryPropertyFromXmlAndReports` omits six knobs — `echoSuppressionMillis`, `containerLogger`, `emitReportsToLogger`, `maxReportsPerMinute`, `format`, `redactionCorrelation` — so a Joran setter-name typo in those would not be caught.

Confirmed: all six were absent from the XML. This PR is that.

## The assertion matters more than the six elements

Adding the elements alone would not actually have fixed the problem, and this is the part worth reviewing.

**Joran does not throw on an element it cannot bind.** It records a WARN on the context and carries on with the property unset. The existing test only reads the report file afterwards — so with a misspelled setter it still finds `gateway timeout` in the log, still passes, and the knob silently does nothing. That is precisely how six properties could sit uncovered without anyone noticing.

So `assertNoJoranComplaints(ctx)` fails on any WARN/ERROR status. That:

- covers **every** property in the XML at once, not just the six
- covers a property added **later**, the moment it appears in the XML, without anyone having to invent an observable effect for it

## Verified the guard is real

Misspelled one property as `echoSupressionMillis` (one `s`) and re-ran:

```
[ERROR] LogbackXmlConfigTest.configuresEveryPropertyFromXmlAndReports:79
  Joran could not bind part of the XML — a setter name or type is wrong:
  [WARN ... Ignoring unknown property [echoSupressionMillis]
   in [io.github.gabrielbbaldez.stacktale.logback.StacktaleAppender]]
```

Restored, and it passes again.

## Two properties get their own test

- **`format`** changes the shape of every line, so it can't share assertions with the text-format block. Its test asserts the output actually `startsWith("{")` — a name-only check would pass even if `setFormat` stopped selecting the JSON renderer.
- **`emitReportsToLogger`** routes reports back through logback, so it would show up in the sibling appenders of any context it shared.

## `anUnknownPropertyIsReportedByJoran` is the control

Without it, `assertNoJoranComplaints` could be passing simply because Joran never complains about anything in this setup — which would make every other use of it vacuous. This test asserts the mechanism fires.

## Verification

`mvn -pl stacktale -am test` → **BUILD SUCCESS**, 128 core tests + 32 module tests, 0 failures. `LogbackXmlConfigTest` itself: 4 run, 0 failures.

## Process note

CONTRIBUTING asks for an issue claim before writing code, and I didn't post one — the work was already done when I read that section, and it seemed worse to claim an issue I'd finished than to just say so here. Happy to follow the claim-first flow on anything further. If someone else has the remaining `ReportPipeline` work in progress, this half is independent of it (different module, different file) and shouldn't collide.