### PR TITLE
feat(mcp): `repro_for(id)` — a JUnit skeleton from the throw site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and pinned by golden-file tests.
 
 ### Added
 
+- **MCP: `repro_for(id)` turns a report's `repro:` seed into a JUnit skeleton.** The seed is the
+  one section stacktale writes for a machine — the throw site's fully qualified class, its
+  method, the declared parameter types and the values the failing call was given — and until
+  now an agent had to transcribe it out of prose, which is where a declared type or an argument
+  order goes quietly wrong. TDD-Bench-Java measured agents writing reproduction tests at 4% on
+  proprietary code with no hints, rising to 20% once given concrete class names and method
+  signatures; this hands over exactly that. Reads both `st/1` and `st-json/1`. A redacted value
+  arrives as an explicit `TODO`, never as a literal: `String token = "███"` compiles, reads as
+  data, and would reproduce a call that never happened. A report with no seed gets the two
+  switches it needs rather than an error. (#135)
 - **A guard that keeps the five adapters' configuration surfaces in step.**
   `check-config-parity.sh` reads the README's configuration table and asserts each knob is
   reachable from Logback, Log4j2, JUL, the Spring starter and Quarkus — matching the shape

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -3,8 +3,8 @@
 `stacktale-mcp` lets an AI assistant read and act on your app's error reports as tools —
 list them (`list_errors`), pull a full report (`get_report`), filter by time
 (`errors_since`), find similar past ones (`find_similar_errors`), **attach a pasted trace to
-its captured report** (`match_report`), and **loop on new errors until they're gone**
-(`errors_since_last_check`). With a subscription it's also **notified the moment a new error
+its captured report** (`match_report`), **turn one into a reproduction test**
+(`repro_for`), and **loop on new errors until they're gone** (`errors_since_last_check`). With a subscription it's also **notified the moment a new error
 lands** instead of polling. It's a tiny read-only server that speaks
 [MCP](https://modelcontextprotocol.io) over stdio. No network, no writes.
 
@@ -134,6 +134,14 @@ Once wired up, ask your assistant:
 > *What broke since 11am?* — it calls `errors_since`.
 > *Have we seen this NPE before?* — it calls `find_similar_errors`.
 > *[paste a stack trace] — what does stacktale have on this?* — it calls `match_report`.
+> *Write me a test that reproduces #c73cf755* — it calls `repro_for`.
+
+`repro_for` answers with a JUnit skeleton built from the report's `repro:` seed: the throw
+site's class, its method, the declared parameter types and the values the call was given. It
+needs `repro=true` and `stacktale-agent`; without them it says so rather than guessing, and
+tells you what to switch on. Values the report had to redact arrive as an explicit `TODO`
+rather than as a literal — a masked string that compiles would reproduce a call that never
+happened.
 
 ## The fix-loop
 

--- a/plugins/stacktale/README.md
+++ b/plugins/stacktale/README.md
@@ -26,6 +26,7 @@ Maven Central on first run.
 | `errors_since` | everything after a timestamp |
 | `find_similar_errors` | has this failed before? |
 | `match_report` | you pasted a bare stack trace — find its captured report, with the story |
+| `repro_for` | a JUnit skeleton for one report, from the throw site's typed signature and arguments |
 
 **A skill** that teaches Claude how to work the loop: baseline, read the marked culprit
 frame, fix, re-run, ask what changed, repeat until clean.

--- a/plugins/stacktale/skills/fix-loop/SKILL.md
+++ b/plugins/stacktale/skills/fix-loop/SKILL.md
@@ -43,6 +43,12 @@ changed.
 - `match_report` — the user pasted a bare stack trace: this finds the captured report for
   it, with the story and values the paste is missing. Reach for it whenever a trace arrives
   without context.
+- `repro_for` — before writing a reproduction test, ask for one. It returns a JUnit skeleton
+  built from the throw site itself: the class, the method, the declared parameter types and
+  the arguments the failing call was given. Those are what you would otherwise infer from the
+  stack trace, and a wrong declared type or argument order produces a test that passes while
+  reproducing something else. It needs `repro=true` and `stacktale-agent`, and says so when
+  the report has no seed — that answer is not a failure, it is the switch you are missing.
 
 ## Reading the reports well
 

--- a/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/ReproSkeleton.java
+++ b/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/ReproSkeleton.java
@@ -1,0 +1,261 @@
+package io.github.gabrielbbaldez.stacktale.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Turns a report's {@code repro:} seed into a JUnit skeleton an agent can paste.
+ *
+ * <p>The seed is the one section stacktale writes for a machine: the throw site's fully
+ * qualified class, its method, the declared parameter types and the values it was given.
+ * TDD-Bench-Java measured agents writing reproduction tests at 4% on proprietary code with no
+ * hints, rising to 20% once given concrete class names and method signatures (#135). The report
+ * already prints those; this renders them in the form the agent would otherwise transcribe by
+ * hand, which is the step where a type or an argument order goes quietly wrong.
+ *
+ * <p>The goal is "an agent can write the test from this", not "this compiles unmodified". How
+ * the receiver was built is not something stacktale captured, and a value it had to redact
+ * cannot become a literal. Both are explicit {@code TODO}s rather than guesses.
+ */
+final class ReproSkeleton {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    /** {@code   com.acme.shop.PaymentService#charge(long orderId, java.math.BigDecimal amount)} */
+    private static final Pattern SIGNATURE = Pattern.compile("^ {2}(\\S+)#(\\w+)\\((.*)\\)$");
+    /** {@code   throws IllegalStateException: payment gateway refused} */
+    private static final Pattern THROWS = Pattern.compile("^ {2}throws (\\S+?)(?::\\s(.*))?$");
+    private static final String SECTION = "repro (throw site, via stacktale-agent):";
+
+    private ReproSkeleton() {
+    }
+
+    /** One argument at the throw site, as the report recorded it. */
+    private record Param(String type, String name, String value) {
+    }
+
+    /** What a skeleton needs: the call, and the outcome it has to assert. */
+    private record Seed(String className, String methodName, List<Param> params,
+                        String thrownType, String thrownMessage) {
+    }
+
+    /**
+     * The skeleton for one report block, or an explanation of why there is none.
+     *
+     * <p>"No seed" is the ordinary case rather than an error — the section is opt-in and needs
+     * the agent — so the answer says how to get one instead of reporting a failure.
+     */
+    static String render(String id, String block) {
+        Seed seed = parse(block);
+        if (seed == null) {
+            return "Report #" + id + " carries no repro: seed, so there is nothing to build a test from.\n\n"
+                    + "The seed is the throw site's typed signature and its argument values. It needs both:\n"
+                    + "  - repro=true on the appender (stacktale.repro with the Spring starter or Quarkus)\n"
+                    + "  - stacktale-agent on the command line: -javaagent:/path/to/stacktale-agent.jar\n\n"
+                    + "It is off by default because it renders argument values against a named signature,\n"
+                    + "a bigger privacy surface than the rest of the report. Errors captured before it was\n"
+                    + "switched on stay without a seed; get_report still has the story, fields and stack.";
+        }
+        return skeleton(id, seed);
+    }
+
+    /** Text {@code st/1}, or the pretty-printed JSON the server holds for an {@code st-json/1} report. */
+    private static Seed parse(String block) {
+        String content = block == null ? "" : block;
+        return content.strip().startsWith("{") ? parseJson(content.strip()) : parseText(content);
+    }
+
+    private static Seed parseJson(String block) {
+        try {
+            JsonNode node = JSON.readTree(block);
+            JsonNode repro = node.path("repro");
+            if (!repro.isObject()) {
+                return null;
+            }
+            List<Param> params = new ArrayList<>();
+            for (JsonNode p : repro.path("params")) {
+                params.add(new Param(p.path("type").asText(""), p.path("name").asText(""),
+                        p.path("value").asText("")));
+            }
+            String message = node.at("/error/message").asText("");
+            return new Seed(repro.path("className").asText(""), repro.path("methodName").asText(""),
+                    params, emptyToNull(node.at("/error/type").asText("")), emptyToNull(message));
+        } catch (Exception e) {
+            return null; // a block we cannot read is a block with no seed, not a failed tool call
+        }
+    }
+
+    private static Seed parseText(String block) {
+        String[] lines = block.split("\n", -1);
+        int start = -1;
+        for (int i = 0; i < lines.length; i++) {
+            if (lines[i].startsWith(SECTION)) {
+                start = i;
+                break;
+            }
+        }
+        if (start < 0 || start + 1 >= lines.length) {
+            return null;
+        }
+
+        Matcher signature = SIGNATURE.matcher(lines[start + 1]);
+        if (!signature.matches()) {
+            return null;
+        }
+        List<String> types = new ArrayList<>();
+        List<String> names = new ArrayList<>();
+        for (String declared : signature.group(3).split(",")) {
+            String trimmed = declared.strip();
+            if (trimmed.isEmpty()) {
+                continue;
+            }
+            int space = trimmed.lastIndexOf(' ');
+            if (space < 0) {
+                return null;
+            }
+            types.add(trimmed.substring(0, space));
+            names.add(trimmed.substring(space + 1));
+        }
+
+        List<Param> params = new ArrayList<>();
+        String thrownType = null;
+        String thrownMessage = null;
+        for (int i = start + 2; i < lines.length; i++) {
+            Matcher thrown = THROWS.matcher(lines[i]);
+            if (thrown.matches()) {
+                thrownType = thrown.group(1);
+                thrownMessage = thrown.group(2);
+                break;
+            }
+            if (!lines[i].startsWith("    ")) {
+                break;
+            }
+            // one `name = value` line per argument, in declaration order; split on the FIRST
+            // " = " so a value containing one survives
+            String pair = lines[i].substring(4);
+            int eq = pair.indexOf(" = ");
+            String name = eq < 0 ? pair : pair.substring(0, eq);
+            String value = eq < 0 ? "" : pair.substring(eq + 3);
+            int index = names.indexOf(name);
+            params.add(new Param(index < 0 ? "java.lang.Object" : types.get(index), name, value));
+        }
+        return new Seed(signature.group(1), signature.group(2), params, thrownType, thrownMessage);
+    }
+
+    private static String skeleton(String id, Seed seed) {
+        String subject = simple(seed.className());
+        StringBuilder b = new StringBuilder(512);
+
+        b.append("// Reproduction skeleton for stacktale report #").append(id).append('\n');
+        b.append("// Built from the repro: seed — the call recorded at the throw site.\n\n");
+
+        for (String imported : imports(seed)) {
+            b.append("import ").append(imported).append(";\n");
+        }
+        b.append("import org.junit.jupiter.api.Test;\n");
+        b.append("import static org.junit.jupiter.api.Assertions.assertEquals;\n");
+        b.append("import static org.junit.jupiter.api.Assertions.assertThrows;\n\n");
+
+        b.append("class ").append(subject).append("ReproTest {\n\n");
+        b.append("    @Test\n");
+        b.append("    void ").append(seed.methodName()).append("Throws")
+                .append(seed.thrownType() == null ? "" : simple(seed.thrownType())).append("() {\n");
+        b.append("        // TODO: stacktale captured the call, not the object it was made on\n");
+        b.append("        ").append(subject).append(" subject = new ").append(subject)
+                .append("(/* dependencies */);\n\n");
+
+        for (Param p : seed.params()) {
+            b.append("        ").append(simple(p.type())).append(' ').append(p.name())
+                    .append(" = ").append(literal(p)).append(";\n");
+        }
+        if (!seed.params().isEmpty()) {
+            b.append('\n');
+        }
+
+        String args = String.join(", ", seed.params().stream().map(Param::name).toList());
+        if (seed.thrownType() == null) {
+            b.append("        subject.").append(seed.methodName()).append('(').append(args).append(");\n");
+        } else {
+            String thrown = simple(seed.thrownType());
+            b.append("        ").append(thrown).append(" thrown = assertThrows(").append(thrown)
+                    .append(".class,\n");
+            b.append("                () -> subject.").append(seed.methodName()).append('(').append(args)
+                    .append("));\n");
+            if (seed.thrownMessage() != null && !seed.thrownMessage().isBlank()) {
+                b.append('\n').append("        assertEquals(").append(quote(seed.thrownMessage()))
+                        .append(", thrown.getMessage());\n");
+            }
+        }
+        b.append("    }\n}\n");
+        return b.toString();
+    }
+
+    /**
+     * Imports for the types this names. The thrown type is deliberately absent: a report carries
+     * its simple name only, so there is no package to import — an application's own exception
+     * type has to be resolved by whoever pastes the skeleton.
+     */
+    private static Set<String> imports(Seed seed) {
+        Set<String> out = new LinkedHashSet<>();
+        addImport(out, seed.className());
+        for (Param p : seed.params()) {
+            addImport(out, p.type());
+        }
+        return out;
+    }
+
+    private static void addImport(Set<String> out, String type) {
+        if (type != null && type.contains(".") && !type.startsWith("java.lang.")) {
+            out.add(type);
+        }
+    }
+
+    /**
+     * A Java literal for a recorded value, or a TODO where one cannot be honest.
+     *
+     * <p>A redacted value never becomes a literal, whatever its declared type: {@code "███"} as
+     * a String reads as data and would quietly make the test reproduce a different call. Same
+     * for a type with no literal form — an explicit gap beats an approximate object.
+     */
+    private static String literal(Param p) {
+        String value = p.value();
+        if (value == null || value.isBlank()) {
+            return "null /* TODO: no value recorded */";
+        }
+        if (value.contains("███")) {
+            return "null /* TODO: redacted in the report */";
+        }
+        return switch (p.type()) {
+            case "int", "short", "byte", "java.lang.Integer", "java.lang.Short", "java.lang.Byte" -> value;
+            case "long", "java.lang.Long" -> value + "L";
+            case "float", "java.lang.Float" -> value + "f";
+            case "double", "java.lang.Double" -> value + "d";
+            case "boolean", "java.lang.Boolean" -> value;
+            case "char", "java.lang.Character" -> "'" + value + "'";
+            case "java.lang.String" -> quote(value);
+            case "java.math.BigDecimal" -> "new BigDecimal(" + quote(value) + ")";
+            case "java.math.BigInteger" -> "new BigInteger(" + quote(value) + ")";
+            default -> "null /* TODO: a " + simple(p.type()) + " equal to " + value + " */";
+        };
+    }
+
+    private static String simple(String type) {
+        int dot = type.lastIndexOf('.');
+        return dot < 0 ? type : type.substring(dot + 1);
+    }
+
+    private static String quote(String s) {
+        return '"' + s.replace("\\", "\\\\").replace("\"", "\\\"") + '"';
+    }
+
+    private static String emptyToNull(String s) {
+        return s == null || s.isEmpty() ? null : s;
+    }
+}

--- a/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServer.java
+++ b/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServer.java
@@ -314,6 +314,13 @@ public final class StacktaleMcpServer {
                 "The fix-loop primitive. First call shows the errors currently on file; after you re-run the app/tests, it reports what's 🆕 new or 🔁 still occurring since your last call — or '✓ No new errors' when it's clean. Call it each round of a fix→run→check loop until clean. Optional reset re-baselines.",
                 "{\"type\":\"object\",\"properties\":{\"reset\":{\"type\":\"boolean\",\"description\":\"forget what was already reported and re-baseline from the current file\"}}}",
                 LOOP_SCHEMA));
+        tools.add(tool("repro_for", "Reproduction skeleton", true,
+                "Turn one error's repro: seed into a JUnit test skeleton: the throw site's class, its method, "
+                + "the declared parameter types and the argument values it was given. Use it when you are about "
+                + "to write a reproduction test — the signature and inputs come from the failure itself rather "
+                + "than from guessing. Needs repro=true and stacktale-agent; says so when the report has no seed.",
+                "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"report id, e.g. c73cf755\"}},\"required\":[\"id\"]}",
+                null));
         tools.add(tool("match_report", "Match a pasted trace", true,
                 "Paste a raw exception + stack trace and get the full stacktale report captured for it (story, fields, distilled stack, env) — matched by root-cause type and message. The bridge from a pasted trace to the agent having the whole context.",
                 "{\"type\":\"object\",\"properties\":{\"trace\":{\"type\":\"string\",\"description\":\"a pasted exception and its stack trace\"}},\"required\":[\"trace\"]}",
@@ -383,6 +390,7 @@ public final class StacktaleMcpServer {
             case "errors_since" -> errorsSince(args.path("since").asText());
             case "find_similar_errors" -> findSimilar(args.path("query").asText());
             case "errors_since_last_check" -> errorsSinceLastCheck(args.path("reset").asBoolean(false));
+            case "repro_for" -> ToolResult.text(reproFor(args.path("id").asText()));
             case "match_report" -> ToolResult.text(matchReport(args.path("trace").asText()));
             default -> throw new IllegalArgumentException("unknown tool: " + name);
         };
@@ -418,6 +426,21 @@ public final class StacktaleMcpServer {
                 .filter(r -> r.id().equals(id))
                 .findFirst()
                 .map(r -> r.repeats() > 1 ? r.block() + "(occurred " + r.repeats() + "× in total)\n" : r.block())
+                .orElse("No report with id '" + id + "'. Use list_errors to see available ids.");
+    }
+
+    /**
+     * The repro: seed rendered as a test skeleton.
+     *
+     * <p>Same lookup as {@link #getReport}, different rendering: that hands over the report for a
+     * human or an LLM to read, this hands over the one section that is already machine-shaped and
+     * saves the transcription step where a declared type or an argument order goes quietly wrong.
+     */
+    private String reproFor(String id) throws IOException {
+        return reports.read().stream()
+                .filter(r -> r.id().equals(id))
+                .findFirst()
+                .map(r -> ReproSkeleton.render(r.id(), r.block()))
                 .orElse("No report with id '" + id + "'. Use list_errors to see available ids.");
     }
 

--- a/stacktale-mcp/src/test/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServerTest.java
+++ b/stacktale-mcp/src/test/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServerTest.java
@@ -36,6 +36,18 @@ class StacktaleMcpServerTest {
 
             env: app=demo | java 21 | linux
             ━━━ END #bbbb2222 ━━━
+            ━━━ ERROR #dddd4444 ━━━ 2026-07-10 12:00:00.000 thread=http-1 ━━━
+            IllegalStateException: payment gateway refused
+            at PaymentService.charge(PaymentService.java:118) ← YOUR CODE
+            repro (throw site, via stacktale-agent):
+              com.acme.shop.PaymentService#charge(long orderId, java.math.BigDecimal amount, java.lang.String token)
+                orderId = 889
+                amount = 149.90
+                token = ███
+              throws IllegalStateException: payment gateway refused
+
+            env: app=demo | java 21 | linux
+            ━━━ END #dddd4444 ━━━
             """;
 
     private Path file;
@@ -66,11 +78,12 @@ class StacktaleMcpServerTest {
         assertThat(r[0].at("/result/serverInfo/name").asText()).isEqualTo("stacktale");
         assertThat(r[0].at("/result/capabilities/resources/subscribe").asBoolean()).isTrue();
         assertThat(r[0].at("/result/capabilities/prompts").isObject()).isTrue();
-        assertThat(r[1].at("/result/tools")).hasSize(6);
+        assertThat(r[1].at("/result/tools")).hasSize(7);
         assertThat(r[1].at("/result/tools/0/name").asText()).isEqualTo("list_errors");
         assertThat(r[1].at("/result/tools/3/name").asText()).isEqualTo("find_similar_errors");
         assertThat(r[1].at("/result/tools/4/name").asText()).isEqualTo("errors_since_last_check");
-        assertThat(r[1].at("/result/tools/5/name").asText()).isEqualTo("match_report");
+        assertThat(r[1].at("/result/tools/5/name").asText()).isEqualTo("repro_for");
+        assertThat(r[1].at("/result/tools/6/name").asText()).isEqualTo("match_report");
     }
 
     @Test
@@ -95,6 +108,83 @@ class StacktaleMcpServerTest {
                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"match_report\","
                 + "\"arguments\":{\"trace\":\"com.acme.WidgetException: the frobnicator jammed\"}}}");
         assertThat(r[0].at("/result/content/0/text").asText()).contains("No captured report matches");
+    }
+
+    /**
+     * The point of the tool: the agent gets the signature and the inputs rather than
+     * transcribing them out of prose, which is the step where a declared type or an argument
+     * order goes quietly wrong.
+     */
+    @Test
+    void reproForBuildsATestSkeletonFromTheSeed() throws Exception {
+        String skeleton = reproFor("dddd4444");
+
+        assertThat(skeleton)
+                .contains("import com.acme.shop.PaymentService;")
+                .contains("import java.math.BigDecimal;")
+                .contains("class PaymentServiceReproTest")
+                .contains("void chargeThrowsIllegalStateException()")
+                .contains("long orderId = 889L;")                          // declared type drives the literal
+                .contains("BigDecimal amount = new BigDecimal(\"149.90\");")
+                .contains("() -> subject.charge(orderId, amount, token)")  // declaration order preserved
+                .contains("assertEquals(\"payment gateway refused\", thrown.getMessage());");
+
+        // java.lang types need no import line
+        assertThat(skeleton).doesNotContain("import java.lang.String;");
+    }
+
+    /**
+     * A masked value must never be handed over as a literal. `String token = "███"` compiles
+     * and reads as data, and the test would then reproduce a call that never happened.
+     */
+    @Test
+    void aRedactedArgumentBecomesATodoRatherThanAStringLiteral() throws Exception {
+        String skeleton = reproFor("dddd4444");
+
+        assertThat(skeleton).contains("String token = null /* TODO: redacted in the report */;");
+        assertThat(skeleton).doesNotContain("\"███\"");
+    }
+
+    /** No seed is the ordinary case — opt-in and needs the agent — so the answer teaches instead of failing. */
+    @Test
+    void reproForSaysHowToGetASeedWhenTheReportHasNone() throws Exception {
+        assertThat(reproFor("aaaa1111"))
+                .contains("carries no repro: seed")
+                .contains("repro=true")
+                .contains("-javaagent:");
+    }
+
+    @Test
+    void reproForAnUnknownIdPointsAtListErrors() throws Exception {
+        assertThat(reproFor("nosuchid")).contains("No report with id 'nosuchid'");
+    }
+
+    /**
+     * st-json/1 reports reach the server as JSON rather than as the text block, and the seed has
+     * to survive that route too — the format written for parsers is the one an agent is most
+     * likely to be reading.
+     */
+    @Test
+    void reproForReadsAnStJsonReportAsWell(@TempDir Path dir) throws Exception {
+        Path jsonFile = dir.resolve("errors-ai.log");
+        Files.writeString(jsonFile, """
+                {"type":"header","format":"st-json/1"}
+                {"type":"report","id":"eeee5555","ts":"2026-07-10T12:00:00.000Z","thread":"http-1",                "error":{"type":"IllegalStateException","message":"payment gateway refused"},                "log":{"pattern":"charge failed","logger":"com.acme.shop.PaymentService"},                "repro":{"className":"com.acme.shop.PaymentService","methodName":"charge",                "params":[{"type":"long","name":"orderId","value":"889"}]}}
+                """, StandardCharsets.UTF_8);
+        file = jsonFile;
+
+        String skeleton = reproFor("eeee5555");
+
+        assertThat(skeleton)
+                .contains("class PaymentServiceReproTest")
+                .contains("long orderId = 889L;")
+                .contains("assertEquals(\"payment gateway refused\", thrown.getMessage());");
+    }
+
+    private String reproFor(String id) throws Exception {
+        JsonNode[] r = roundTrip("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
+                + "\"params\":{\"name\":\"repro_for\",\"arguments\":{\"id\":\"" + id + "\"}}}");
+        return r[0].at("/result/content/0/text").asText();
     }
 
     private static final String NEW_BLOCK = """
@@ -265,7 +355,7 @@ class StacktaleMcpServerTest {
         JsonNode[] r = roundTrip(
                 "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"list_errors\",\"arguments\":{}}}");
         String text = r[0].at("/result/content/0/text").asText();
-        assertThat(text.lines().findFirst().orElse("")).contains("#bbbb2222"); // newest first
+        assertThat(text.lines().findFirst().orElse("")).contains("#dddd4444"); // newest first (12:00)
         assertThat(text).contains("(×4)");                                     // repeat count folded in
         assertThat(text).contains("NullPointerException: customer is null");
     }


### PR DESCRIPTION
Closes #135.

The report half of #135 has been shipping since the `repro:` section landed. This is the other
half: the tool that hands the seed to an agent in the form it was going to write anyway.

```
> Write me a test that reproduces #5eed0001
```

```java
// Reproduction skeleton for stacktale report #5eed0001
// Built from the repro: seed — the call recorded at the throw site.

import com.acme.shop.PaymentService;
import java.math.BigDecimal;
import org.junit.jupiter.api.Test;
import static org.junit.jupiter.api.Assertions.assertEquals;
import static org.junit.jupiter.api.Assertions.assertThrows;

class PaymentServiceReproTest {

    @Test
    void chargeThrowsIllegalStateException() {
        // TODO: stacktale captured the call, not the object it was made on
        PaymentService subject = new PaymentService(/* dependencies */);

        long orderId = 889L;
        BigDecimal amount = new BigDecimal("149.90");
        String couponCode = "SUMMER24";
        boolean retry = false;

        IllegalStateException thrown = assertThrows(IllegalStateException.class,
                () -> subject.charge(orderId, amount, couponCode, retry));

        assertEquals("payment gateway refused", thrown.getMessage());
    }
}
```

That is real output, from the built jar against a report file — not a mock-up of the intended
shape.

## Why a tool rather than "read the report"

The seed is already in `get_report`, so the tool is not carrying new information — it removes a
transcription. Going from `charge(long orderId, java.math.BigDecimal amount)` plus four value
lines to a compiling call is where a declared type silently becomes the wrong one and where two
arguments of the same type swap places. A test that reproduces *something else* still passes,
which is the failure mode worth engineering against.

The measurement behind #135 says the same thing from the other side: TDD-Bench-Java put agents
at 4% on proprietary code with no hints, rising to 20% once given concrete class names and
method signatures.

## Three decisions worth reading

**A redacted value never becomes a literal.** `String token = "███"` compiles and reads as
data; the resulting test reproduces a call that never happened. It comes out as
`null /* TODO: redacted in the report */`, and there is a test asserting the skeleton contains
no `"███"` anywhere. Same rule for a type with no literal form — an explicit gap beats an
approximate object.

**No seed is an answer, not an error.** The section is opt-in and needs the agent, so the
common case is a report without one. The tool replies with the two switches to turn on
(`repro=true`, `-javaagent:`) and why it is off by default, instead of a failure the agent has
to interpret. `repro=true` only became settable from Logback, the starter and Quarkus in #212,
so this answer is what most users will see first.

**Both formats.** `st-json/1` reports reach the server as JSON rather than as a text block, and
#217 is what put the seed there at all. The parser takes either route.

## Verified

24 tests in `stacktale-mcp`, 0 failures; full reactor `mvn -B verify` green. The new cases
cover the text route, the JSON route, the redacted argument, the no-seed answer and an unknown
id. Beyond the assertions I ran the packaged jar against a report file and read the output —
the block above — because `contains(...)` on fragments does not tell you whether the whole
thing reads like Java.
The JSON route was checked through the production path rather than against a hand-written
fixture, since a test that writes its own JSON proves the parser reads what the test wrote and
nothing about what the renderer emits. I had `JsonReportRenderer` write a report — including
the redaction, which it applied itself to a parameter named `apiKey` — and fed that file to the
built jar:

```java
        long orderId = 889L;
        BigDecimal amount = new BigDecimal("149.90");
        String apiKey = null /* TODO: redacted in the report */;

        IllegalStateException thrown = assertThrows(IllegalStateException.class,
                () -> subject.charge(orderId, amount, apiKey));
```

The secret never becomes a literal, and the argument keeps its place in the call.

Docs: `docs/mcp-setup.md`, the plugin README's tool table, and the fix-loop skill, which is
where an agent actually learns the tool exists.
