### PR TITLE
fix(format): carry the `repro` seed in st-json/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,22 @@ and pinned by golden-file tests.
   Deliberate absences are listed with their reason: an undocumented gap and a bug are
   otherwise indistinguishable. (#211)
 
+### Changed
+
+- `docs/FORMAT.md` files the `repro:` section under **§3 Report block** and gives it a row in
+  that section's field table. It was a subsection of §5 *Non-report entries*, next to
+  `repeated`, `app start` and `storm:` — the three things that are not reports. (#216)
+
 ### Fixed
 
+- **`st-json/1` dropped the `repro:` seed the text format carries.** FORMAT.md §7 opens its
+  correspondence table with "Both formats carry the same information"; `JsonReportRenderer` is
+  242 lines and the string `repro` appeared in none of them. An application on `format=json`
+  with `repro=true` and the agent attached paid for the capture and got nothing — silently,
+  since an absent seed looks exactly like a throw site the agent did not instrument. It is now
+  a `repro` member mirroring the record, omitted when there is no seed like `mdc` and `fields`
+  already are. The one format an agent is most likely to read was the one dropping the section
+  written for a machine. (#216)
 - **Every Quarkus report said `env: app=?`.** Quarkus knows the application name and version —
   `quarkus.application.*`, defaulted from the artifact's coordinates — and the extension never
   asked, so `EnvCollector` fell through to its two fallbacks: a Spring Boot artifact

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -100,9 +100,40 @@ Fields:
 | `mdc:` / `fields:` | space-separated `key=value` pairs, keys sorted. Omitted when empty. `mdc:` also carries SLF4J 2.0 event key-values (`log.atError().addKeyValue("orderId", 889)`), merged into the same line — MDC wins on a key clash. |
 | `seen:` | recurrence — `N× this session, first at <HH:mm:ss.SSS>`. Present **only** when the error has occurred before this session (its absence means the error is new). Session-scoped: resets on restart. |
 | `captured:` | present only when the agent is attached; method frames with argument values. |
+| `repro:` | present only when `repro` is on **and** the agent is attached: the throw site's typed signature and argument values. Detailed below. |
 | `story` | events leading up to and including the error, oldest first. `<label>` is `traceId=…` (correlated) or `thread <name>` (fallback). The error's own line ends with `   ← this error`. A `… N earlier event(s) older than the story window omitted` line appears when events were dropped by age (vs never logged). Omitted when empty. |
 | `stack` | the distilled stack: shown frames plus `… N collapsed (<framework groups>)` markers; the culprit frame ends with `← culprit`. Omitted for reports with no throwable. |
 | `env:` | `app=<name> <version> (git <sha>) \| java <ver> \| profile=<p> \| <os>`; unknown parts degrade (`app=?`, no `(git …)`, no `profile=`). |
+
+### `repro:` — the reproduction seed
+
+Off by default. Switched on with `repro=true` and only produced when `stacktale-agent` is
+attached, since the argument values come from the throw site.
+
+It answers "what call, with what inputs, produced this?" in a form a test can be written
+from. The declared parameter types are the point: `charge(orderId=889)` in `captured:` names
+neither the class the method lives on nor the type of 889, and a signature cannot be
+reconstructed from either.
+
+```
+repro (throw site, via stacktale-agent):
+  com.acme.shop.PaymentService#charge(long orderId, java.math.BigDecimal amount)
+    orderId = 889
+    amount = 149.90
+  throws IllegalStateException: payment gateway refused
+```
+
+- The class is **fully qualified**, because a test has to import it.
+- Types are the ones the method **declares**. When the method cannot be resolved
+  unambiguously — an overload of the same arity — the runtime class of the argument is used
+  instead; a wrong declared type is worse than an approximate one.
+- Only the **innermost** captured frame becomes a seed. Captures are appended as the
+  throwable unwinds, so the first is the closest to the throw. The frames above it remain in
+  `captured:`.
+- Values are truncated by the agent and **redacted** by the core, like every other rendered
+  value. This is the only section that renders values against a named signature, which is why
+  it is opt-in rather than default.
+- The `throws` line restates the root cause so the seed carries its own assertion.
 
 ## 4. Escaping
 
@@ -161,36 +192,6 @@ A new application run began appending to an existing file. Separates sessions.
 A flood of **distinct** errors exceeded the report rate limit; `N` full reports were
 suppressed to protect the file. The errors still happened — this line is the acknowledgement.
 
-### `repro:` — the reproduction seed
-
-Off by default. Switched on with `repro=true` and only produced when `stacktale-agent` is
-attached, since the argument values come from the throw site.
-
-It answers "what call, with what inputs, produced this?" in a form a test can be written
-from. The declared parameter types are the point: `charge(orderId=889)` in `captured:` names
-neither the class the method lives on nor the type of 889, and a signature cannot be
-reconstructed from either.
-
-```
-repro (throw site, via stacktale-agent):
-  com.acme.shop.PaymentService#charge(long orderId, java.math.BigDecimal amount)
-    orderId = 889
-    amount = 149.90
-  throws IllegalStateException: payment gateway refused
-```
-
-- The class is **fully qualified**, because a test has to import it.
-- Types are the ones the method **declares**. When the method cannot be resolved
-  unambiguously — an overload of the same arity — the runtime class of the argument is used
-  instead; a wrong declared type is worse than an approximate one.
-- Only the **innermost** captured frame becomes a seed. Captures are appended as the
-  throwable unwinds, so the first is the closest to the throw. The frames above it remain in
-  `captured:`.
-- Values are truncated by the agent and **redacted** by the core, like every other rendered
-  value. This is the only section that renders values against a named signature, which is why
-  it is opt-in rather than default.
-- The `throws` line restates the root cause so the seed carries its own assertion.
-
 ## 6. Versioning & compatibility
 
 - The format version is `st/1`, declared in the file header.
@@ -237,6 +238,14 @@ A `report` object (pretty-printed here; on disk it is one line):
   "mdc": { "traceId": "7c2e" },
   "fields": { "orderId": "889", "retryable": "false" },
   "captured": ["PaymentService.charge(orderId=889, amount=149.90)"],
+  "repro": {
+    "className": "com.acme.shop.PaymentService",
+    "methodName": "charge",
+    "params": [
+      { "type": "long", "name": "orderId", "value": "889" },
+      { "type": "java.math.BigDecimal", "name": "amount", "value": "149.90" }
+    ]
+  },
   "recurrence": { "count": 3, "firstSeen": "2026-07-10T20:16:40.000Z" },
   "story": {
     "label": "traceId=7c2e",
@@ -254,7 +263,7 @@ A `report` object (pretty-printed here; on disk it is one line):
 Rules:
 
 - Timestamps are ISO-8601 with fixed millisecond precision (`.SSS`) and an offset (`Z` for UTC).
-- Optional members (`mdc`, `fields`, `captured`, `recurrence`, `error.wrappedBy`,
+- Optional members (`mdc`, `fields`, `captured`, `repro`, `recurrence`, `error.wrappedBy`,
   `error.culprit`, `stack`, `env`) are **omitted** when empty — absence is the signal.
 - A no-throwable report has `"error": { "noException": true, "message": "…" }` and no `stack`.
 - Redaction is identical to the text format: a secret-named key masks its value, a
@@ -287,3 +296,4 @@ below, so the mapping never has to be inferred from the example above.
 | `story.events[].thisError` | the `   ← this error` suffix on the error's own event |
 | `stack.shown` / `stack.total` | the `X of Y frames` in the `stack (distilled, …)` header |
 | `stack.frames[]` | the frame lines, including the `… N collapsed (…)` markers |
+| `repro.className` + `repro.methodName` + `repro.params[]` | the `repro:` block (§3). The block's `throws` line has no member of its own: it restates the root cause, which is already `error.type` and `error.message` |

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/JsonReportRenderer.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/JsonReportRenderer.java
@@ -51,6 +51,7 @@ final class JsonReportRenderer implements Renderer {
         appendIfPresent(b, "mdc", mapObj(r.mdc()));
         appendIfPresent(b, "fields", mapObj(r.fields()));
         appendIfPresent(b, "captured", cleanArr(r.captured()));
+        appendIfPresent(b, "repro", reproObj(r.repro()));
         if (r.occurrences() > 1) {
             b.append(",\"recurrence\":{\"count\":").append(r.occurrences())
                     .append(",\"firstSeen\":").append(quote(iso(r.firstSeenMillis()))).append('}');
@@ -103,6 +104,42 @@ final class JsonReportRenderer implements Renderer {
             b.append(",\"wrappedBy\":").append(cleanArr(s.wrappedBy()));
         }
         return b.append('}').toString();
+    }
+
+    /**
+     * The reproduction seed, mirroring {@link ReproSeed} member for member so the mapping to
+     * {@code st/1}'s {@code repro:} block needs no explanation.
+     *
+     * <p>No counterpart to the text format's {@code throws} line: that restates the root cause,
+     * which this format already carries as {@code error.type} and {@code error.message}.
+     */
+    private String reproObj(ReproSeed seed) {
+        if (seed == null) return null;
+        StringBuilder b = new StringBuilder("{\"className\":").append(quote(nz(seed.className())))
+                .append(",\"methodName\":").append(quote(nz(seed.methodName())))
+                .append(",\"params\":[");
+        for (int i = 0; i < seed.params().size(); i++) {
+            ReproSeed.Param p = seed.params().get(i);
+            if (i > 0) b.append(',');
+            b.append("{\"type\":").append(quote(nz(p.type())))
+                    .append(",\"name\":").append(quote(nz(p.name())))
+                    .append(",\"value\":").append(quote(redactedValue(p))).append('}');
+        }
+        return b.append("]}").toString();
+    }
+
+    /**
+     * Redacts the value with its name in front of it, then takes the name back off.
+     *
+     * <p>The same reason {@code mdc:} and {@code fields:} clean {@code name = value} as one
+     * string: name-based redaction keys off {@code password = …}, and a value cleaned on its own
+     * has no name before it for the rule to match. The text renderer keeps the pair joined and
+     * prints it; this format has to separate them again.
+     */
+    private String redactedValue(ReproSeed.Param p) {
+        String prefix = nz(p.name()) + " = ";
+        String redacted = redactor.redact(prefix + nz(p.value()));
+        return redacted.startsWith(prefix) ? redacted.substring(prefix.length()) : redacted;
     }
 
     private String logObj(Report r) {

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/JsonReportRendererTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/JsonReportRendererTest.java
@@ -129,6 +129,69 @@ class JsonReportRendererTest {
         assertThat(j.at("/fields/note").asText()).isEqualTo("line1\nline2"); // newline preserved, escaped
     }
 
+    /**
+     * The seed is the section written for a machine, and st-json/1 is the format a machine
+     * reads — it carried everything else and dropped this one (#216). Asserted member by
+     * member rather than against a rendered string, because the point of this format is that
+     * a consumer addresses `/repro/params/0/type` instead of parsing prose.
+     */
+    @Test
+    void theReproSeedIsAddressableJson() throws Exception {
+        Report r = seeded(new ReproSeed("com.acme.shop.PaymentService", "charge", List.of(
+                new ReproSeed.Param("long", "orderId", "889"),
+                new ReproSeed.Param("java.math.BigDecimal", "amount", "149.90"))));
+
+        JsonNode j = parse(renderer.render(r));
+
+        assertThat(j.at("/repro/className").asText()).isEqualTo("com.acme.shop.PaymentService");
+        assertThat(j.at("/repro/methodName").asText()).isEqualTo("charge");
+        assertThat(j.at("/repro/params")).hasSize(2);
+        assertThat(j.at("/repro/params/0/type").asText()).isEqualTo("long");
+        assertThat(j.at("/repro/params/0/name").asText()).isEqualTo("orderId");
+        assertThat(j.at("/repro/params/0/value").asText()).isEqualTo("889");
+        assertThat(j.at("/repro/params/1/type").asText()).isEqualTo("java.math.BigDecimal");
+        assertThat(j.at("/repro/params/1/value").asText()).isEqualTo("149.90");
+
+        // the text format's `throws` line has no counterpart: it restates the root cause, which
+        // this format already carries — a consumer reads it from here
+        assertThat(j.at("/error/type").asText()).isEqualTo("IllegalStateException");
+        assertThat(j.at("/error/message").asText()).isEqualTo("payment gateway refused");
+    }
+
+    @Test
+    void withoutASeedTheReproMemberIsAbsentEntirely() throws Exception {
+        assertThat(parse(renderer.render(seeded(null))).has("repro")).isFalse();
+    }
+
+    /**
+     * Values are redacted with the parameter name in front of them and the name taken back off,
+     * because the rules that matter here are name-based: `password` alone is a keyword, `hunter2`
+     * on its own is an ordinary string. Splitting them first would mask nothing.
+     */
+    @Test
+    void aSecretlyNamedParameterHasItsValueMaskedAndItsNameKept() throws Exception {
+        Report r = seeded(new ReproSeed("com.acme.auth.LoginService", "authenticate", List.of(
+                new ReproSeed.Param("java.lang.String", "user", "bob"),
+                new ReproSeed.Param("java.lang.String", "password", "hunter2"))));
+
+        JsonNode j = parse(renderer.render(r));
+
+        assertThat(j.at("/repro/params/1/name").asText()).isEqualTo("password");
+        assertThat(j.at("/repro/params/1/value").asText()).isEqualTo("███");
+        assertThat(j.at("/repro/params/0/value").asText()).isEqualTo("bob"); // ordinary values survive
+    }
+
+    /** One report shaped for the repro assertions above; the seed is the only thing that varies. */
+    private static Report seeded(ReproSeed seed) {
+        DistilledStack stack = new DistilledStack("IllegalStateException", "payment gateway refused",
+                "PaymentService.charge(PaymentService.java:118)", true, List.of(),
+                List.of("PaymentService.charge(PaymentService.java:118) ← culprit"), 1, 1, List.of());
+        return new Report("5eed0001", 1_000_412L, "http-nio-8080-exec-2", stack,
+                "charge failed for order {}", new Object[]{889}, "com.acme.shop.PaymentService",
+                Map.of(), Map.of(), List.of(), new Story(List.of(), "traceId=7c2e"),
+                "app=shop 2.1.0 | java 21 | linux", 1, 0L, seed);
+    }
+
     @Test
     void nonReportEntriesAreTypedJson() throws Exception {
         assertThat(parse(renderer.fileHeader()).get("format").asText()).isEqualTo("st-json/1");


### PR DESCRIPTION
Closes #216.

FORMAT.md §7 opens its correspondence table with "Both formats carry the same information."
`JsonReportRenderer` is 242 lines and the string `repro` appears in none of them —
`render(Report)` emits `id`, `ts`, `thread`, `error`, `log`, `mdc`, `fields`, `captured`,
`recurrence`, `story`, `stack`, `env`, and stops.

So an application on `format=json` with `repro=true` and `stacktale-agent` attached paid for
the capture and got nothing back. Silently: the seed is optional in both formats, so an absent
one is indistinguishable from a throw site the agent never instrumented.

The section written for a machine was missing from the format a machine reads.

## The member

```json
"repro": {
  "className": "com.acme.shop.PaymentService",
  "methodName": "charge",
  "params": [
    { "type": "long", "name": "orderId", "value": "889" },
    { "type": "java.math.BigDecimal", "name": "amount", "value": "149.90" }
  ]
}
```

Mirrors `ReproSeed` member for member, so the mapping needs no explanation, and is omitted
entirely when there is no seed — like `mdc` and `fields` already are. Additive, so §6 holds:
`st-json/1` readers that skip unknown members are unaffected.

The text block's `throws` line gets no member of its own. It restates the root cause, which
this format already carries as `error.type` and `error.message`; the correspondence table now
says that rather than leaving a reader to notice the asymmetry.

## Redaction

Values are redacted **with the parameter name in front of them**, then the name is taken back
off — the same reason `mdc:` and `fields:` clean `name = value` as one string. `password` alone
is a secret keyword; `hunter2` alone is an ordinary word. Splitting them first would mask
nothing, which is a leak rather than a formatting detail, so there is a test for exactly that:

```
/repro/params/1/name  -> "password"
/repro/params/1/value -> "███"
/repro/params/0/value -> "bob"     (ordinary values survive)
```

## Verified against the un-fixed renderer

With the one `appendIfPresent` line removed, two of the three new tests fail —
`theReproSeedIsAddressableJson` and `aSecretlyNamedParameterHasItsValueMaskedAndItsNameKept`.
The third (`withoutASeedTheReproMemberIsAbsentEntirely`) passes either way, by design: it pins
the absence, and absence is what the bug looked like.

`stacktale-core`: 131 tests, 0 failures. Full reactor `mvn -B verify` green.

## One thing fixed on the way

`docs/FORMAT.md` had the `repro:` section as a subsection of **§5 Non-report entries** — next
to `repeated`, `app start` and `storm:`, the three things that are not reports — and §3's field
table, which lists every token in a report block, had no row for it. Both corrected: the
section now lives under §3 and the table names it between `captured:` and `story`, matching the
order it renders in.
