### PR TITLE
test: check every published JPMS module name against the jar that ships

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Docs example report guard
         if: matrix.java == 21
         run: bash scripts/check-readme-reports.sh
+      # After the build, because it reads the jars' manifests rather than the poms alone —
+      # the point is what actually ships, not what the pom meant to say.
+      - name: JPMS module name guard
+        if: matrix.java == 21
+        run: bash scripts/check-module-names.sh
       - name: Coverage summary
         if: matrix.java == 21
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and pinned by golden-file tests.
 
 ### Changed
 
+- **Every published JPMS module name is checked against the jar that ships it.** The README
+  documented ten and CI verified two — the other eight, including both halves of
+  `stacktale-quarkus` published in 1.3.0, rested on a hand-written pom property. A name is a
+  `requires` directive in someone else's build, so a typo is not fixable after release.
+  `check-module-names.sh` compares the pom property, the manifest of the built jar and the
+  README row, and the README no longer claims more coverage than it has. (#203)
 - The compatibility matrix gains a **Quarkus 3.15 (floor)** leg, and the README's
   compatibility table a Quarkus row — checked by `check-readme-compat.sh`, which had no way
   to read a property the root pom does not define and now takes a module. Without it the

--- a/README.md
+++ b/README.md
@@ -710,7 +710,9 @@ The Spring Boot starter follows Boot's own Logback version (1.5 on Boot 3.4+); t
 ### Java modules (JPMS)
 
 Every jar declares a stable `Automatic-Module-Name`, so stacktale works on the module
-path as well as the classpath — a resolution smoke test in CI pins this:
+path as well as the classpath. CI checks every name in this table against the manifest of
+the jar that ships, and resolves the core and Logback jars together on a real module path
+to prove the packages stay disjoint:
 
 | Artifact | Module name |
 |---|---|

--- a/scripts/check-module-names.sh
+++ b/scripts/check-module-names.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Guard the published JPMS module names.
+#
+# Each module declares `stacktale.module.name`, which the parent pom writes into the jar's
+# manifest as Automatic-Module-Name. Consumers put that string in a `requires` directive, so
+# it is a published API: changing it breaks them, and shipping a typo means shipping a name
+# we cannot take back.
+#
+# The README documents the names in a table and JpmsModulePathIT resolves two of them on the
+# module path; neither notices a typo in the rest. This checks all three agree:
+#
+#   pom property  ==  the jar's Automatic-Module-Name  ==  a row in README.md
+#
+# Reads built jars, so it needs a package first. CI runs it after `mvn verify`.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+version="$(mvn -q help:evaluate -DforceStdout -Dexpression=project.version 2>/dev/null)"
+fail=0
+checked=0
+
+while IFS= read -r pom; do
+  dir="$(dirname "$pom")"
+
+  # `|| true` throughout: the root pom references the property without declaring one, and a
+  # grep that matches nothing exits 1, which `set -e` would take as this script failing.
+  declared="$(grep -oE '<stacktale\.module\.name>[^<]+' "$pom" | sed 's/.*>//' || true)"
+  [ -z "$declared" ] && continue
+
+  # Drop <parent> first: its artifactId precedes the module's own, so a plain first-match
+  # grep names the parent and every jar path built from it points at nothing.
+  artifact="$(sed '/<parent>/,/<\/parent>/d' "$pom" \
+    | grep -m1 -oE '<artifactId>[^<]+' | sed 's/.*>//' || true)"
+
+  jar="$dir/target/$artifact-$version.jar"
+  if [ ! -f "$jar" ]; then
+    echo "check-module-names: $artifact has no jar at $jar — package first" >&2
+    fail=1
+    continue
+  fi
+
+  # The manifest wraps at 72 bytes and continues on the next line with a leading space, and
+  # these names reach it: the quarkus jars carry '...quarkus.runtim' then ' e'. Unfold before
+  # reading, or every long name looks truncated and the check cries wolf.
+  manifest="$(unzip -p "$jar" META-INF/MANIFEST.MF | tr -d '\r' \
+    | awk '{ if (substr($0,1,1) == " ") printf "%s", substr($0,2); else printf "\n%s", $0 } END { print "" }' \
+    | grep -m1 '^Automatic-Module-Name:' | sed 's/^Automatic-Module-Name: *//' || true)"
+
+  if [ "$manifest" != "$declared" ]; then
+    echo "check-module-names: $artifact declares '$declared' but its jar says '$manifest'" >&2
+    fail=1
+  fi
+
+  if ! grep -qF "\`$declared\`" README.md; then
+    echo "check-module-names: $artifact publishes '$declared', absent from the README table" >&2
+    fail=1
+  fi
+
+  checked=$((checked + 1))
+done < <(grep -rl "stacktale.module.name" --include=pom.xml . | grep -v "/target/")
+
+if [ "$fail" -eq 0 ]; then
+  echo "module names agree across pom, jar manifest and README ($checked modules)"
+fi
+
+exit "$fail"


### PR DESCRIPTION
Closes #203.

The README documents ten module names. `JpmsModulePathIT` resolves two of them. The other eight — including both halves of `stacktale-quarkus`, published in 1.3.0 three weeks ago — came from a hand-written `stacktale.module.name` property that nothing checked.

That matters more than an ordinary typo: a module name is a `requires` directive in someone else's build. Once a jar carrying the wrong one is on Central, correcting it is a breaking change for anyone who already wrote the `requires`.

`scripts/check-module-names.sh` compares three sources that can disagree:

```
pom property  ==  the jar's Automatic-Module-Name  ==  a row in README.md
```

It runs in CI after the build, since the point is what actually ships rather than what the pom meant to say.

## It fails when a name is wrong

Misspelled `stacktale-jul`'s as `...stacktale.juul`, rebuilt that module:

```
check-module-names: stacktale-jul publishes 'io.github.gabrielbbaldez.stacktale.juul',
  absent from the README table
exit 1
```

Worth noting *which* comparison caught it. A typo in the pom propagates into the manifest, so those two agree and only the README disagrees — which is why the table is in the check at all rather than the script deriving everything from the poms.

## Two bugs in my own first draft, both found by running it

- A first-match `grep` for `<artifactId>` names the **parent**, so every jar path was built from `stacktale-parent` and nothing was found.
- Manifest lines wrap at 72 bytes and continue with a leading space. Both Quarkus names are long enough to hit it, so the check read `...quarkus.runtim` and `...quarkus.deploy` and reported two defects that did not exist. It unfolds the manifest now.

The README sentence changed too: it promised "a resolution smoke test in CI pins this" above a ten-row table, which was the overclaim this issue was about. It now says what is true — every name checked against its jar, and core plus Logback resolved together on a real module path for the split-package guarantee.