### PR TITLE
fix(redaction): mask vendor API keys and PEM private keys by shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,19 @@ and pinned by golden-file tests.
 
 ### Fixed
 
+- **Vendor API keys and PEM private keys reached the report file.** Every redaction rule but
+  one needs *context* — a keyword before the value, a scheme word, a quoted JSON member — so a
+  credential sitting in an ordinary log sentence had nothing around it to recognise. Measured
+  against the previous redactor, six of eight prefixed vendor credentials passed through
+  intact, and a `-----BEGIN RSA PRIVATE KEY-----` block went into the file verbatim although
+  SECURITY.md listed private-key blocks under *Masks*. Now caught by shape: AWS, GitHub,
+  OpenAI, Stripe, Slack and Google prefixes, and a PEM block masked from its header to the end
+  of the value — the header is harmless, the bytes after it are the key. There is deliberately
+  no entropy heuristic: on a file of stack traces that fires on class names and hashes, and a
+  redactor that eats class names is worse than one that misses a token. **Free on the hot
+  path**: the six-branch alternation alone cost +23% per redacted value (5092 → 6296 ns over
+  eight representative report lines, three interleaved rounds), and an `indexOf` gate in front
+  of it brings that back to 5027 ns — below the run-to-run spread of the old code. (#221)
 - **`st-json/1` dropped the `repro:` seed the text format carries.** FORMAT.md §7 opens its
   correspondence table with "Both formats carry the same information"; `JsonReportRenderer` is
   242 lines and the string `repro` appeared in none of them. An application on `format=json`

--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ itself on startup, and the file header explains the format to any AI that opens 
 
 > **Add `errors-ai.log*` to your `.gitignore`.** Reports carry MDC values, log arguments
 > and exception field values — everything stacktale captured at the moment of the error.
-> stacktale redacts common secrets by default (JWTs, bearer tokens, passwords — see
+> stacktale redacts common secrets by default (JWTs, bearer tokens, passwords, vendor API
+> keys — see
 > [SECURITY.md](SECURITY.md)), but the file is still request-scoped data and does not
 > belong in version control.
 
@@ -465,8 +466,9 @@ On the roadmap: an idiomatic starter for **Micronaut** (#81) — already usable 
 | restarts | `─── app start … ───` markers separate application runs |
 
 Everything user-controlled is **redacted by default** (JWTs, bearer tokens,
-`password=...` pairs, long hex secrets, emails, Luhn-valid card numbers) and flattened to
-one line per section. Uncaught exceptions (threads dying without any `log.error`) flow
+`password=...` pairs, long hex secrets, emails, Luhn-valid card numbers, and
+vendor-prefixed API keys — AWS, GitHub, OpenAI, Stripe, Slack, Google — plus PEM private
+key blocks) and flattened to one line per section. Uncaught exceptions (threads dying without any `log.error`) flow
 through the same pipeline.
 
 ## Performance (measured, JMH)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,8 +20,11 @@ is **read-only** and speaks JSON-RPC over **stdio** — there is no network list
 **Redaction is on by default** — know its edges:
 
 - **Masks:** values of secret-named keys (including compound keys like `db.password`,
-  `x-api-key`), secret-*shaped* values (high-entropy tokens, `Bearer …`, private-key
-  blocks), and message arguments at positions your patterns mark.
+  `x-api-key`), secret-*shaped* values (`Bearer …`, JWTs, long hex runs, PEM private-key
+  blocks, and vendor-prefixed API keys — AWS, GitHub, OpenAI, Stripe, Slack, Google), and
+  message arguments at positions your patterns mark. The vendor prefixes matter because
+  everything else on this line needs a keyword or a scheme word beside the value; a key
+  named by nothing is caught by its own shape.
 - **Can't know:** a secret in an unusual shape under a benign name. Redaction is a strong
   default, not a guarantee.
 - **Harden it:** add your own `redactPattern`s; set `captureExceptionFields=false` to stop
@@ -29,7 +32,9 @@ is **read-only** and speaks JSON-RPC over **stdio** — there is no network list
   sensitive state); weigh `redactionCorrelation` (a keyed hash of masked values — see
   [docs/FORMAT.md](docs/FORMAT.md)) against your threat model.
 - **Verify before you trust it:** in **dev**, read `errors-ai.log` and confirm nothing
-  sensitive leaks before wiring it near prod. (A redaction self-audit tool is planned.)
+  sensitive leaks before wiring it near prod. The `audit_redaction` tool in `stacktale-mcp`
+  does the mechanical half — it scans the file for credential shapes and reports where,
+  never the value. Run it before attaching a report file to a ticket, a PR or a CI artifact.
 
 **What ends up in the file** (by design): the distilled exception chain, the log message and
 args, MDC, exception field values (unless disabled), the recent story of the same

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -267,7 +267,8 @@ Rules:
   `error.culprit`, `stack`, `env`) are **omitted** when empty — absence is the signal.
 - A no-throwable report has `"error": { "noException": true, "message": "…" }` and no `stack`.
 - Redaction is identical to the text format: a secret-named key masks its value, a
-  secret-position arg becomes `███`, secret-shaped values are redacted. Multi-line values
+  secret-position arg becomes `███`, secret-shaped values are redacted — including
+  vendor-prefixed API keys, which carry no keyword beside them. Multi-line values
   keep their newlines (JSON-escaped) instead of being flattened.
 - `mdc` also carries SLF4J 2.0 event key-values (`addKeyValue`), merged with the MDC map.
 - The `logger` is the full name (the text format abbreviates it for display; JSON does not).

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/Redactor.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/Redactor.java
@@ -68,6 +68,64 @@ final class Redactor {
             "(?i)\\b(bearer|basic)\\s+([A-Za-z0-9._~+/=-]{16,})");
     private static final Pattern JWT = Pattern.compile(
             "\\beyJ[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{4,}\\b");
+    /**
+     * Credentials recognisable on their own, by the prefix the vendor put on them.
+     *
+     * <p>Every other rule here needs <em>context</em> — a keyword before the value, a scheme
+     * word, a quoted JSON member. A credential in an ordinary sentence has none:
+     * {@code "upload failed for key AKIAIOSFODNN7EXAMPLE"} is not {@code key=…}, not hex, not a
+     * JWT, and used to travel intact into a file that gets attached to tickets and CI artifacts
+     * (#221; `audit_redaction` in stacktale-mcp is what found it).
+     *
+     * <p>These are safe to mask on shape alone because the prefix is the evidence: {@code AKIA}
+     * followed by sixteen upper-alphanumerics is an AWS access key id and essentially nothing
+     * else. There is deliberately no entropy heuristic — on a file of stack traces that fires on
+     * class names, base64 payloads and hashes, and a redactor that eats class names is worse
+     * than one that misses a token.
+     *
+     * <p>One alternation rather than six patterns: one pass over the value, and {@code Pattern}
+     * can still pre-scan for the literal prefixes, so a value containing none of them is
+     * rejected without entering the machine.
+     */
+    private static final Pattern VENDOR_TOKEN = Pattern.compile(
+            "\\b(?:(?:AKIA|ASIA)[0-9A-Z]{16}"              // AWS access key id
+            + "|gh[pousr]_[A-Za-z0-9]{36,}"                 // GitHub token
+            + "|sk-(?:proj-)?[A-Za-z0-9_-]{20,}"            // OpenAI-style key
+            + "|(?:sk|rk)_(?:live|test)_[A-Za-z0-9]{16,}"   // Stripe secret key
+            + "|xox[baprs]-[A-Za-z0-9-]{10,}"               // Slack token
+            // {35,} rather than {35}: a Google key is 39 characters, but an exact count leaves
+            // the tail of anything longer sitting in the report next to a ███, which reads as
+            // masked and is not
+            + "|AIza[0-9A-Za-z_-]{35,})");                  // Google API key
+
+    /**
+     * A PEM private key, masked from its header to the end of the value.
+     *
+     * <p>Not just the header line: the header is harmless and the bytes after it are the key.
+     * Whatever else shares the value with a private key is not worth preserving, so this takes
+     * the remainder — including across newlines, since redaction runs before values are
+     * flattened to one line.
+     */
+    private static final Pattern PRIVATE_KEY_BLOCK = Pattern.compile(
+            "(?s)-----BEGIN [A-Z ]*PRIVATE KEY-----.*");
+
+    /**
+     * Cheap gate in front of {@link #VENDOR_TOKEN}.
+     *
+     * <p>An alternation of six branches has no single required literal, so the engine tries
+     * every branch at every position of every value — and nearly every value in a report
+     * contains none of them. {@code indexOf} on a short literal is intrinsified and settles
+     * that in a fraction of the time. Each marker is chosen to be rare in ordinary text:
+     * {@code gh} would fire on "through" and "light", {@code ghp_} does not.
+     */
+    private static boolean mayCarryVendorToken(String s) {
+        return s.indexOf("AKIA") >= 0 || s.indexOf("ASIA") >= 0
+                || s.indexOf("ghp_") >= 0 || s.indexOf("gho_") >= 0 || s.indexOf("ghu_") >= 0
+                || s.indexOf("ghs_") >= 0 || s.indexOf("ghr_") >= 0
+                || s.indexOf("sk-") >= 0 || s.indexOf("sk_") >= 0 || s.indexOf("rk_") >= 0
+                || s.indexOf("xox") >= 0 || s.indexOf("AIza") >= 0;
+    }
+
     private static final Pattern LONG_HEX = Pattern.compile("\\b[0-9a-fA-F]{32,}\\b");
     private static final Pattern EMAIL = Pattern.compile(
             "\\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}\\b");
@@ -127,7 +185,11 @@ final class Redactor {
         try {
             // specific before generic: KEY_VALUE would otherwise match "Authorization: Bearer"
             // and mask the word "Bearer" while leaving the token itself exposed
+            s = PRIVATE_KEY_BLOCK.matcher(s).replaceAll(m -> mask(m.group()));
             s = JWT.matcher(s).replaceAll(m -> mask(m.group()));
+            // before the context rules: those would mask `key=AKIA…` anyway, this one also
+            // catches the same token with nothing beside it
+            if (mayCarryVendorToken(s)) s = VENDOR_TOKEN.matcher(s).replaceAll(m -> mask(m.group()));
             s = BEARER_BASIC.matcher(s).replaceAll(m -> m.group(1) + " " + mask(m.group(2)));
             s = JSON_KEY_VALUE.matcher(s).replaceAll(
                     m -> '"' + m.group(1) + '"' + m.group(2) + '"' + mask(m.group(3)) + '"');

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/RedactorTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/RedactorTest.java
@@ -19,6 +19,69 @@ class RedactorTest {
                 .isEqualTo("apiKey: ███");
     }
 
+    /**
+     * Every other rule needs context — a keyword before the value, a scheme word, a quoted JSON
+     * member. These six are the ones that used to travel intact when a log line simply mentioned
+     * them, which is how a credential reached a file that gets attached to tickets and CI
+     * artifacts (#221). Written as whole sentences on purpose: the failing case was never
+     * `key=<secret>`, it was the secret inside prose.
+     */
+    @Test
+    void masksVendorCredentialsWithNoKeywordBesideThem() {
+        assertThat(redactor.redact("upload failed for bucket orders, key AKIAIOSFODNN7EXAMPLE rejected"))
+                .isEqualTo("upload failed for bucket orders, key ███ rejected");
+        assertThat(redactor.redact("clone failed: ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 is expired"))
+                .isEqualTo("clone failed: ███ is expired");
+        assertThat(redactor.redact("openai call failed with sk-proj-abcdefghijklmnopqrstuvwxyz012345"))
+                .isEqualTo("openai call failed with ███");
+        assertThat(redactor.redact("charge failed key sk_live_abcdefghijklmnop1234"))
+                .isEqualTo("charge failed key ███");
+        assertThat(redactor.redact("slack post failed xoxb-1234567890-abcdefghijkl"))
+                .isEqualTo("slack post failed ███");
+        // a Google key is AIza + 35; the pattern takes a longer run too, so no tail is left
+        // sitting next to a ███ looking masked
+        assertThat(redactor.redact("maps lookup failed AIzaSyD-abcdefghijklmnopqrstuvwxyz01234567"))
+                .isEqualTo("maps lookup failed ███");
+    }
+
+    /**
+     * A redactor that eats class names is worse than one that misses a token: reports are mostly
+     * stack frames and identifiers, and a mask over one of those destroys the diagnosis while
+     * protecting nothing.
+     */
+    @Test
+    void leavesOrdinaryReportTextAlone() {
+        String[] ordinary = {
+                "at com.acme.shop.PaymentService.charge(PaymentService.java:118)",
+                "at org.springframework.web.servlet.DispatcherServlet.doDispatch(DispatcherServlet.java:1072)",
+                "IllegalStateException: SKIPPED_VALIDATION for order 889",
+                "built from commit 7e3c1f2a9b (branch release/1.4.0)",
+                "checksum mismatch: expected AAAABBBBCCCCDDDD got EEEEFFFFGGGGHHHH",
+                "GET /api/v2/orders?status=SHIPPED&page=3 returned 502",
+        };
+        for (String line : ordinary) {
+            assertThat(redactor.redact(line))
+                    .withFailMessage("redacted ordinary report text: %s -> %s", line, redactor.redact(line))
+                    .isEqualTo(line);
+        }
+    }
+
+    /**
+     * The header is harmless; the bytes after it are the key. Masking the header alone would
+     * leave the key in the report under a line that looks handled.
+     */
+    @Test
+    void masksAPrivateKeyBlockToTheEndOfTheValue() {
+        String pem = "config load failed: -----BEGIN RSA PRIVATE KEY-----\n"
+                + "MIIEowIBAAKCAQEAxLd1qUvXm8pQ\nnB2fake+key+material+here\n"
+                + "-----END RSA PRIVATE KEY-----";
+
+        String redacted = redactor.redact(pem);
+
+        assertThat(redacted).isEqualTo("config load failed: ███");
+        assertThat(redacted).doesNotContain("MIIEow");
+    }
+
     @Test
     void masksBearerAndJwt() {
         assertThat(redactor.redact("header Authorization: Bearer abcdef1234567890TOKENVALUE"))

--- a/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/RedactionAudit.java
+++ b/stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/RedactionAudit.java
@@ -47,7 +47,7 @@ final class RedactionAudit {
                     "a Stripe secret key"),
             new Rule("slack-token", Pattern.compile("\\bxox[baprs]-[A-Za-z0-9-]{10,}\\b"),
                     "a Slack token"),
-            new Rule("google-api-key", Pattern.compile("\\bAIza[0-9A-Za-z_-]{35}\\b"),
+            new Rule("google-api-key", Pattern.compile("\\bAIza[0-9A-Za-z_-]{35,}"),
                     "a Google API key"),
             new Rule("jwt", Pattern.compile("\\beyJ[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{8,}\\.[A-Za-z0-9_-]{4,}"),
                     "a JWT"),


### PR DESCRIPTION
Closes #221.

`audit_redaction` (#222) tells you a credential reached the file. This stops it getting there.

Every redaction rule but one needs **context** — a keyword before the value, a scheme word, a
quoted JSON member, a long hex run. A credential sitting in an ordinary log sentence has none
of that, so it travelled intact. Measured against the previous redactor:

```
THROUGH  | upload failed for bucket orders, key AKIAIOSFODNN7EXAMPLE rejected
THROUGH  | clone failed: ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789 is expired
THROUGH  | openai call failed with sk-proj-abcdefghijklmnopqrstuvwxyz012345
THROUGH  | charge failed key sk_live_abcdefghijklmnop1234
THROUGH  | slack post failed xoxb-1234567890-abcdefghijkl
THROUGH  | maps lookup failed AIzaSyD-abcdefghijklmnopqrstuvwxyz01234567
```

All six are masked now, by the prefix the vendor put on them. `AKIA` plus sixteen
upper-alphanumerics is an AWS access key id and essentially nothing else — which is why there
is deliberately **no entropy heuristic**: on a file of stack traces that fires on class names,
base64 payloads and hashes, and a redactor that eats class names is worse than one that misses
a token. There is a test pinning six ordinary report lines — stack frames, a commit sha, a
query string, an ALL_CAPS enum — as untouched.

## A promise SECURITY.md was already making

SECURITY.md lists **private-key blocks** under *Masks*. It was not true:

```
main   : LEAKED  | config load failed: -----BEGIN RSA PRIVATE KEY-----\nMIIEowIBAAKCAQEAxLd1qUvXm8pQnB2fake…
branch : MASKED  | config load failed: ███
```

None of the existing rules matches a PEM header, and the body is base64 rather than hex, so
`LONG_HEX` never fired either. It is masked **from the header to the end of the value**, not
just the header line: the header is harmless and the bytes after it are the key. Whatever else
shares a value with a private key is not worth preserving.

## Free on the hot path, and that took a second attempt

This runs on every rendered value of every report, and CONTRIBUTING states a cheap-happy-path
guarantee, so "should be close to free" was not good enough. `AppendBenchmark` measures the
appender path, where redaction is a small share — the happy path never reaches it and a
repeated error renders once then writes summaries — so I timed `redact` directly over eight
lines shaped like the ones a report actually carries, interleaving the variants in one session
to cancel drift:

| variant | round 1 | round 2 | round 3 |
|---|---|---|---|
| before | 5092 | 5114 | 5074 ns/line |
| + rules, plain | 6233 | 6306 | 6296 ns/line |
| + rules, gated | 4992 | 5078 | 5027 ns/line |

**+23% for the alternation on its own.** A six-branch alternation has no single required
literal, so the engine tries every branch at every position of every value — and nearly every
value in a report contains none of them. An `indexOf` gate in front settles that in a fraction
of the time: intrinsified, and each marker chosen to be rare in prose (`gh` would fire on
"through" and "light"; `ghp_` does not).

Gated, it lands below the run-to-run spread of the old code. I am not claiming it made
redaction faster — that difference is noise. The claim is that the new rules cost nothing
measurable, and the middle row is why the gate is there rather than a tidiness preference.

The first two rows also answer a question this repo has been bitten by before: a single
before/after pair on this machine drifted ~8% between sessions, which is larger than the effect
being measured. Interleaved rounds are the only reason these numbers mean anything.

## Verified

134 tests in `stacktale-core` (three new: the six vendor shapes, the false-positive set, the
PEM block), full reactor `mvn -B verify` green. Every measurement above is from the built
classes, with `main`'s `Redactor` compiled separately and shadowed onto the classpath so both
versions run in the same session.

`RedactionAudit`'s Google rule moves to `{35,}` alongside the redactor's, for the same reason:
an exact count leaves the tail of a longer token sitting next to a `███`, which reads as masked
and is not. The two rule sets stay separate implementations — the audit's value is being an
independent check, and a shared scanner means one bug blinds both.

Docs: SECURITY.md (both the Masks list and the verify step, which no longer calls the audit
tool "planned" now that #222 shipped it), README, and FORMAT.md §7.
