### PR TITLE
fix: let `repro` be turned on from Logback, the starter and Quarkus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to stacktale are documented here. The format follows
 [SemVer](https://semver.org/). The report format (`st/1`) is versioned independently
 and pinned by golden-file tests.
 
+## [Unreleased]
+
+### Fixed
+
+- **`repro` could not be turned on from Logback, the Spring Boot starter or Quarkus.** The
+  configuration table offers it "as appender properties in `logback.xml`, or `stacktale.*` in
+  `application.yml`", and only Log4j2 and JUL ever read it: the Logback appender held the
+  field and passed it to the builder but had no setter, the starter drives that appender and
+  had no property, and the Quarkus mapping had no method. All three fail silently — Joran logs
+  `Ignoring unknown property [repro]`, `@ConfigurationProperties` drops unknown fields, Quarkus
+  warns and starts — so the knob looked set and the `repro:` section simply never appeared.
+  (#210)
+
+### Changed
+
+- The tests that guard those three surfaces now fail when a knob stops arriving, rather than
+  when it stops binding. `everyPropertyReachesTheAppender` asserted on the properties bean, so
+  a value that bound and was then never passed to the appender read as covered — which is the
+  exact shape of the bug above. `LogbackXmlConfigTest` also picks up `appName` and `appVersion`,
+  settable since #150 and named in no test in the module. (#210)
+
 ## [1.3.1] — 2026-09-03
 
 ### Fixed

--- a/stacktale-quarkus/deployment/src/test/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleExtensionTest.java
+++ b/stacktale-quarkus/deployment/src/test/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleExtensionTest.java
@@ -1,5 +1,6 @@
 package io.github.gabrielbbaldez.stacktale.quarkus.deployment;
 
+import io.github.gabrielbbaldez.stacktale.quarkus.runtime.StacktaleConfig;
 import io.quarkus.test.QuarkusUnitTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -24,7 +25,11 @@ class StacktaleExtensionTest {
     static final QuarkusUnitTest APP = new QuarkusUnitTest()
             .overrideConfigKey("stacktale.file", REPORT.toString())
             .overrideConfigKey("stacktale.truncate-on-start", "true")
-            .overrideConfigKey("stacktale.app-packages", "io.github.gabrielbbaldez.stacktale.quarkus");
+            .overrideConfigKey("stacktale.app-packages", "io.github.gabrielbbaldez.stacktale.quarkus")
+            .overrideConfigKey("stacktale.repro", "true");
+
+    @jakarta.inject.Inject
+    StacktaleConfig config;
 
     @Test
     void severeLogWithThrowableBecomesAnAiReport() throws Exception {
@@ -36,6 +41,19 @@ class StacktaleExtensionTest {
         assertContains(report, "IllegalStateException");
         assertContains(report, "customer cache returned null");
         assertContains(report, "← YOUR CODE");
+    }
+
+    /**
+     * A {@code stacktale.*} key with no method behind it does not fail a build — Quarkus logs
+     * "Unrecognized configuration key" and starts — so an override alone proves nothing. Ask
+     * the mapping for the value instead: a missing method is a compile error here.
+     *
+     * <p>{@code repro} needs no agent to be asserted this way, which is the point: the seed is
+     * optional extra content, the configuration path is not.
+     */
+    @Test
+    void reproIsBoundFromConfiguration() {
+        assertTrue(config.repro(), "stacktale.repro=true did not reach StacktaleConfig");
     }
 
     private static void assertContains(String haystack, String needle) {

--- a/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleConfig.java
+++ b/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleConfig.java
@@ -60,6 +60,14 @@ public interface StacktaleConfig {
     @WithDefault("true")
     boolean captureExceptionFields();
 
+    /**
+     * Add a {@code repro:} seed — the throw site's typed signature and argument values. Needs
+     * {@code stacktale-agent} on the command line; without it the seed resolves to nothing and
+     * the section is simply absent.
+     */
+    @WithDefault("false")
+    boolean repro();
+
     /** Redact secrets (tokens, passwords, emails, …) from reports. */
     @WithDefault("true")
     boolean redactionEnabled();

--- a/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRecorder.java
+++ b/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRecorder.java
@@ -61,6 +61,7 @@ public class StacktaleRecorder {
                 .truncateOnStart(config.truncateOnStart())
                 .reportErrorsWithoutThrowable(config.reportErrorsWithoutThrowable())
                 .captureExceptionFields(config.captureExceptionFields())
+                .repro(config.repro())
                 .redactionEnabled(config.redactionEnabled())
                 .redactPatterns(compilePatterns(config.redactPatterns().orElse(List.of())))
                 .redactionCorrelation(config.redactionCorrelation())

--- a/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleAutoConfiguration.java
+++ b/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleAutoConfiguration.java
@@ -79,6 +79,7 @@ public class StacktaleAutoConfiguration {
         appender.setInstallUncaughtHandler(props.isInstallUncaughtHandler());
         appender.setReportErrorsWithoutThrowable(props.isReportErrorsWithoutThrowable());
         appender.setCaptureExceptionFields(props.isCaptureExceptionFields());
+        appender.setRepro(props.isRepro());
         appender.setRedactionEnabled(props.isRedactionEnabled());
         props.getRedactPatterns().forEach(appender::addRedactPattern);
         appender.setRedactionCorrelation(props.isRedactionCorrelation());

--- a/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleProperties.java
+++ b/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleProperties.java
@@ -46,6 +46,9 @@ public class StacktaleProperties {
     /** Read state from the root-cause exception's getters into a fields: section. */
     private boolean captureExceptionFields = true;
 
+    /** Add a repro: seed — the throw site's typed signature and argument values. Needs stacktale-agent. */
+    private boolean repro = false;
+
     /** Mask secrets/PII (JWTs, bearer tokens, key=value secrets, emails, cards). */
     private boolean redactionEnabled = true;
 
@@ -106,6 +109,8 @@ public class StacktaleProperties {
     public void setReportErrorsWithoutThrowable(boolean reportErrorsWithoutThrowable) { this.reportErrorsWithoutThrowable = reportErrorsWithoutThrowable; }
     public boolean isCaptureExceptionFields() { return captureExceptionFields; }
     public void setCaptureExceptionFields(boolean captureExceptionFields) { this.captureExceptionFields = captureExceptionFields; }
+    public boolean isRepro() { return repro; }
+    public void setRepro(boolean repro) { this.repro = repro; }
     public boolean isRedactionEnabled() { return redactionEnabled; }
     public void setRedactionEnabled(boolean redactionEnabled) { this.redactionEnabled = redactionEnabled; }
     public List<String> getRedactPatterns() { return redactPatterns; }

--- a/stacktale-spring-boot-starter/src/test/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleAutoConfigurationTest.java
+++ b/stacktale-spring-boot-starter/src/test/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleAutoConfigurationTest.java
@@ -48,6 +48,7 @@ class StacktaleAutoConfigurationTest {
                 "stacktale.file=target/props-test.log",
                 "stacktale.max-reports-per-minute=42",
                 "stacktale.story-size=7",
+                "stacktale.repro=true",
                 "stacktale.emit-reports-to-logger=true").run(context -> {
             io.github.gabrielbbaldez.stacktale.spring.StacktaleProperties props =
                     context.getBean(io.github.gabrielbbaldez.stacktale.spring.StacktaleProperties.class);
@@ -55,7 +56,28 @@ class StacktaleAutoConfigurationTest {
             assertThat(props.getStorySize()).isEqualTo(7);
             assertThat(props.isEmitReportsToLogger()).isTrue();
             assertThat(context).hasSingleBean(StacktaleAppender.class);
+
+            // The name promises the appender but the assertions above stop at the properties
+            // bean, so a property that binds and is then never passed on reads as covered.
+            // That is precisely how `repro` stayed a no-op for starter users: declared in the
+            // table, absent from this class AND from the wiring below it.
+            assertThat(appenderFlag(context.getBean(StacktaleAppender.class), "repro"))
+                    .withFailMessage("stacktale.repro bound but never reached the appender — "
+                            + "the setter call is missing from StacktaleAutoConfiguration")
+                    .isTrue();
         });
+    }
+
+    /**
+     * The appender is a Logback config object: setters only, no getters, and in another
+     * package. Reading the field is the only way to assert a knob arrived, and it is worth the
+     * reflection — the alternative is asserting on behaviour, which for an opt-in extra like
+     * {@code repro} means attaching stacktale-agent to the test JVM.
+     */
+    private static boolean appenderFlag(StacktaleAppender appender, String field) throws Exception {
+        java.lang.reflect.Field f = StacktaleAppender.class.getDeclaredField(field);
+        f.setAccessible(true);
+        return f.getBoolean(appender);
     }
 
     @Test

--- a/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
+++ b/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
@@ -325,6 +325,13 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
 
     public void setCaptureExceptionFields(boolean captureExceptionFields) { this.captureExceptionFields = captureExceptionFields; }
 
+    /**
+     * Opt-in: render the throw site's typed signature and argument values as a {@code repro:}
+     * section. Needs {@code stacktale-agent} on the command line; without it the seed resolves
+     * to nothing and the section is simply absent.
+     */
+    public void setRepro(boolean repro) { this.repro = repro; }
+
     public void setRedactionEnabled(boolean redactionEnabled) { this.redactionEnabled = redactionEnabled; }
 
     /** Joran calls this once per {@code <redactPattern>} element in logback.xml. */

--- a/stacktale/src/test/java/io/github/gabrielbbaldez/stacktale/LogbackXmlConfigTest.java
+++ b/stacktale/src/test/java/io/github/gabrielbbaldez/stacktale/LogbackXmlConfigTest.java
@@ -37,6 +37,8 @@ class LogbackXmlConfigTest {
                 <configuration>
                   <appender name="STACKTALE" class="io.github.gabrielbbaldez.stacktale.logback.StacktaleAppender">
                     <file>%s</file>
+                    <appName>checkout-api</appName>
+                    <appVersion>9.9.9</appVersion>
                     <appPackages>com.acme</appPackages>
                     <storySize>10</storySize>
                     <storyWindowSeconds>30</storyWindowSeconds>
@@ -47,6 +49,7 @@ class LogbackXmlConfigTest {
                     <installUncaughtHandler>false</installUncaughtHandler>
                     <reportErrorsWithoutThrowable>true</reportErrorsWithoutThrowable>
                     <captureExceptionFields>true</captureExceptionFields>
+                    <repro>true</repro>
                     <redactionEnabled>true</redactionEnabled>
                     <redactPattern>BR\\d{2}-\\d{4}</redactPattern>
                     <redactionCorrelation>true</redactionCorrelation>
@@ -82,6 +85,13 @@ class LogbackXmlConfigTest {
         assertThat(content).contains("IllegalStateException: gateway timeout");
         assertThat(content).contains("charging card for order 42");   // story flowed through XML config too
         assertThat(content).contains("← YOUR CODE");                  // appPackages applied
+        assertThat(content).contains("app=checkout-api 9.9.9");        // appName + appVersion reached EnvCollector
+
+        // `repro` is in the block above for the binding check, and there is nothing further to
+        // assert here: the seed comes from stacktale-agent, and with no agent attached it
+        // resolves to null and the section is correctly absent. What must not happen is a
+        // *report* — the knob is opt-in extra content, not a switch that can suppress one.
+        assertThat(content).contains("ERROR #");
     }
 
     /**


### PR DESCRIPTION
Closes #210.

`repro` is in the configuration table, which is introduced as "appender properties in
`logback.xml`, or `stacktale.*` in `application.yml` with the starter". Neither of those two
could set it — only Log4j2 and JUL read the property at all.

The field was already in the Logback appender and already passed to the builder; only the
setter was missing, so every Logback user was pinned to `false`. The starter drives that same
appender through its setters, so it inherited the gap and had no property of its own. Quarkus
builds `Settings` itself and never mentioned `repro`.

## Why it survived

Each of the three fails *silently*, which is the part worth fixing rather than documenting:

```
WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler -
  Ignoring unknown property [repro] in [...logback.StacktaleAppender]
```

That is Joran's whole reaction to `<repro>true</repro>` — a status line nobody reads, and the
appender starts fine. `@ConfigurationProperties` drops unknown fields by default; Quarkus logs
`Unrecognized configuration key` and boots. The user sets the knob, sees no error, and gets no
`repro:` section.

## Each test was run against the un-fixed code

A guard that has never been red is a guess, so each of the three was checked by removing the
line it guards:

| removed | result |
|---|---|
| `StacktaleAppender.setRepro` | `AssertionError: Joran could not bind part of the XML — a setter name or type is wrong: [Ignoring unknown property [repro]]` |
| `appender.setRepro(props.isRepro())` in the auto-configuration | `AssertionFailedError: stacktale.repro bound but never reached the appender` |
| `StacktaleConfig.repro()` | `cannot find symbol: method repro()` — the deployment tests stop compiling |

The Spring one is the interesting case. `everyPropertyReachesTheAppender` asserted on the
properties bean, never on the appender, so a property that bound and was then never passed on
read as fully covered — which is exactly the half of this bug that lives in the starter. It now
reads the value back off the appender; the appender is a Logback config object with setters and
no getters, in another package, so that is a reflective field read, with the reasoning in a
comment.

Turning `repro` on without `stacktale-agent` attached is not an error — the seed resolves to
`null` and the section is absent — so none of these tests need the agent, and none of them
assert on report content.

While in `LogbackXmlConfigTest`: `appName` and `appVersion` have been settable since #150 and
appeared in no test in that module. They are in the XML block now, asserted through the env
line (`app=checkout-api 9.9.9`) rather than through binding alone.

`mvn -B verify` on the full reactor: 467 tests, 0 failures, 1 skipped — `MemorySoakTest`, which
is opt-in behind `-Dstacktale.soak=true` and skipped on main too.

## Still open after this

The three adapters were compared by hand for this fix, and `repro` was the only knob missing
anywhere. Nothing stops the next one from drifting the same way, so that guard is #211.
