### PR TITLE
chore(deps): resume Quarkus bumps now that #193 has landed

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,12 +22,6 @@ updates:
       # Spring Boot 4 is a deliberate major migration, not a routine bump — don't nag.
       - dependency-name: "org.springframework.boot:*"
         update-types: ["version-update:semver-major"]
-      # Paused until #193. Quarkus stopped accepting a runtime @ConfigMapping as a @BuildStep
-      # parameter somewhere after 3.15, so StacktaleProcessor no longer loads and every bump
-      # since has arrived red — #194, #197 and #201, closed unmerged. The version has to move
-      # in the PR that fixes the recorder, next to the matrix leg from #188. Remove this entry
-      # then; leaving it in place after that would silently freeze Quarkus instead.
-      - dependency-name: "io.quarkus:*"
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
#202 paused `io.quarkus` while the extension could not start on anything newer than 3.15. #206 fixed the recorder and moved the pin to 3.39.1, so the pause has done its job.

Leaving it would be the worse failure of the two: a weekly red PR is noisy and visible, a frozen dependency is neither. The comment in the file said to remove this when #193 landed, so here it is.

The **group exclusion stays**. Quarkus minors turned out not to be routine — 3.15 → 3.39 broke a build-time contract — so they keep arriving as their own PR instead of inside a batch of six unrelated bumps, where one failure holds the rest hostage.