### PR TITLE
feat(mcp): `culprit_source` and `tests_covering`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and pinned by golden-file tests.
 
 ### Added
 
+- **MCP: `culprit_source(id, radius)` and `tests_covering(id)` read the working tree.** The
+  report says which line failed; the first says what is on it, with the lines around it and the
+  culprit marked. Source code is deliberately not in `errors-ai.log` — that file is gitignored,
+  redacted, uploaded to CI artifacts and sized for tokens — and it is stale besides: during a
+  fix loop only the current source is the right answer. The second reports which test files name
+  the culprit's class and method, a name match rather than coverage, and says so in its own
+  reply; the answer worth acting on is `none`, which means writing a reproduction test rather
+  than hunting for one that does not exist. Both degrade with an explanation when the frame
+  names a file the tree does not have, because a failed tool call leaves an agent with nothing
+  to do next. (#138)
 - **MCP: `repro_for(id)` turns a report's `repro:` seed into a JUnit skeleton.** The seed is the
   one section stacktale writes for a machine — the throw site's fully qualified class, its
   method, the declared parameter types and the values the failing call was given — and until

--- a/README.md
+++ b/README.md
@@ -544,11 +544,15 @@ anything else that speaks MCP.
 } } }
 ```
 
-**Six tools**, all read-only (annotated so clients can auto-approve them):
+**Nine tools**, all read-only (annotated so clients can auto-approve them):
 
 - **`errors_since_last_check`** — the loop primitive: what's 🆕 new or 🔁 still occurring
   since the last check, or *✓ no new errors* when it's clean.
 - **`match_report`** — paste a raw stack trace, get the full captured report for it.
+- **`repro_for`** — a JUnit skeleton from the throw site's typed signature and the arguments
+  the failing call was given (needs `repro=true` and `stacktale-agent`).
+- **`culprit_source`** / **`tests_covering`** — the source at the culprit line, read from the
+  working tree rather than the log, and whether any test names that method.
 - `list_errors`, `get_report`, `errors_since`, `find_similar_errors` — browse and search.
 
 Plus **prompts** (`fix_loop`, `explain_latest_error`) clients surface as slash-commands, and

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -4,7 +4,9 @@
 list them (`list_errors`), pull a full report (`get_report`), filter by time
 (`errors_since`), find similar past ones (`find_similar_errors`), **attach a pasted trace to
 its captured report** (`match_report`), **turn one into a reproduction test**
-(`repro_for`), and **loop on new errors until they're gone** (`errors_since_last_check`). With a subscription it's also **notified the moment a new error
+(`repro_for`), **read the source at the culprit line** (`culprit_source`), **ask whether any
+test names it** (`tests_covering`), and **loop on new errors until they're gone**
+(`errors_since_last_check`). With a subscription it's also **notified the moment a new error
 lands** instead of polling. It's a tiny read-only server that speaks
 [MCP](https://modelcontextprotocol.io) over stdio. No network, no writes.
 
@@ -67,6 +69,14 @@ The server reads one report file. Point it there with either:
 - the `STACKTALE_FILE` environment variable (cleaner in some client configs).
 
 If neither is set it defaults to `errors-ai.log` in the working directory.
+
+`culprit_source` and `tests_covering` read your **sources**, which is a different location:
+they search the working directory the client launched the server from. That is normally the
+project root, and normally the same place the default report path resolves against — but a
+client that starts elsewhere, or a log kept outside the project (`/var/log`, a container
+mount), makes the two diverge. Point them with `--workspace /path/to/project` or
+`STACKTALE_WORKSPACE`. Build output (`target`, `build`, `node_modules`, `.git`) is never
+searched: a copy of a source file there answers for the wrong tree.
 
 ## Client setup
 
@@ -135,6 +145,19 @@ Once wired up, ask your assistant:
 > *Have we seen this NPE before?* — it calls `find_similar_errors`.
 > *[paste a stack trace] — what does stacktale have on this?* — it calls `match_report`.
 > *Write me a test that reproduces #c73cf755* — it calls `repro_for`.
+> *Show me the code that failed* — it calls `culprit_source`.
+> *Is this path tested at all?* — it calls `tests_covering`.
+
+`culprit_source` and `tests_covering` read the **working tree**, not the log. Source code is
+deliberately not in `errors-ai.log`: that file is gitignored, redacted, uploaded to CI
+artifacts, pasted into PR comments and sized for tokens. It is also stale — during a fix loop
+the current source is the only correct answer, and the log may be days old. Both degrade with
+an explanation when the frame names a file this tree does not have (a dependency, generated
+code, another service sharing the log).
+
+`tests_covering` is a name match rather than coverage, and says so in its own answer. The
+valuable reply is the negative one: nothing naming the failing method means writing a
+reproduction test rather than hunting for one that does not exist.
 
 `repro_for` answers with a JUnit skeleton built from the report's `repro:` seed: the throw
 site's class, its method, the declared parameter types and the values the call was given. It

--- a/plugins/stacktale/README.md
+++ b/plugins/stacktale/README.md
@@ -27,6 +27,8 @@ Maven Central on first run.
 | `find_similar_errors` | has this failed before? |
 | `match_report` | you pasted a bare stack trace — find its captured report, with the story |
 | `repro_for` | a JUnit skeleton for one report, from the throw site's typed signature and arguments |
+| `culprit_source` | the source around the culprit line, read from the working tree |
+| `tests_covering` | which tests name the culprit's method — or that none do |
 
 **A skill** that teaches Claude how to work the loop: baseline, read the marked culprit
 frame, fix, re-run, ask what changed, repeat until clean.

--- a/plugins/stacktale/skills/fix-loop/SKILL.md
+++ b/plugins/stacktale/skills/fix-loop/SKILL.md
@@ -43,6 +43,12 @@ changed.
 - `match_report` — the user pasted a bare stack trace: this finds the captured report for
   it, with the story and values the paste is missing. Reach for it whenever a trace arrives
   without context.
+- `culprit_source` — the code at the culprit line, read from the working tree rather than the
+  log. Reach for it before proposing a fix: the report tells you which line failed, this tells
+  you what is on it, and it is current where the log may be days old.
+- `tests_covering` — which test files name the culprit's class and method. It is a name match,
+  not coverage, and the reply says so. The answer to act on is `none`: that means the failing
+  path has no test, so write one instead of looking for the one that does not exist.
 - `repro_for` — before writing a reproduction test, ask for one. It returns a JUnit skeleton
   built from the throw site itself: the class, the method, the declared parameter types and
   the arguments the failing call was given. Those are what you would otherwise infer from the

--- a/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServer.java
+++ b/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServer.java
@@ -45,10 +45,19 @@ public final class StacktaleMcpServer {
 
     private final StReportFile reports;
     private final Path file;
+    private final Workspace workspace;
 
     StacktaleMcpServer(Path file) {
+        // The working directory, not the log file's parent: the log can be configured anywhere
+        // (/var/log, a container mount), while the tree the client has open is where it launched
+        // the server — the same directory the default `errors-ai.log` resolves against.
+        this(file, Path.of("").toAbsolutePath());
+    }
+
+    StacktaleMcpServer(Path file, Path workspaceRoot) {
         this.file = file;
         this.reports = new StReportFile(file);
+        this.workspace = new Workspace(workspaceRoot);
     }
 
     public static void main(String[] args) throws Exception {
@@ -56,10 +65,18 @@ public final class StacktaleMcpServer {
         Path file = Path.of("errors-ai.log");
         String env = System.getenv("STACKTALE_FILE");
         if (env != null && !env.isBlank()) file = Path.of(env);
+        // The tree culprit_source and tests_covering read. Defaults to the working directory,
+        // which is the project root whenever the client launches the server from it — the same
+        // assumption the default report path already makes. A client that launches from
+        // somewhere else needs to say where the sources are, hence the override.
+        Path workspace = Path.of("").toAbsolutePath();
+        String workspaceEnv = System.getenv("STACKTALE_WORKSPACE");
+        if (workspaceEnv != null && !workspaceEnv.isBlank()) workspace = Path.of(workspaceEnv);
         for (int i = 0; i < args.length - 1; i++) {
             if ("--file".equals(args[i])) file = Path.of(args[i + 1]);
+            if ("--workspace".equals(args[i])) workspace = Path.of(args[i + 1]);
         }
-        new StacktaleMcpServer(file).serve(System.in, System.out);
+        new StacktaleMcpServer(file, workspace.toAbsolutePath()).serve(System.in, System.out);
     }
 
     /** The single resource this server exposes: the live error report file. */
@@ -321,6 +338,20 @@ public final class StacktaleMcpServer {
                 + "than from guessing. Needs repro=true and stacktale-agent; says so when the report has no seed.",
                 "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"report id, e.g. c73cf755\"}},\"required\":[\"id\"]}",
                 null));
+        tools.add(tool("culprit_source", "Source at the culprit", true,
+                "Read the source around a report's culprit frame, from the working tree rather than the log: "
+                + "the code is current where the log may be days old. Use it before proposing a fix — the "
+                + "report says which line failed, this says what is on it.",
+                "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"report id, e.g. c73cf755\"},"
+                + "\"radius\":{\"type\":\"integer\",\"description\":\"lines of context each side, default 12\"}},\"required\":[\"id\"]}",
+                null));
+        tools.add(tool("tests_covering", "Tests naming the culprit", true,
+                "Which test sources name the culprit's class and method — or, decisively, that none do. "
+                + "A name match rather than coverage; the useful answer is the negative one, because "
+                + "nothing naming the failing method means writing a reproduction test instead of hunting "
+                + "for one that does not exist.",
+                "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"report id, e.g. c73cf755\"}},\"required\":[\"id\"]}",
+                null));
         tools.add(tool("match_report", "Match a pasted trace", true,
                 "Paste a raw exception + stack trace and get the full stacktale report captured for it (story, fields, distilled stack, env) — matched by root-cause type and message. The bridge from a pasted trace to the agent having the whole context.",
                 "{\"type\":\"object\",\"properties\":{\"trace\":{\"type\":\"string\",\"description\":\"a pasted exception and its stack trace\"}},\"required\":[\"trace\"]}",
@@ -391,6 +422,9 @@ public final class StacktaleMcpServer {
             case "find_similar_errors" -> findSimilar(args.path("query").asText());
             case "errors_since_last_check" -> errorsSinceLastCheck(args.path("reset").asBoolean(false));
             case "repro_for" -> ToolResult.text(reproFor(args.path("id").asText()));
+            case "culprit_source" -> ToolResult.text(
+                    culpritSource(args.path("id").asText(), args.path("radius").asInt(12)));
+            case "tests_covering" -> ToolResult.text(testsCovering(args.path("id").asText()));
             case "match_report" -> ToolResult.text(matchReport(args.path("trace").asText()));
             default -> throw new IllegalArgumentException("unknown tool: " + name);
         };
@@ -442,6 +476,40 @@ public final class StacktaleMcpServer {
                 .findFirst()
                 .map(r -> ReproSkeleton.render(r.id(), r.block()))
                 .orElse("No report with id '" + id + "'. Use list_errors to see available ids.");
+    }
+
+    /**
+     * The code at the culprit line, read now rather than when the error was logged.
+     *
+     * <p>Sentry's frame model carries {@code pre_context}/{@code context_line}/{@code post_context}
+     * for the same reason: an agent reasons far better with the lines in hand than with a
+     * {@code file:line} it has to go and fetch.
+     */
+    private String culpritSource(String id, int radius) throws IOException {
+        return forCulprit(id, frame -> workspace.sourceAround(frame, Math.max(1, Math.min(radius, 200))));
+    }
+
+    private String testsCovering(String id) throws IOException {
+        return forCulprit(id, workspace::testsCovering);
+    }
+
+    /**
+     * Shared lookup for the two workspace tools. Both dead ends — no such report, no frame in it —
+     * are answers rather than failures: an error logged without a throwable genuinely has no
+     * culprit frame, and a tool call that errors leaves the agent with nothing to do next.
+     */
+    private String forCulprit(String id, java.util.function.Function<Workspace.Frame, String> f)
+            throws IOException {
+        StReport report = reports.read().stream().filter(r -> r.id().equals(id)).findFirst().orElse(null);
+        if (report == null) {
+            return "No report with id '" + id + "'. Use list_errors to see available ids.";
+        }
+        Workspace.Frame frame = Workspace.culpritOf(report.block());
+        if (frame == null) {
+            return "Report #" + id + " has no culprit frame — it was logged without a throwable,"
+                    + " so there is no stack to point at. get_report has its message and story.";
+        }
+        return f.apply(frame);
     }
 
     private ToolResult errorsSince(String since) throws IOException {

--- a/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/Workspace.java
+++ b/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/Workspace.java
@@ -1,0 +1,261 @@
+package io.github.gabrielbbaldez.stacktale.mcp;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+/**
+ * Reads the working tree around a report's culprit frame.
+ *
+ * <p>Deliberately not in {@code errors-ai.log}: that file is gitignored, redacted, uploaded to
+ * CI artifacts, pasted into PR comments and sized for tokens, and source code belongs in none
+ * of those. It is also <em>stale</em> — the log can be days old while the tree is current, and
+ * during a fix loop only the current source is the right answer. Keeping code out of the file
+ * and reading it here is the design, not a compromise (#138).
+ */
+final class Workspace {
+
+    private static final ObjectMapper JSON = new ObjectMapper();
+
+    /** {@code at PaymentService.charge(PaymentService.java:118) ← YOUR CODE} */
+    private static final Pattern CULPRIT_LINE = Pattern.compile("^at (.+)$");
+    /** {@code PaymentService.charge(PaymentService.java:118)} */
+    private static final Pattern FRAME = Pattern.compile("^(\\S+)\\.(\\w+)\\(([^:()]+\\.\\w+):(\\d+)\\)");
+
+    /** Build output and dependencies: a copy of the source there answers for the wrong tree. */
+    private static final Set<String> SKIPPED = Set.of(
+            "target", "build", "out", "bin", "node_modules", ".git", ".idea", ".gradle", ".mvn");
+    private static final int MAX_DEPTH = 12;
+    private static final int MAX_LINES_PER_FILE = 8;
+
+    private final Path root;
+
+    /**
+     * @param root where the client launched the server — the same working directory the default
+     *             {@code errors-ai.log} is resolved against, so "the app that wrote this log" and
+     *             "the tree open in the editor" are normally one and the same
+     */
+    Workspace(Path root) {
+        this.root = root;
+    }
+
+    /** A culprit frame, split into the parts both tools need. */
+    record Frame(String className, String methodName, String fileName, int line) {
+    }
+
+    /**
+     * The culprit frame of a report block, text or JSON, or {@code null} when it has none — a
+     * report for an error logged without a throwable has no frame to point at.
+     */
+    static Frame culpritOf(String block) {
+        if (block == null || block.isBlank()) {
+            return null;
+        }
+        String frame = block.strip().startsWith("{") ? jsonFrame(block.strip()) : textFrame(block);
+        if (frame == null) {
+            return null;
+        }
+        Matcher m = FRAME.matcher(frame.strip());
+        if (!m.find()) {
+            return null;
+        }
+        return new Frame(m.group(1), m.group(2), m.group(3), Integer.parseInt(m.group(4)));
+    }
+
+    private static String jsonFrame(String block) {
+        try {
+            JsonNode frame = JSON.readTree(block).at("/error/culprit/frame");
+            return frame.isMissingNode() ? null : frame.asText();
+        } catch (IOException e) {
+            return null;
+        }
+    }
+
+    private static String textFrame(String block) {
+        for (String line : block.split("\n", -1)) {
+            Matcher m = CULPRIT_LINE.matcher(line.strip());
+            if (m.matches()) {
+                return m.group(1);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * The source around a frame, with line numbers and the culprit marked.
+     *
+     * <p>Every failure here is an answer rather than an error: a stack frame can name a file
+     * that is not in this tree at all (a dependency, a generated class, a different service),
+     * and a tool call that fails for that leaves the agent with nothing to act on.
+     */
+    String sourceAround(Frame frame, int radius) {
+        List<Path> candidates = filesNamed(frame.fileName());
+        if (candidates.isEmpty()) {
+            return "No file named " + frame.fileName() + " under " + root.toAbsolutePath()
+                    + ".\n\nThe frame may belong to a dependency, to generated code, or to another"
+                    + " service whose reports share this log. get_report " + "still has the"
+                    + " distilled stack and the story.";
+        }
+        Path file = candidates.get(0);
+        List<String> lines;
+        try {
+            lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            return "Could not read " + display(file) + ": " + e.getMessage();
+        }
+
+        StringBuilder b = new StringBuilder();
+        b.append(display(file)).append("  (").append(frame.className()).append('.')
+                .append(frame.methodName()).append(", line ").append(frame.line()).append(")\n\n");
+        if (frame.line() > lines.size()) {
+            // the tree moved on since the report: saying so beats printing the end of the file
+            // as if it were the failure site
+            b.append("The report points at line ").append(frame.line()).append(", but the file has ")
+                    .append(lines.size()).append(" lines — it has changed since the error was")
+                    .append(" captured. Showing the last ").append(Math.min(radius, lines.size()))
+                    .append(" lines instead.\n\n");
+        }
+        int culprit = Math.min(frame.line(), lines.size());
+        int from = Math.max(1, culprit - radius);
+        int to = Math.min(lines.size(), culprit + radius);
+        int width = String.valueOf(to).length();
+        for (int i = from; i <= to; i++) {
+            b.append(String.format("%" + width + "d", i))
+                    .append(i == frame.line() ? " > " : " | ")
+                    .append(lines.get(i - 1)).append('\n');
+        }
+        if (candidates.size() > 1) {
+            b.append("\n").append(candidates.size() - 1).append(" other file(s) share that name: ");
+            b.append(String.join(", ", candidates.stream().skip(1).limit(5)
+                    .map(this::display).toList()));
+            b.append("\nThe distilled frame carries a simple class name, so pick by package if this"
+                    + " is the wrong one.\n");
+        }
+        return b.toString();
+    }
+
+    /**
+     * Test sources that mention the culprit's class and method.
+     *
+     * <p>A name match, not coverage: it is wrong in both directions — a test can exercise the
+     * method through a caller and never name it, and naming it is not the same as covering the
+     * failing path. The valuable answer is still the negative one. ORACLE-SWE ranks a
+     * reproduction test above every other signal an agent can be handed, so "nothing names this
+     * method" tells it to write one rather than spend turns looking for one that is not there.
+     */
+    String testsCovering(Frame frame) {
+        List<Path> tests = testSources();
+        if (tests.isEmpty()) {
+            return "No test sources found under " + root.toAbsolutePath()
+                    + " (looked for src/test/java and src/test/kotlin).";
+        }
+        StringBuilder hits = new StringBuilder();
+        int matched = 0;
+        for (Path test : tests) {
+            String content;
+            try {
+                content = Files.readString(test, StandardCharsets.UTF_8);
+            } catch (IOException | RuntimeException e) {
+                continue; // an unreadable or non-UTF-8 file is not worth failing the answer over
+            }
+            if (!content.contains(frame.className()) || !content.contains(frame.methodName())) {
+                continue;
+            }
+            matched++;
+            if (matched > 20) {
+                continue;
+            }
+            hits.append("  ").append(display(test)).append('\n');
+            String[] lines = content.split("\n", -1);
+            int shown = 0;
+            int naming = 0;
+            for (int i = 0; i < lines.length; i++) {
+                if (!lines[i].contains(frame.methodName())) {
+                    continue;
+                }
+                naming++;
+                // a method called in a loop of assertions produces dozens of identical lines, and
+                // this answer is read by something paying per token: enough to open the file at
+                // the right place, then the count
+                if (shown++ < MAX_LINES_PER_FILE) {
+                    hits.append("    ").append(i + 1).append(": ").append(lines[i].strip()).append('\n');
+                }
+            }
+            if (naming > MAX_LINES_PER_FILE) {
+                hits.append("    … ").append(naming - MAX_LINES_PER_FILE).append(" more line(s)\n");
+            }
+        }
+        if (matched == 0) {
+            return "none: no test source names " + frame.className() + "." + frame.methodName() + ".\n\n"
+                    + "Searched " + tests.size() + " file(s) under src/test. This is a name match rather"
+                    + " than coverage, so it can miss a test that reaches the method through a caller —"
+                    + " but nothing naming it is a strong signal that the failing path is untested."
+                    + " repro_for " + "gives you the call and its arguments to write one from.";
+        }
+        return matched + " test file(s) name " + frame.className() + "." + frame.methodName()
+                + " (a name match, not coverage — a test can name the method without exercising"
+                + " the failing path):\n\n" + hits;
+    }
+
+    /**
+     * A repo-relative path with forward slashes on every platform. Whoever reads this answer is
+     * as likely to quote the path back into a shell command as to open it, and a Windows
+     * backslash in that position is an escape character.
+     */
+    private String display(Path file) {
+        return root.relativize(file).toString().replace('\\', '/');
+    }
+
+    private List<Path> filesNamed(String fileName) {
+        List<Path> found = walk(p -> p.getFileName().toString().equals(fileName));
+        // prefer main sources over test copies, then the shallowest path — a fixture named after
+        // a production class is a common way to answer with the wrong file
+        found.sort(Comparator
+                .comparing((Path p) -> p.toString().replace('\\', '/').contains("/src/test/"))
+                .thenComparingInt(Path::getNameCount));
+        return found;
+    }
+
+    private List<Path> testSources() {
+        return walk(p -> {
+            String path = p.toString().replace('\\', '/');
+            return (path.contains("/src/test/java/") || path.contains("/src/test/kotlin/"))
+                    && (path.endsWith(".java") || path.endsWith(".kt"));
+        });
+    }
+
+    /** Bounded walk of the working tree: build output and VCS directories are never the answer. */
+    private List<Path> walk(java.util.function.Predicate<Path> accept) {
+        List<Path> found = new ArrayList<>();
+        try (Stream<Path> paths = Files.walk(root, MAX_DEPTH)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(p -> !isSkipped(p))
+                    .filter(accept)
+                    .limit(500)
+                    .forEach(found::add);
+        } catch (IOException | RuntimeException e) {
+            return found; // a partial answer beats a failed tool call
+        }
+        return found;
+    }
+
+    private boolean isSkipped(Path path) {
+        for (Path segment : root.relativize(path)) {
+            if (SKIPPED.contains(segment.toString())) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/stacktale-mcp/src/test/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServerTest.java
+++ b/stacktale-mcp/src/test/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServerTest.java
@@ -78,12 +78,14 @@ class StacktaleMcpServerTest {
         assertThat(r[0].at("/result/serverInfo/name").asText()).isEqualTo("stacktale");
         assertThat(r[0].at("/result/capabilities/resources/subscribe").asBoolean()).isTrue();
         assertThat(r[0].at("/result/capabilities/prompts").isObject()).isTrue();
-        assertThat(r[1].at("/result/tools")).hasSize(7);
+        assertThat(r[1].at("/result/tools")).hasSize(9);
         assertThat(r[1].at("/result/tools/0/name").asText()).isEqualTo("list_errors");
         assertThat(r[1].at("/result/tools/3/name").asText()).isEqualTo("find_similar_errors");
         assertThat(r[1].at("/result/tools/4/name").asText()).isEqualTo("errors_since_last_check");
         assertThat(r[1].at("/result/tools/5/name").asText()).isEqualTo("repro_for");
-        assertThat(r[1].at("/result/tools/6/name").asText()).isEqualTo("match_report");
+        assertThat(r[1].at("/result/tools/6/name").asText()).isEqualTo("culprit_source");
+        assertThat(r[1].at("/result/tools/7/name").asText()).isEqualTo("tests_covering");
+        assertThat(r[1].at("/result/tools/8/name").asText()).isEqualTo("match_report");
     }
 
     @Test
@@ -185,6 +187,133 @@ class StacktaleMcpServerTest {
         JsonNode[] r = roundTrip("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
                 + "\"params\":{\"name\":\"repro_for\",\"arguments\":{\"id\":\"" + id + "\"}}}");
         return r[0].at("/result/content/0/text").asText();
+    }
+
+    // --- workspace tools (#138) ---
+
+    /** A tree shaped like the one the client has open, holding the class #aaaa1111 blames. */
+    private Path workspaceWithSvc(Path dir, int lines) throws Exception {
+        Path src = dir.resolve("src/main/java/com/acme");
+        Files.createDirectories(src);
+        StringBuilder body = new StringBuilder("package com.acme;\n\nclass Svc {\n");
+        for (int i = 4; i <= lines; i++) {
+            body.append("    // line ").append(i).append('\n');
+        }
+        Files.writeString(src.resolve("Svc.java"), body.toString(), StandardCharsets.UTF_8);
+        return dir;
+    }
+
+    @Test
+    void culpritSourceReadsTheLineFromTheWorkingTree(@TempDir Path dir) throws Exception {
+        Path workspace = workspaceWithSvc(dir, 40);
+
+        String text = workspaceTool(workspace, "culprit_source", "aaaa1111", ",\"radius\":3");
+
+        assertThat(text)
+                .contains("Svc.java")
+                .contains("Svc.run, line 1")
+                .contains("1 > package com.acme;")  // the culprit line is marked, the rest are not
+                .contains("2 | ")
+                .doesNotContain("5 | ");            // radius honoured
+    }
+
+    /**
+     * A stack frame can name a file this tree does not have — a dependency, generated code, or
+     * another service sharing the log. That has to be an answer: a failed tool call leaves the
+     * agent with nothing to do next.
+     */
+    @Test
+    void culpritSourceSaysSoWhenTheFileIsNotInTheTree(@TempDir Path dir) throws Exception {
+        Files.createDirectories(dir.resolve("src/main/java"));
+
+        assertThat(workspaceTool(dir, "culprit_source", "aaaa1111", ""))
+                .contains("No file named Svc.java")
+                .contains("dependency");
+    }
+
+    /** The log can be days older than the tree; pointing past the end of the file must say why. */
+    @Test
+    void culpritSourceFlagsAReportOlderThanTheFile(@TempDir Path dir) throws Exception {
+        Path src = dir.resolve("src/main/java/com/acme");
+        Files.createDirectories(src);
+        Files.writeString(src.resolve("Pay.java"), "package com.acme;\n", StandardCharsets.UTF_8);
+
+        // #bbbb2222 blames Pay.charge(Pay.java:9); the file here has one line
+        assertThat(workspaceTool(dir, "culprit_source", "bbbb2222", ""))
+                .contains("points at line 9")
+                .contains("changed since the error was captured");
+    }
+
+    @Test
+    void culpritSourceHasNoFrameForAnErrorLoggedWithoutAThrowable(@TempDir Path dir) throws Exception {
+        file = dir.resolve("errors-ai.log");
+        Files.writeString(file, """
+                ━━━ ERROR #eeee5555 ━━━ 2026-07-10 10:00:00.000 thread=main ━━━
+                ERROR (no exception): payment queue is backing up
+                ━━━ END #eeee5555 ━━━
+                """, StandardCharsets.UTF_8);
+
+        assertThat(workspaceTool(dir, "culprit_source", "eeee5555", ""))
+                .contains("no culprit frame")
+                .contains("logged without a throwable");
+    }
+
+    /**
+     * The negative answer is the one worth having: ORACLE-SWE ranks a reproduction test above
+     * every other signal an agent can be given, so "nothing names this method" tells it to write
+     * one rather than spend turns hunting for a test that does not exist.
+     */
+    @Test
+    void testsCoveringSaysNoneWhenNothingNamesTheMethod(@TempDir Path dir) throws Exception {
+        Path workspace = workspaceWithSvc(dir, 10);
+        Path tests = workspace.resolve("src/test/java/com/acme");
+        Files.createDirectories(tests);
+        Files.writeString(tests.resolve("OtherTest.java"),
+                "package com.acme;\nclass OtherTest { void checkout() {} }\n", StandardCharsets.UTF_8);
+
+        assertThat(workspaceTool(workspace, "tests_covering", "aaaa1111", ""))
+                .startsWith("none: no test source names Svc.run")
+                .contains("repro_for");             // points at the tool that helps write one
+    }
+
+    @Test
+    void testsCoveringListsTheFilesThatNameTheCulprit(@TempDir Path dir) throws Exception {
+        Path workspace = workspaceWithSvc(dir, 10);
+        Path tests = workspace.resolve("src/test/java/com/acme");
+        Files.createDirectories(tests);
+        Files.writeString(tests.resolve("SvcTest.java"),
+                "package com.acme;\nclass SvcTest {\n    void runReturnsTheCustomer() { new Svc().run(); }\n}\n",
+                StandardCharsets.UTF_8);
+
+        assertThat(workspaceTool(workspace, "tests_covering", "aaaa1111", ""))
+                .contains("1 test file(s) name Svc.run")
+                .contains("SvcTest.java")
+                .contains("3: void runReturnsTheCustomer")  // the line, so the agent can open it
+                .contains("not coverage");                  // the caveat travels with the answer
+    }
+
+    /** Build output holds copies of the sources; answering from target/ describes the wrong tree. */
+    @Test
+    void theWalkIgnoresBuildOutput(@TempDir Path dir) throws Exception {
+        Path stale = dir.resolve("target/classes/com/acme");
+        Files.createDirectories(stale);
+        Files.writeString(stale.resolve("Svc.java"), "package com.acme;\n// STALE COPY\n",
+                StandardCharsets.UTF_8);
+
+        assertThat(workspaceTool(dir, "culprit_source", "aaaa1111", ""))
+                .contains("No file named Svc.java")
+                .doesNotContain("STALE COPY");
+    }
+
+    private String workspaceTool(Path workspaceRoot, String tool, String id, String extraArgs)
+            throws Exception {
+        String req = "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\""
+                + tool + "\",\"arguments\":{\"id\":\"" + id + "\"" + extraArgs + "}}}\n";
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        new StacktaleMcpServer(file, workspaceRoot).serve(
+                new ByteArrayInputStream(req.getBytes(StandardCharsets.UTF_8)), out);
+        return JSON.readTree(out.toString(StandardCharsets.UTF_8).trim())
+                .at("/result/content/0/text").asText();
     }
 
     private static final String NEW_BLOCK = """


### PR DESCRIPTION
Closes #138.

`repro_for` (#218) gives an agent the failing call. These two give it the code that call ran
into, and whether anything tests it. Together that is the fix loop's missing context: what
broke, what is on that line now, and whether a reproduction test already exists.

## `culprit_source(id, radius)`

Run against this repository, from a report blaming `ReportPipeline.process(ReportPipeline.java:305)`:

```
stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportPipeline.java  (ReportPipeline.process, line 305)

301 |                 resolved = settings.file();
302 |             }
303 |             absolutePath = resolved;
304 |         }
305 >         return resolved;
306 |     }
307 |
308 |     public void process(LogEventData event) {
309 |         try {
```

Those lines match the file on disk. It found the right one in a twelve-module reactor without
being told where to look.

## `tests_covering(id)`

Same report, same repository:

```
1 test file(s) name ReportPipeline.process (a name match, not coverage — a test can name the
method without exercising the failing path):

  stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportPipelineTest.java
    182: f.pipeline().process(error("alpha", f.clock().get()));
    …
    … 12 more line(s)
```

Paths come back with forward slashes on every platform: whoever reads this is as likely to
quote one into a shell command as to open it, and a Windows backslash there is an escape
character.

The caveat travels with the answer rather than living in the docs, because the answer is what
the agent reads. The first version printed every matching line — twenty of them for a method
called in a loop of assertions — so there is a per-file cap; enough to open the file at the
right place, then the count.

## Why the tree and not the log

`errors-ai.log` is gitignored, redacted, uploaded to CI artifacts, pasted into PR comments and
sized for tokens. Source code belongs in none of that. It is also *stale*: during a fix loop
the log may be days old while the tree is current, and only the current source is the right
answer. Keeping code out of the file and reading it here is the design.

## What a dead end returns

Every one of these is an answer, never a failed tool call — an agent that gets an error has
nothing to do next:

| situation | reply |
|---|---|
| the frame names a file this tree has not got | names it, and says it may be a dependency, generated code, or another service sharing the log |
| the report has no throwable | says there is no stack to point at, and that `get_report` still has the message and story |
| the report points past the end of the file | says the file has changed since the error was captured, then shows the end of it |
| no test names the method | `none: …`, plus why that is the useful answer, plus `repro_for` |

The stale-line case is the one I would have missed: a log older than the tree is the normal
state of a fix loop, and printing the last lines of the file as though they were the failure
site is worse than saying nothing.

## Scope and cost

`stacktale-mcp` only, no new dependency, nothing touching `st/1` or the library. The tree walk
is bounded — depth 12, 500 files, and `target`/`build`/`out`/`bin`/`node_modules`/`.git`/`.idea`
skipped, since a copy of a source file under `target/` answers for the wrong tree (there is a
test for exactly that). Files under `src/test/` sort last when resolving a name, so a fixture
named after a production class does not win.

The tools search the working directory the client launched the server from — the same
assumption the default report path already makes. `--workspace` / `STACKTALE_WORKSPACE`
overrides it for a client that starts elsewhere, or a log kept outside the project.

## Verified

31 tests in `stacktale-mcp`, 0 failures; full reactor `mvn -B verify` green. Seven new cases
cover the happy path, the missing file, the stale line, the no-throwable report, both
`tests_covering` answers, and the `target/` exclusion. The two blocks above are from the built
jar against this repository, because assertions on fragments do not tell you whether the output
reads well.

Docs: `docs/mcp-setup.md` (including the workspace-vs-log-location distinction), the plugin
README's tool table, and the fix-loop skill.

One stale claim of my own fixed on the way: the README's MCP section still said "**Six tools**"
— #218 added `repro_for` and left the count behind. It says nine now and lists them. Nothing
checks that against the server, which is how it went stale, so that guard is #219.
