### PR TITLE
infra: keep the five adapters' configuration surfaces in step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Docs example report guard
         if: matrix.java == 21
         run: bash scripts/check-readme-reports.sh
+      - name: Config parity guard
+        if: matrix.java == 21
+        run: bash scripts/check-config-parity.sh
       # After the build, because it reads the jars' manifests rather than the poms alone —
       # the point is what actually ships, not what the pom meant to say.
       - name: JPMS module name guard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and pinned by golden-file tests.
 
 ## [Unreleased]
 
+### Added
+
+- **A guard that keeps the five adapters' configuration surfaces in step.**
+  `check-config-parity.sh` reads the README's configuration table and asserts each knob is
+  reachable from Logback, Log4j2, JUL, the Spring starter and Quarkus — matching the shape
+  that makes it *settable* in each, so a private field nobody can set does not count. Run
+  against the commit before the fix below, it names those three gaps and nothing else.
+  Deliberate absences are listed with their reason: an undocumented gap and a bug are
+  otherwise indistinguishable. (#211)
+
 ### Fixed
 
 - **`repro` could not be turned on from Logback, the Spring Boot starter or Quarkus.** The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,16 @@ CI also runs `scripts/check-readme-compat.sh`, which fails when the README's
 the build actually tests — the pom properties and the `compat.yml` matrix. If
 that check fails after a dependency bump, update the table in `README.md`.
 
+`scripts/check-config-parity.sh` guards the other README table. One knob is one
+row and five unrelated pieces of syntax — a Logback setter, a Log4j2
+`@PluginBuilderAttribute`, a JUL LogManager property, a read in the Spring
+auto-configuration, a method on the Quarkus mapping — and none of the five
+complains when a knob is missing from it, so a new property tends to reach one
+adapter and stop. If you add a row to the table, expect this to name the
+adapters you have not reached yet. When an absence is deliberate, say why in the
+script's `allowed()` list rather than dropping the row; an undocumented gap and
+a bug look identical from the outside.
+
 Markdown links are checked too, by `.github/workflows/links.yml`:
 
 - **On every PR**, `lychee --offline` verifies the *relative* links in every

--- a/scripts/check-config-parity.sh
+++ b/scripts/check-config-parity.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Guard the configuration surface across the five adapters.
+#
+# One knob is one row in the README's configuration table, and five unrelated pieces of
+# syntax: a setter on the Logback appender, a @PluginBuilderAttribute field in Log4j2, a
+# LogManager property in JUL, an accessor read by the Spring auto-configuration, a method on
+# the Quarkus @ConfigMapping. Nothing connects them, so they drift one at a time — and every
+# way of drifting is silent. Joran logs `Ignoring unknown property`, @ConfigurationProperties
+# drops unknown fields, Quarkus warns and boots. The user sets the knob, sees no error, and
+# gets no behaviour (#210: `repro` reached only Log4j2 and JUL, for four releases).
+#
+# What is checked is *reachability*, not merely that the name appears: each adapter is matched
+# on the shape that makes a knob settable — a setter, an attribute declaration, a property
+# read, a wiring call. A private field nobody can set does not count, which is exactly the
+# state #210 was in.
+#
+# Not checked, deliberately: `appName` and `appVersion` are settable on the Logback appender
+# and nowhere else, and have no README row. Everywhere else the name is derived — Spring Boot
+# from spring.application.name (#150), Log4j2 and JUL from the stacktale.app.* system
+# properties or META-INF/build-info.properties. Adding rows for them would make this script
+# demand four surfaces that should not exist. (Quarkus derives nothing today and reports
+# `app=?`; that is #213, a missing feature rather than a knob that drifted.)
+#
+# Source only, no build needed.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+LOGBACK="stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java"
+LOG4J2="stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java"
+JUL="stacktale-jul/src/main/java/io/github/gabrielbbaldez/stacktale/jul/StacktaleJulHandler.java"
+SPRING="stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleAutoConfiguration.java"
+QUARKUS="stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRecorder.java"
+
+# Deliberate absences. Every entry is a decision someone made; anything not listed here and not
+# found is a bug. Keeping them explicit is the point — today an accidental gap and an
+# intentional one look identical from the outside.
+allowed() {
+  case "$1:$2" in
+    jul:correlationMdcKeys)
+      echo "JUL has no MDC" ;;
+    logback:enabled|log4j2:enabled|jul:enabled)
+      echo "master switch belongs to the framework integrations; a raw appender is removed, not disabled" ;;
+    logback:requestLogging|log4j2:requestLogging|jul:requestLogging)
+      echo "HTTP request lines come from a servlet/reactive filter the plain appenders have no access to" ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+# The README is the contract, so the knob list comes from it rather than from a list kept here
+# that could drift the same way the adapters did.
+knobs="$(sed -n '/^| Property | Default | What it does |/,/^$/p' README.md \
+  | grep -oE '^\| `[a-zA-Z.]+`' | tr -d '|` ' | sed 's/^stacktale\.//' || true)"
+
+if [ -z "$knobs" ]; then
+  echo "check-config-parity: found no configuration table in README.md" >&2
+  exit 1
+fi
+
+fail=0
+checked=0
+skipped=0
+
+for knob in $knobs; do
+  # Setter/accessor spelling: repro -> Repro, redactPattern -> RedactPattern.
+  cap="$(printf '%s' "${knob:0:1}" | tr '[:lower:]' '[:upper:]')${knob:1}"
+  # Spring reads two knobs through @ConditionalOnProperty, which names them in kebab-case.
+  kebab="$(printf '%s' "$knob" | sed 's/\([A-Z]\)/-\L\1/g')"
+
+  for adapter in logback log4j2 jul spring quarkus; do
+    case "$adapter" in
+      # A field is not a knob: match the setter, which is what #210 was missing.
+      logback) file="$LOGBACK";  pattern="(set|add)${cap}s?\(" ;;
+      log4j2)  file="$LOG4J2";   pattern="@PluginBuilderAttribute[^;]*\b${knob}s?\b" ;;
+      # `installUncaughtHandler` is read as class.getName() + ".installUncaughtHandler",
+      # not through the `p + "…"` helper — hence the optional leading dot.
+      jul)     file="$JUL";      pattern="\"\.?${knob}s?\"" ;;
+      # The auto-configuration, not the properties class: a property that binds and is never
+      # passed to the appender is the other half of #210.
+      spring)  file="$SPRING";   pattern="props\.(is|get)${cap}s?\(|name = \"${kebab}\"" ;;
+      quarkus) file="$QUARKUS";  pattern="config\.${knob}s?\(" ;;
+    esac
+
+    if [ ! -f "$file" ]; then
+      echo "check-config-parity: $adapter source missing at $file" >&2
+      fail=1
+      continue
+    fi
+
+    if grep -qE "$pattern" "$file"; then
+      checked=$((checked + 1))
+    elif reason="$(allowed "$adapter" "$knob")"; then
+      skipped=$((skipped + 1))
+      : "$reason"
+    else
+      echo "check-config-parity: '$knob' is in the README table but $adapter cannot set it" >&2
+      echo "                    ($file has no match for /$pattern/)" >&2
+      fail=1
+    fi
+  done
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "configuration knobs reachable from every adapter ($checked pairs, $skipped documented exceptions)"
+fi
+
+exit "$fail"


### PR DESCRIPTION
Closes #211.

#210 was a README knob that two of the five adapters could not set, and it was found by reading
five config classes side by side — not something that happens on a schedule. This is the guard
that would have found it the day it appeared.

## What it checks

Reachability, not presence. Each adapter is matched on the shape that makes a knob *settable*,
because a private field nobody can set is exactly the state `repro` was in for four releases:

| adapter | matched on |
|---|---|
| Logback | `set…`/`add…` on the appender — the field alone does not count |
| Log4j2 | the `@PluginBuilderAttribute` declaration |
| JUL | the LogManager property name |
| Spring Boot | the read in `StacktaleAutoConfiguration` — a property that binds and is never passed on is the other half of #210 |
| Quarkus | the call in `StacktaleRecorder#install` |

The knob list comes from the README table rather than from a list kept in the script, which
could drift the same way the adapters did.

## Run against the commit before the fix

The strongest thing I can say about it: on `3fec4ad`, the parent of #212, the script reports

```
check-config-parity: 'repro' is in the README table but logback cannot set it
check-config-parity: 'repro' is in the README table but spring cannot set it
check-config-parity: 'repro' is in the README table but quarkus cannot set it
```

Three lines, exactly the three gaps found by hand, and nothing else across 24 knobs × 5
adapters. No false positives to tune away.

Then, on this branch, three separate injections — one per adapter shape — each restored after:

| injected | reported |
|---|---|
| `setCaptureExceptionFields` → `setCaptureFields` | `'captureExceptionFields' … logback cannot set it` |
| `appender.setFormat(props.getFormat())` deleted | `'format' … spring cannot set it` |
| `p + "maxBackups"` → `p + "maxBackup"` | `'maxBackups' … jul cannot set it` |

Clean tree: `configuration knobs reachable from every adapter (113 pairs, 7 documented exceptions)`.

## The exceptions are the point

Seven pairs are absent on purpose and each says why in `allowed()`: JUL has no MDC, so no
`correlationMdcKeys`; the master switch and the request filter belong to the two framework
integrations and mean nothing to a raw appender. Anything not listed and not found fails the
build — today a deliberate gap and a bug look identical from the outside, which is how #210
lasted.

## Two decisions it forced

- `appName`/`appVersion` are settable on the Logback appender and nowhere else, with no README
  row. Everywhere else the name is derived — Spring from `spring.application.name` (#150),
  Log4j2 and JUL from `stacktale.app.*` or `build-info.properties` — so giving them rows would
  make the script demand four surfaces that should not exist. Left out of the table, with the
  reasoning in the script header rather than nowhere.
- Quarkus derives nothing, and its reports say `env: app=?` — from the extension's own test
  output. That is a missing feature rather than a knob that drifted, so it is #213.
