### PR TITLE
fix(quarkus): take the runtime config through the recorder, not a build step

### DIFF
--- a/.github/workflows/compat.yml
+++ b/.github/workflows/compat.yml
@@ -31,6 +31,11 @@ jobs:
             args: "-Dspring-boot.version=3.3.13"
           - name: "Spring Boot 3.5"
             args: "-Dspring-boot.version=3.5.6"
+          # 3.15 is the previous LTS, and the version the extension shipped against in 1.3.0.
+          # Worth a leg of its own: the runtime/deployment contract is a build-time API, and
+          # #193 was exactly that contract changing under us between two supported versions.
+          - name: "Quarkus 3.15 (floor)"
+            args: "-Dquarkus.version=3.15.1"
           - name: "JUnit Platform 1.10 (floor)"
             args: "-pl stacktale-core,stacktale-junit -am -Djunit.platform.version=1.10.0 -Djunit.jupiter.version=5.10.0"
     name: ${{ matrix.name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to stacktale are documented here. The format follows
 [SemVer](https://semver.org/). The report format (`st/1`) is versioned independently
 and pinned by golden-file tests.
 
+## [Unreleased]
+
+### Fixed
+
+- **`stacktale-quarkus` did not work on any Quarkus newer than the 3.15 it shipped against.**
+  The build step took the runtime `@ConfigMapping` as a parameter, and Quarkus now refuses
+  that outright — a build step runs at augmentation time, when a run-time value does not
+  exist yet — so `StacktaleProcessor` failed to load and the application did not start. The
+  recorder receives the configuration as a `RuntimeValue` through its constructor instead,
+  which is what the framework's own error message asks for. Verified against 3.15.1, 3.20.0
+  and 3.39.1: the new shape works on all three, so the floor does not move. (#193)
+
+### Changed
+
+- The compatibility matrix gains a **Quarkus 3.15 (floor)** leg, and the README's
+  compatibility table a Quarkus row — checked by `check-readme-compat.sh`, which had no way
+  to read a property the root pom does not define and now takes a module. Without it the
+  row would have been a claim nobody verified. (#188)
+
 ## [1.3.0] — 2026-08-20
 
 Two headline additions. `repro:` turns the top of a report into the call that failed — the

--- a/README.md
+++ b/README.md
@@ -701,6 +701,7 @@ each backed by a passing build:
 | Logback | 1.4+ | 1.6.x |
 | Log4j2 | 2.20+ | 2.26.x |
 | Spring Boot *(starter)* | 3.2+ | 3.5.x |
+| Quarkus *(extension)* | 3.15+ | 3.39.x |
 | JUnit Platform *(stacktale-junit)* | 1.10+ | 6.1.x |
 
 The Spring Boot starter follows Boot's own Logback version (1.5 on Boot 3.4+); the

--- a/scripts/check-readme-compat.sh
+++ b/scripts/check-readme-compat.sh
@@ -14,8 +14,17 @@ cd "$(dirname "$0")/.."
 
 fail=0
 
+# The second argument names a module, for properties the root pom does not define:
+# quarkus.version lives in stacktale-quarkus/pom.xml, so evaluating it at the root
+# answers "null object or invalid expression" and every comparison below would pass
+# against an empty string.
 pom_property() {
-  mvn -q help:evaluate -DforceStdout -Dexpression="$1" 2>/dev/null
+  local expression="$1" module="${2:-}"
+  if [[ -n "$module" ]]; then
+    mvn -q -pl "$module" help:evaluate -DforceStdout -Dexpression="$expression" 2>/dev/null
+  else
+    mvn -q help:evaluate -DforceStdout -Dexpression="$expression" 2>/dev/null
+  fi
 }
 
 # Highest -D<property>=X override exercised by the compat matrix (may be empty).
@@ -37,9 +46,9 @@ major_minor() {
 }
 
 check_row() {
-  local display="$1" pattern="$2" property="$3"
+  local display="$1" pattern="$2" property="$3" module="${4:-}"
   local pom matrix highest table
-  pom="$(pom_property "$property")"
+  pom="$(pom_property "$property" "$module")"
   matrix="$(matrix_max "$property")"
   highest="$(printf '%s\n%s\n' "$pom" "$matrix" | grep -v '^$' | sort -V | tail -n1)"
   table="$(readme_tested_up_to "$pattern")"
@@ -55,6 +64,7 @@ check_row() {
 check_row "Logback" 'Logback \|' "logback.version"
 check_row "Log4j2" 'Log4j2 \|' "log4j2.version"
 check_row "Spring Boot" 'Spring Boot ' "spring-boot.version"
+check_row "Quarkus" 'Quarkus ' "quarkus.version" "stacktale-quarkus"
 check_row "JUnit Platform" 'JUnit Platform ' "junit.platform.version"
 
 # Java: the floor ("17+") tracks the pom's compiler release; "Tested up to"

--- a/stacktale-quarkus/deployment/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleProcessor.java
+++ b/stacktale-quarkus/deployment/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleProcessor.java
@@ -1,6 +1,5 @@
 package io.github.gabrielbbaldez.stacktale.quarkus.deployment;
 
-import io.github.gabrielbbaldez.stacktale.quarkus.runtime.StacktaleConfig;
 import io.github.gabrielbbaldez.stacktale.quarkus.runtime.StacktaleRecorder;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.deployment.Capabilities;
@@ -46,8 +45,8 @@ public class StacktaleProcessor {
      */
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    void install(StacktaleRecorder recorder, StacktaleConfig config, ApplicationArchivesBuildItem archives) {
-        recorder.install(config, deduceAppPackages(archives));
+    void install(StacktaleRecorder recorder, ApplicationArchivesBuildItem archives) {
+        recorder.install(deduceAppPackages(archives));
     }
 
     /**

--- a/stacktale-quarkus/pom.xml
+++ b/stacktale-quarkus/pom.xml
@@ -22,7 +22,7 @@
 
   <properties>
     <!-- The Quarkus platform version this extension is built and tested against. -->
-    <quarkus.version>3.15.1</quarkus.version>
+    <quarkus.version>3.39.1</quarkus.version>
   </properties>
 
   <dependencyManagement>

--- a/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRecorder.java
+++ b/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRecorder.java
@@ -3,6 +3,7 @@ package io.github.gabrielbbaldez.stacktale.quarkus.runtime;
 import io.github.gabrielbbaldez.stacktale.Csv;
 import io.github.gabrielbbaldez.stacktale.ReportPipeline;
 import io.github.gabrielbbaldez.stacktale.jul.StacktaleJulHandler;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 import java.time.DateTimeException;
@@ -27,7 +28,19 @@ import java.util.logging.Logger;
 @Recorder
 public class StacktaleRecorder {
 
-    public void install(StacktaleConfig config, List<String> deducedAppPackages) {
+    private final RuntimeValue<StacktaleConfig> config;
+
+    /**
+     * Quarkus builds the recorder with the runtime configuration and hands it in here. It used to
+     * arrive as a {@code @BuildStep} parameter instead, which newer Quarkus rejects outright —
+     * build steps run at augmentation time, when a run-time value does not exist yet.
+     */
+    public StacktaleRecorder(RuntimeValue<StacktaleConfig> config) {
+        this.config = config;
+    }
+
+    public void install(List<String> deducedAppPackages) {
+        StacktaleConfig config = this.config.getValue();
         if (!config.enabled()) {
             return;
         }


### PR DESCRIPTION
Closes #193. Closes #188.

`stacktale-quarkus` shipped in 1.3.0 against Quarkus 3.15 and does not start on anything newer:

```
Failed to load steps from class ...quarkus.deployment.StacktaleProcessor
Caused by: Run time configuration cannot be consumed in Build Steps,
  use RuntimeValue<...StacktaleConfig> in a @Recorder constructor instead
```

A `@BuildStep` runs at augmentation time, when a run-time value does not exist yet. Quarkus used to allow the parameter and now rejects it. Three dependabot bumps arrived red on this and were closed unmerged (#194, #197, #201).

The recorder takes `RuntimeValue<StacktaleConfig>` in its constructor and reads it in `install`; the build step no longer mentions the config at all.

## The floor does not move, and I measured rather than assumed

| Quarkus | Extension boots, writes a report |
|---|---|
| 3.15.1 — the version 1.3.0 shipped against | yes |
| 3.20.0 — the LTS in between | yes |
| 3.39.1 — current | yes |

So the new shape works on the old version too: what changed upstream was Quarkus refusing the old form, not the new form appearing. Nobody on 3.15 has to move.

The pom pins 3.39.1 and the compatibility matrix gains a **Quarkus 3.15 (floor)** leg — #188's ask, and it belongs in this PR rather than after it, since this is exactly the kind of build-time contract that broke here.

## Two things I checked instead of trusting

**The matrix leg actually overrides the version.** `quarkus.version` lives in the module pom, not the root, so `-Dquarkus.version=3.15.1` could plausibly have been ignored while the leg reported success against 3.39. It is not — the running application says so:

```
powered by Quarkus 3.15.1
```

**The README row is guarded.** Adding a Quarkus row to the compatibility table would have been an unchecked claim: `check-readme-compat.sh` evaluates properties against the root pom, where `quarkus.version` answers `null object or invalid expression` — which compares equal to nothing, so any number in the table would have passed. The script now takes a module for that case, and I confirmed it both ways: it passes on the real numbers and fails with *"Quarkus says 9.99.x but the build tests up to 3.39.1"* when the table is wrong.

The existing `StacktaleExtensionTest` already proves the configuration reaches the recorder — it overrides `stacktale.file` and `stacktale.app-packages` and asserts the report lands at the configured path with `← YOUR CODE`, neither of which happens if the recorder receives an empty config.

Once this lands, the `io.quarkus` entry added to `.github/dependabot.yml` in #202 should come out, so bumps resume.