### PR TITLE
chore(deps): stop proposing Quarkus bumps until #193 lands

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,12 @@ updates:
       # Spring Boot 4 is a deliberate major migration, not a routine bump — don't nag.
       - dependency-name: "org.springframework.boot:*"
         update-types: ["version-update:semver-major"]
+      # Paused until #193. Quarkus stopped accepting a runtime @ConfigMapping as a @BuildStep
+      # parameter somewhere after 3.15, so StacktaleProcessor no longer loads and every bump
+      # since has arrived red — #194, #197 and #201, closed unmerged. The version has to move
+      # in the PR that fixes the recorder, next to the matrix leg from #188. Remove this entry
+      # then; leaving it in place after that would silently freeze Quarkus instead.
+      - dependency-name: "io.quarkus:*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
#194, #197 and #201 were the same PR three weeks running, each closed unmerged on the same failure:

```
Failed to load steps from class io.github.gabrielbbaldez.stacktale.quarkus.deployment.StacktaleProcessor
Caused by: Run time configuration cannot be consumed in Build Steps
```

Adding `io.quarkus:*` to `ignore` stops the weekly red PR. The version still has to move — in #193, next to the recorder change that makes it possible, and ideally with the compatibility-matrix leg from #188 so whatever version we land on stays tested.

The comment in the file says to remove this entry when #193 lands, because an `ignore` left behind would freeze Quarkus silently — which is a worse failure than the noisy one it replaces.