### PR TITLE
feat(mcp): `audit_redaction` — check the file before you share it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and pinned by golden-file tests.
 
 ### Added
 
+- **MCP: `audit_redaction` checks the file before you share it.** Redaction masks what it can
+  recognise by context — `password=…`, a JSON `"token"` member, `Authorization: Bearer …`, a
+  long hex run — so a credential sitting in an ordinary log sentence has nothing around it to
+  recognise and travels intact. Measured against the current redactor, six of eight prefixed
+  vendor credentials pass through when no keyword is beside them. This scans every report for
+  those shapes (AWS, GitHub, Stripe, Slack, Google, JWTs, private-key blocks, Authorization
+  headers) and reports the id and the line — **never the value**, since the answer goes into an
+  assistant's context and a transcript, and quoting the secret would move it somewhere new. A
+  file with nothing masked anywhere is called out too: that reads the same whether nothing
+  sensitive was logged or redaction is switched off. (#95)
 - **MCP: `culprit_source(id, radius)` and `tests_covering(id)` read the working tree.** The
   report says which line failed; the first says what is on it, with the lines around it and the
   culprit marked. Source code is deliberately not in `errors-ai.log` — that file is gitignored,

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ anything else that speaks MCP.
 } } }
 ```
 
-**Nine tools**, all read-only (annotated so clients can auto-approve them):
+**Ten tools**, all read-only (annotated so clients can auto-approve them):
 
 - **`errors_since_last_check`** — the loop primitive: what's 🆕 new or 🔁 still occurring
   since the last check, or *✓ no new errors* when it's clean.
@@ -553,6 +553,8 @@ anything else that speaks MCP.
   the failing call was given (needs `repro=true` and `stacktale-agent`).
 - **`culprit_source`** / **`tests_covering`** — the source at the culprit line, read from the
   working tree rather than the log, and whether any test names that method.
+- **`audit_redaction`** — scan the file for credential shapes redaction missed, before you
+  attach it to a ticket or a CI artifact. Reports where, never the value.
 - `list_errors`, `get_report`, `errors_since`, `find_similar_errors` — browse and search.
 
 Plus **prompts** (`fix_loop`, `explain_latest_error`) clients surface as slash-commands, and

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -5,7 +5,8 @@ list them (`list_errors`), pull a full report (`get_report`), filter by time
 (`errors_since`), find similar past ones (`find_similar_errors`), **attach a pasted trace to
 its captured report** (`match_report`), **turn one into a reproduction test**
 (`repro_for`), **read the source at the culprit line** (`culprit_source`), **ask whether any
-test names it** (`tests_covering`), and **loop on new errors until they're gone**
+test names it** (`tests_covering`), **check the file for leaked credentials**
+(`audit_redaction`), and **loop on new errors until they're gone**
 (`errors_since_last_check`). With a subscription it's also **notified the moment a new error
 lands** instead of polling. It's a tiny read-only server that speaks
 [MCP](https://modelcontextprotocol.io) over stdio. No network, no writes.
@@ -147,6 +148,7 @@ Once wired up, ask your assistant:
 > *Write me a test that reproduces #c73cf755* — it calls `repro_for`.
 > *Show me the code that failed* — it calls `culprit_source`.
 > *Is this path tested at all?* — it calls `tests_covering`.
+> *Is this log safe to attach to the ticket?* — it calls `audit_redaction`.
 
 `culprit_source` and `tests_covering` read the **working tree**, not the log. Source code is
 deliberately not in `errors-ai.log`: that file is gitignored, redacted, uploaded to CI
@@ -158,6 +160,15 @@ code, another service sharing the log).
 `tests_covering` is a name match rather than coverage, and says so in its own answer. The
 valuable reply is the negative one: nothing naming the failing method means writing a
 reproduction test rather than hunting for one that does not exist.
+
+`audit_redaction` scans every report for values shaped like credentials the redactor did not
+mask — AWS, GitHub, Stripe, Slack and Google keys, JWTs, private-key blocks, Authorization
+headers. Redaction masks what it can recognise by context (`password=…`, a JSON `"token"`
+member, a long hex run), so a credential sitting in an ordinary sentence has nothing around it
+to recognise. The answer names the report and the line and **never the value**: it is going
+into an assistant's context and a transcript, and quoting the secret would move it somewhere
+new. A clean result is evidence, not proof — a secret with no recognisable shape cannot be
+found this way.
 
 `repro_for` answers with a JUnit skeleton built from the report's `repro:` seed: the throw
 site's class, its method, the declared parameter types and the values the call was given. It

--- a/plugins/stacktale/README.md
+++ b/plugins/stacktale/README.md
@@ -29,6 +29,7 @@ Maven Central on first run.
 | `repro_for` | a JUnit skeleton for one report, from the throw site's typed signature and arguments |
 | `culprit_source` | the source around the culprit line, read from the working tree |
 | `tests_covering` | which tests name the culprit's method — or that none do |
+| `audit_redaction` | credential shapes redaction missed — where, never the value |
 
 **A skill** that teaches Claude how to work the loop: baseline, read the marked culprit
 frame, fix, re-run, ask what changed, repeat until clean.

--- a/plugins/stacktale/skills/fix-loop/SKILL.md
+++ b/plugins/stacktale/skills/fix-loop/SKILL.md
@@ -43,6 +43,10 @@ changed.
 - `match_report` — the user pasted a bare stack trace: this finds the captured report for
   it, with the story and values the paste is missing. Reach for it whenever a trace arrives
   without context.
+- `audit_redaction` — before you paste a report anywhere, or attach `errors-ai.log` to a
+  ticket or a PR, run this. It scans for credential shapes redaction did not mask and answers
+  with the report and line, never the value. Treat a hit as a leak that already happened: the
+  value has been on disk, so the fix is to rotate it, not only to add a pattern.
 - `culprit_source` — the code at the culprit line, read from the working tree rather than the
   log. Reach for it before proposing a fix: the report tells you which line failed, this tells
   you what is on it, and it is current where the log may be days old.

--- a/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/RedactionAudit.java
+++ b/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/RedactionAudit.java
@@ -1,0 +1,149 @@
+package io.github.gabrielbbaldez.stacktale.mcp;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Scans written reports for values that look like credentials the redactor did not mask.
+ *
+ * <p>Defence in depth, and specifically a check on the gap the core redactor has by design: it
+ * masks a secret it can <em>recognise by context</em> — {@code password=…}, a JSON
+ * {@code "token"} member, {@code Authorization: Bearer …}, a long hex run — so a credential
+ * with none of that around it travels as an ordinary word. {@code AKIAIOSFODNN7EXAMPLE} in the
+ * middle of a log message is not next to a keyword, is not hex, and is not a JWT.
+ *
+ * <p>What makes those findable anyway is that the vendors gave them fixed prefixes. This looks
+ * for exactly that: shapes strong enough to name without guessing, so a team can check the
+ * file rather than trust it before pasting it into a PR or shipping it to CI (#95).
+ *
+ * <p><strong>Nothing here ever prints the value it found.</strong> The answer goes to an
+ * assistant and into a transcript, so an audit that quotes the secret has moved it somewhere
+ * new — which is the thing being warned about. A finding carries the report id, the line, the
+ * rule and the vendor prefix; enough to go and look, useless on its own.
+ */
+final class RedactionAudit {
+
+    /** A shape strong enough to name. The prefix is the evidence; the rest is never shown. */
+    private record Rule(String name, Pattern pattern, String what) {
+    }
+
+    /**
+     * Prefixed credentials, because a prefix is what survives having no context around it.
+     * Deliberately no "high entropy string" rule: on a file of stack traces it fires on class
+     * names, base64 payloads and hashes, and an audit nobody trusts gets switched off.
+     */
+    private static final List<Rule> RULES = List.of(
+            new Rule("aws-access-key-id", Pattern.compile("\\b(AKIA|ASIA)[0-9A-Z]{16}\\b"),
+                    "an AWS access key id"),
+            new Rule("github-token", Pattern.compile("\\bgh[pousr]_[A-Za-z0-9]{36,}\\b"),
+                    "a GitHub token"),
+            new Rule("openai-key", Pattern.compile("\\bsk-(proj-)?[A-Za-z0-9_-]{20,}\\b"),
+                    "an OpenAI-style API key"),
+            new Rule("stripe-key", Pattern.compile("\\b(sk|rk)_(live|test)_[A-Za-z0-9]{16,}\\b"),
+                    "a Stripe secret key"),
+            new Rule("slack-token", Pattern.compile("\\bxox[baprs]-[A-Za-z0-9-]{10,}\\b"),
+                    "a Slack token"),
+            new Rule("google-api-key", Pattern.compile("\\bAIza[0-9A-Za-z_-]{35}\\b"),
+                    "a Google API key"),
+            new Rule("jwt", Pattern.compile("\\beyJ[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{4,}"),
+                    "a JWT"),
+            new Rule("private-key", Pattern.compile("-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+                    "a private key block"),
+            new Rule("authorization-header", Pattern.compile("(?i)\\bauthorization\\s*[:=]\\s*(bearer|basic)\\s+\\S{8,}"),
+                    "an Authorization header with its credential"));
+
+    /** The mask the core writes. A line already carrying one is evidence redaction ran, not a leak. */
+    private static final String MASK = "███";
+
+    private RedactionAudit() {
+    }
+
+    /** One line of one report that matched a rule. The value itself is not part of it. */
+    private record Finding(String reportId, int line, Rule rule, String prefix, int length) {
+    }
+
+    /**
+     * The audit over every report the server can see.
+     *
+     * <p>A clean result is an answer worth returning in full: "nothing matched" is what someone
+     * is asking for before they attach the file to a ticket, and it means more when it says what
+     * was looked for.
+     */
+    static String run(List<StReportFile.StReport> reports) {
+        List<Finding> findings = new ArrayList<>();
+        int masked = 0;
+        for (StReportFile.StReport report : reports) {
+            String[] lines = report.block().split("\n", -1);
+            for (int i = 0; i < lines.length; i++) {
+                if (lines[i].contains(MASK)) {
+                    masked++;
+                }
+                for (Rule rule : RULES) {
+                    Matcher m = rule.pattern().matcher(lines[i]);
+                    if (m.find()) {
+                        findings.add(new Finding(report.id(), i + 1, rule,
+                                m.group().substring(0, Math.min(4, m.group().length())),
+                                m.group().length()));
+                    }
+                }
+            }
+        }
+        return findings.isEmpty() ? clean(reports.size(), masked) : report(findings, reports.size(), masked);
+    }
+
+    private static String clean(int reports, int masked) {
+        StringBuilder b = new StringBuilder();
+        b.append("✓ No un-redacted credential shapes in ").append(reports).append(" report(s).\n\n");
+        b.append("Checked for: ");
+        b.append(String.join(", ", RULES.stream().map(Rule::name).toList()));
+        b.append(".\n");
+        if (masked == 0) {
+            // the check that would otherwise pass loudest on a file where redaction never ran
+            b.append("\nNo masked values (").append(MASK).append(") anywhere in the file either. That is")
+                    .append(" expected when nothing sensitive was logged, and is also what a file written")
+                    .append(" with redactionEnabled=false looks like — worth confirming which.\n");
+        } else {
+            b.append("\n").append(masked).append(" line(s) carry a masked value, so redaction is running.\n");
+        }
+        b.append("\nThis finds credentials with a known vendor prefix. A secret with no recognisable"
+                + " shape and no keyword beside it cannot be found this way, so a clean result is"
+                + " evidence rather than proof.\n");
+        return b.toString();
+    }
+
+    private static String report(List<Finding> findings, int reports, int masked) {
+        StringBuilder b = new StringBuilder();
+        b.append("⚠ ").append(findings.size()).append(" possible un-redacted credential(s) in ")
+                .append(reports).append(" report(s).\n\n");
+
+        Map<String, List<Finding>> byReport = new LinkedHashMap<>();
+        for (Finding f : findings) {
+            byReport.computeIfAbsent(f.reportId(), k -> new ArrayList<>()).add(f);
+        }
+        for (Map.Entry<String, List<Finding>> entry : byReport.entrySet()) {
+            b.append("#").append(entry.getKey()).append('\n');
+            for (Finding f : entry.getValue()) {
+                b.append("  line ").append(f.line()).append(": ").append(f.rule().what())
+                        .append(" — starts ").append(f.prefix()).append("…, ")
+                        .append(f.length()).append(" chars (")
+                        .append(f.rule().name()).append(")\n");
+            }
+        }
+        b.append("\nThe values are not shown: this answer is going into an assistant's context and a"
+                + " transcript, and quoting the secret would move it somewhere new. Open the report"
+                + " file at those lines to see them.\n");
+        b.append("\nWhat to do: treat each as compromised and rotate it — it has been on disk, and"
+                + " probably in a CI artifact. Then stop it recurring: add a redactPattern for the"
+                + " shape (redactPattern in logback.xml, stacktale.redact-patterns elsewhere), or"
+                + " stop logging the value.\n");
+        if (masked == 0) {
+            b.append("\nNothing in the file is masked at all, which points at redactionEnabled=false"
+                    + " rather than at a gap in the rules.\n");
+        }
+        return b.toString();
+    }
+}

--- a/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServer.java
+++ b/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServer.java
@@ -352,6 +352,13 @@ public final class StacktaleMcpServer {
                 + "for one that does not exist.",
                 "{\"type\":\"object\",\"properties\":{\"id\":{\"type\":\"string\",\"description\":\"report id, e.g. c73cf755\"}},\"required\":[\"id\"]}",
                 null));
+        tools.add(tool("audit_redaction", "Audit the file for leaks", true,
+                "Scan every report for values that look like credentials the redactor did not mask — "
+                + "AWS/GitHub/Stripe/Slack/Google keys, JWTs, private-key blocks, Authorization headers. "
+                + "Run it before attaching errors-ai.log to a ticket, a PR or a CI artifact. Reports the "
+                + "id and line of each hit and never the value itself.",
+                "{\"type\":\"object\",\"properties\":{}}",
+                null));
         tools.add(tool("match_report", "Match a pasted trace", true,
                 "Paste a raw exception + stack trace and get the full stacktale report captured for it (story, fields, distilled stack, env) — matched by root-cause type and message. The bridge from a pasted trace to the agent having the whole context.",
                 "{\"type\":\"object\",\"properties\":{\"trace\":{\"type\":\"string\",\"description\":\"a pasted exception and its stack trace\"}},\"required\":[\"trace\"]}",
@@ -425,6 +432,7 @@ public final class StacktaleMcpServer {
             case "culprit_source" -> ToolResult.text(
                     culpritSource(args.path("id").asText(), args.path("radius").asInt(12)));
             case "tests_covering" -> ToolResult.text(testsCovering(args.path("id").asText()));
+            case "audit_redaction" -> ToolResult.text(RedactionAudit.run(reports.read()));
             case "match_report" -> ToolResult.text(matchReport(args.path("trace").asText()));
             default -> throw new IllegalArgumentException("unknown tool: " + name);
         };

--- a/stacktale-mcp/src/test/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServerTest.java
+++ b/stacktale-mcp/src/test/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServerTest.java
@@ -78,14 +78,15 @@ class StacktaleMcpServerTest {
         assertThat(r[0].at("/result/serverInfo/name").asText()).isEqualTo("stacktale");
         assertThat(r[0].at("/result/capabilities/resources/subscribe").asBoolean()).isTrue();
         assertThat(r[0].at("/result/capabilities/prompts").isObject()).isTrue();
-        assertThat(r[1].at("/result/tools")).hasSize(9);
+        assertThat(r[1].at("/result/tools")).hasSize(10);
         assertThat(r[1].at("/result/tools/0/name").asText()).isEqualTo("list_errors");
         assertThat(r[1].at("/result/tools/3/name").asText()).isEqualTo("find_similar_errors");
         assertThat(r[1].at("/result/tools/4/name").asText()).isEqualTo("errors_since_last_check");
         assertThat(r[1].at("/result/tools/5/name").asText()).isEqualTo("repro_for");
         assertThat(r[1].at("/result/tools/6/name").asText()).isEqualTo("culprit_source");
         assertThat(r[1].at("/result/tools/7/name").asText()).isEqualTo("tests_covering");
-        assertThat(r[1].at("/result/tools/8/name").asText()).isEqualTo("match_report");
+        assertThat(r[1].at("/result/tools/8/name").asText()).isEqualTo("audit_redaction");
+        assertThat(r[1].at("/result/tools/9/name").asText()).isEqualTo("match_report");
     }
 
     @Test
@@ -186,6 +187,97 @@ class StacktaleMcpServerTest {
     private String reproFor(String id) throws Exception {
         JsonNode[] r = roundTrip("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
                 + "\"params\":{\"name\":\"repro_for\",\"arguments\":{\"id\":\"" + id + "\"}}}");
+        return r[0].at("/result/content/0/text").asText();
+    }
+
+    // --- redaction audit (#95) ---
+
+    /**
+     * The gap this covers, measured against the core redactor: a prefixed credential sitting in
+     * a message with no keyword beside it is not `password=…`, not a JSON member, not hex and
+     * not a JWT, so the redactor has nothing to recognise and the value travels intact.
+     */
+    @Test
+    void auditFlagsACredentialTheRedactorHadNoContextToCatch(@TempDir Path dir) throws Exception {
+        file = dir.resolve("errors-ai.log");
+        Files.writeString(file, """
+                ━━━ ERROR #leak0001 ━━━ 2026-07-10 10:00:00.000 thread=main ━━━
+                IllegalStateException: upload rejected
+                log: "upload failed for key AKIAIOSFODNN7EXAMPLE" logger=c.a.S3
+                ━━━ END #leak0001 ━━━
+                """, StandardCharsets.UTF_8);
+
+        String text = audit();
+
+        assertThat(text)
+                .contains("1 possible un-redacted credential")
+                .contains("#leak0001")
+                .contains("an AWS access key id")
+                .contains("aws-access-key-id")
+                .contains("line 3");
+    }
+
+    /**
+     * The answer goes into an assistant's context and a transcript, so quoting the secret would
+     * move it somewhere new — which is the thing being warned about.
+     */
+    @Test
+    void auditNeverPrintsTheValueItFound(@TempDir Path dir) throws Exception {
+        file = dir.resolve("errors-ai.log");
+        Files.writeString(file, """
+                ━━━ ERROR #leak0002 ━━━ 2026-07-10 10:00:00.000 thread=main ━━━
+                IllegalStateException: clone failed
+                log: "ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 expired" logger=c.a.Git
+                ━━━ END #leak0002 ━━━
+                """, StandardCharsets.UTF_8);
+
+        String text = audit();
+
+        assertThat(text).contains("a GitHub token").contains("starts ghp_…");
+        assertThat(text).doesNotContain("aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789");
+    }
+
+    @Test
+    void auditPassesAFileWhoseSecretsWereMasked(@TempDir Path dir) throws Exception {
+        file = dir.resolve("errors-ai.log");
+        Files.writeString(file, """
+                ━━━ ERROR #safe0001 ━━━ 2026-07-10 10:00:00.000 thread=main ━━━
+                IllegalStateException: login failed
+                log: "login failed password=███" logger=c.a.Auth
+                ━━━ END #safe0001 ━━━
+                """, StandardCharsets.UTF_8);
+
+        assertThat(audit())
+                .startsWith("✓ No un-redacted credential shapes")
+                .contains("redaction is running")   // the mask is evidence the redactor ran
+                .contains("evidence rather than proof");
+    }
+
+    /**
+     * A file with nothing masked anywhere looks identical whether nothing sensitive was logged
+     * or redaction was switched off — the reading someone most needs prompting about.
+     */
+    @Test
+    void auditSaysWhenNothingInTheFileIsMaskedAtAll(@TempDir Path dir) throws Exception {
+        file = dir.resolve("errors-ai.log");
+        Files.writeString(file, """
+                ━━━ ERROR #safe0002 ━━━ 2026-07-10 10:00:00.000 thread=main ━━━
+                IllegalStateException: nothing sensitive here
+                ━━━ END #safe0002 ━━━
+                """, StandardCharsets.UTF_8);
+
+        assertThat(audit()).contains("redactionEnabled=false");
+    }
+
+    /** The ordinary fixture is stack traces and log lines; an audit that fires on those is noise. */
+    @Test
+    void auditDoesNotFireOnOrdinaryReports() throws Exception {
+        assertThat(audit()).startsWith("✓ No un-redacted credential shapes");
+    }
+
+    private String audit() throws Exception {
+        JsonNode[] r = roundTrip("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\","
+                + "\"params\":{\"name\":\"audit_redaction\",\"arguments\":{}}}");
         return r[0].at("/result/content/0/text").asText();
     }
 


### PR DESCRIPTION
Closes #95.

The redactor masks a secret it can recognise **by context**: `password=…`, a JSON `"token"`
member, `Authorization: Bearer …`, a long hex run. A credential sitting in an ordinary log
sentence has none of that around it.

I measured it rather than assuming, against `Redactor.withDefaults(List.of())` on `main`:

```
THROUGH  | upload failed for bucket orders, key AKIAIOSFODNN7EXAMPLE rejected
THROUGH  | clone failed: ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 is expired
THROUGH  | openai call failed with sk-proj-abcdefghijklmnopqrstuvwxyz012345
THROUGH  | charge failed key sk_live_abcdefghijklmnop1234
THROUGH  | slack post failed xoxb-1234567890-abcdefghijkl
THROUGH  | maps lookup failed AIzaSyD-abcdefghijklmnopqrstuvwxyz01234567
MASKED   | token=███ rejected
MASKED   | Authorization: ███
```

Six of eight. The two that are caught are the two with context — the rule working exactly as
designed, and its blind spot.

That is the gap `audit_redaction` closes, for the question "is this file safe to attach to a
ticket, a PR, a CI artifact". Run against a report file with two of those in it:

```
⚠ 2 possible un-redacted credential(s) in 2 report(s).

#a1b2c3d4
  line 3: an AWS access key id — starts AKIA…, 20 chars (aws-access-key-id)
#e5f6a7b8
  line 3: a GitHub token — starts ghp_…, 40 chars (github-token)

The values are not shown: this answer is going into an assistant's context and a transcript,
and quoting the secret would move it somewhere new. Open the report file at those lines to
see them.

What to do: treat each as compromised and rotate it — it has been on disk, and probably in a
CI artifact. Then stop it recurring: add a redactPattern for the shape, or stop logging the
value.
```

## The rule that shaped it

**The audit never prints what it found.** Its output goes into an assistant's context and a
transcript, so a tool that quotes the secret has copied it somewhere new — which is the thing
it is warning about. A finding carries the id, the line, the vendor prefix and a length: enough
to go and look, useless on its own. There is a test asserting the token body appears nowhere in
the answer.

**No "high entropy string" rule.** On a file of stack traces it fires on class names, base64
payloads and hashes, and an audit nobody trusts gets switched off. Every rule here is a vendor
prefix — `AKIA` plus sixteen upper-alphanumerics is an AWS key id and essentially nothing else.
Six tests, including one asserting the ordinary fixture of stack traces and log lines stays
silent.

**A clean answer says what it checked.** "Nothing matched" is what someone wants before
attaching the file, and it is worth more when it names the rules and admits its limit: a secret
with no recognisable shape cannot be found this way, so a clean result is evidence rather than
proof.

**A file with nothing masked anywhere gets called out.** That reads identically whether nothing
sensitive was logged or `redactionEnabled=false` — and the second is the one worth knowing.

## Follow-up, not folded in

If the redactor caught these itself, the value would never reach the disk — an audit only ever
tells you about a leak that already happened. The same prefix set transfers, and it is anchored
enough to be nearly free. But that is the hot path, with a stated cheap-happy-path guarantee and
`AppendBenchmark` built for the question, so it wants its own PR and its own numbers: **#221**,
with this measurement in it.

The audit stays either way — it still covers a custom secret shape, `redactionEnabled=false`,
and a file written by an older version. Keeping the two implementations separate is deliberate
for the same reason: a shared scanner means one bug blinds both.

## Verified

36 tests in `stacktale-mcp`, 0 failures; full reactor `mvn -B verify` green. The blocks above
are from the built jar, not from the assertions.

Docs: README, `docs/mcp-setup.md`, the plugin README's tool table, and the fix-loop skill —
where it is framed as the step before pasting a report anywhere, and a hit as a leak that
already happened, so the fix is rotation rather than only a new pattern.
