### PR TITLE
fix(quarkus): name the application in the env line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,20 @@ and pinned by golden-file tests.
   `check-config-parity.sh` reads the README's configuration table and asserts each knob is
   reachable from Logback, Log4j2, JUL, the Spring starter and Quarkus — matching the shape
   that makes it *settable* in each, so a private field nobody can set does not count. Run
-  against the commit before the fix below, it names those three gaps and nothing else.
+  against the commit before #212, it names those three `repro` gaps and nothing else.
   Deliberate absences are listed with their reason: an undocumented gap and a bug are
   otherwise indistinguishable. (#211)
 
 ### Fixed
 
+- **Every Quarkus report said `env: app=?`.** Quarkus knows the application name and version —
+  `quarkus.application.*`, defaulted from the artifact's coordinates — and the extension never
+  asked, so `EnvCollector` fell through to its two fallbacks: a Spring Boot artifact
+  (`build-info.properties`) and a system property nobody sets. The values now come from
+  `ApplicationInfoBuildItem` at build time, which is where Quarkus fixes them, and travel to
+  the recorder beside the deduced app packages. Which service is on fire is the first thing on
+  that line, and it is the field that matters when several services' reports land in one place
+  for an agent to read. (#213)
 - **`repro` could not be turned on from Logback, the Spring Boot starter or Quarkus.** The
   configuration table offers it "as appender properties in `logback.xml`, or `stacktale.*` in
   `application.yml`", and only Log4j2 and JUL ever read it: the Logback appender held the

--- a/stacktale-quarkus/deployment/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleProcessor.java
+++ b/stacktale-quarkus/deployment/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleProcessor.java
@@ -8,6 +8,7 @@ import io.quarkus.deployment.annotations.BuildStep;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.ApplicationArchivesBuildItem;
+import io.quarkus.deployment.builditem.ApplicationInfoBuildItem;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.RuntimeInitializedClassBuildItem;
 import io.quarkus.deployment.pkg.steps.NativeOrNativeSourcesBuild;
@@ -45,8 +46,19 @@ public class StacktaleProcessor {
      */
     @BuildStep
     @Record(ExecutionTime.RUNTIME_INIT)
-    void install(StacktaleRecorder recorder, ApplicationArchivesBuildItem archives) {
-        recorder.install(deduceAppPackages(archives));
+    void install(StacktaleRecorder recorder, ApplicationArchivesBuildItem archives,
+                 ApplicationInfoBuildItem app) {
+        recorder.install(deduceAppPackages(archives), named(app.getName()), named(app.getVersion()));
+    }
+
+    /**
+     * {@code quarkus.application.name} and {@code .version} default to the artifact's
+     * coordinates, but a build that sets neither leaves the literal {@code <<unset>>} here.
+     * Passing that through would put it in every report's {@code env:} line; an empty string
+     * lets {@code EnvCollector} fall back the way it does for every other adapter.
+     */
+    private static String named(String value) {
+        return value == null || ApplicationInfoBuildItem.UNSET_VALUE.equals(value) ? "" : value;
     }
 
     /**

--- a/stacktale-quarkus/deployment/src/test/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleExtensionTest.java
+++ b/stacktale-quarkus/deployment/src/test/java/io/github/gabrielbbaldez/stacktale/quarkus/deployment/StacktaleExtensionTest.java
@@ -26,7 +26,9 @@ class StacktaleExtensionTest {
             .overrideConfigKey("stacktale.file", REPORT.toString())
             .overrideConfigKey("stacktale.truncate-on-start", "true")
             .overrideConfigKey("stacktale.app-packages", "io.github.gabrielbbaldez.stacktale.quarkus")
-            .overrideConfigKey("stacktale.repro", "true");
+            .overrideConfigKey("stacktale.repro", "true")
+            .overrideConfigKey("quarkus.application.name", "checkout-api")
+            .overrideConfigKey("quarkus.application.version", "9.9.9");
 
     @jakarta.inject.Inject
     StacktaleConfig config;
@@ -41,6 +43,22 @@ class StacktaleExtensionTest {
         assertContains(report, "IllegalStateException");
         assertContains(report, "customer cache returned null");
         assertContains(report, "← YOUR CODE");
+    }
+
+    /**
+     * Which service is on fire is the first thing on the {@code env:} line, and it read
+     * {@code app=?} for every Quarkus application: the extension never asked, and the two
+     * fallbacks EnvCollector has are a Spring Boot artifact (build-info.properties) and a
+     * system property nobody sets. Quarkus fixes {@code quarkus.application.*} at build time,
+     * so the values come from {@code ApplicationInfoBuildItem} rather than a config read at
+     * startup — same as the deduced app packages beside them.
+     */
+    @Test
+    void theEnvLineNamesTheQuarkusApplication() throws Exception {
+        Logger.getLogger(StacktaleExtensionTest.class.getName())
+                .log(Level.SEVERE, "Failed to price order 1001", new IllegalStateException("no rate"));
+
+        assertContains(awaitReport(), "app=checkout-api 9.9.9");
     }
 
     /**

--- a/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRecorder.java
+++ b/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRecorder.java
@@ -39,7 +39,7 @@ public class StacktaleRecorder {
         this.config = config;
     }
 
-    public void install(List<String> deducedAppPackages) {
+    public void install(List<String> deducedAppPackages, String appName, String appVersion) {
         StacktaleConfig config = this.config.getValue();
         if (!config.enabled()) {
             return;
@@ -52,6 +52,12 @@ public class StacktaleRecorder {
 
         ReportPipeline.Settings settings = ReportPipeline.Settings.builder()
                 .appPackages(appPackages)
+                // Resolved at build time from quarkus.application.*, which Quarkus fixes at
+                // build time anyway. Without them every report read `env: app=?`, because the
+                // fallbacks EnvCollector has are a Spring Boot artifact (build-info.properties)
+                // and a system property nobody sets.
+                .appName(appName)
+                .appVersion(appVersion)
                 .file(config.file())
                 .storySize(config.storySize())
                 .storyWindowMillis(config.storyWindowSeconds() * 1000L)


### PR DESCRIPTION
Closes #213.

Found while writing the parity guard in #214: the extension's own test report read

```
env: app=? | java 21.0.6 | windows
```

Quarkus knows the answer. `quarkus.application.name` and `.version` are standard config,
defaulted from the artifact's coordinates, and the extension never asked — so `EnvCollector`
fell through to the two fallbacks it has, `META-INF/build-info.properties` (a Spring Boot
artifact) and a system property nobody sets.

That is the field that says which service is on fire, and stacktale is aimed at exactly the
case where several services' reports land in one place for an agent to read.

## Build time, not a runtime read

The issue suggested `ConfigProvider.getConfig()` inside the recorder. `ApplicationInfoBuildItem`
is better and is what shipped: Quarkus fixes `quarkus.application.*` at build time, so reading
it there matches the framework's own semantics and keeps the value out of a native image's
startup path. It also travels the same way the deduced app packages already do — one more
build-time argument to `StacktaleRecorder#install` — rather than introducing a second
configuration mechanism next to `@ConfigMapping`.

## Verified

Test written to fail first. With the wiring removed from the recorder:

```
StacktaleExtensionTest.theEnvLineNamesTheQuarkusApplication:61->assertContains:78
  expected report to contain "app=checkout-api 9.9.9"
```

and with it in place, from `target/errors-ai-test.log`:

```
env: app=checkout-api 9.9.9 | java 21.0.6 | windows
```

Three tests in the module, all green.

I also ran it once with both overrides removed, to see what an application that configures
nothing now reports:

```
env: app=stacktale-quarkus-deployment 1.4.0-SNAPSHOT | java 21.0.6 | windows
```

Quarkus fills in the artifact's coordinates, so the zero-config case improves too. The
`<<unset>>` guard in `named()` did not fire in that run — it is defensive, for builds where
Quarkus resolves no name at all, and I am not claiming it was exercised.
