### PR TITLE
feat: stacktale's own counters, and Micrometer meters for them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and pinned by golden-file tests.
 
 ### Added
 
+- **stacktale's own counters, and Micrometer meters for them.** An error reporter is the one
+  component whose failure is invisible by construction: the way it would tell you something
+  broke is the thing that broke. `ReportPipeline.stats()` — reachable as `stats()` on the
+  Logback, Log4j2 and JUL adapters — reports what was written, what dedup and the rate limit
+  held back, how many throwables the never-throw guarantee swallowed, how often the file
+  rotated, and two states. **`parked` is the one to alert on**: after repeated write failures
+  the pipeline stops producing for the rest of the run, and until now the only trace was a
+  single warning at the moment it happened. The Spring starter publishes all of it as
+  `stacktale.*` meters when Micrometer is on the classpath, and costs nothing when it is not.
+  Every increment is on the error path, so the cheap happy path is untouched. (#96)
 - **MCP: `audit_redaction` checks the file before you share it.** Redaction masks what it can
   recognise by context — `password=…`, a JSON `"token"` member, `Authorization: Bearer …`, a
   long hex run — so a credential sitting in an ordinary log sentence has nothing around it to

--- a/README.md
+++ b/README.md
@@ -564,6 +564,14 @@ a subscription that pushes a notification the moment a new error lands. No netwo
 writes. Per-client setup (Claude Code, Claude Desktop, Cursor) and the loop recipe in
 [docs/mcp-setup.md](docs/mcp-setup.md).
 
+**Is it working?** `stacktale.*` Micrometer meters answer that when Micrometer is on the
+classpath (nothing to configure, nothing to pay without it): reports and summaries written,
+occurrences held back by dedup and by the rate limit, throwables swallowed on the report path,
+file rotations, and two states. Alert on **`stacktale.parked`** — after repeated write failures
+the pipeline stops producing for the rest of the run, and an error reporter that has quietly
+stopped reporting is the failure that hides itself. Outside Spring, the same numbers come from
+`appender.stats()`.
+
 Shipping to aggregators instead? Set `emitReportsToLogger=true` and each report block is
 also emitted as ONE log event through logger `stacktale.reports` — attach your existing
 Loki/ELK/CloudWatch shipper to that logger and production reports reach your incident

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportPipeline.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportPipeline.java
@@ -205,6 +205,25 @@ public final class ReportPipeline {
             new java.util.concurrent.atomic.AtomicInteger();
     private volatile boolean parked;
     private final AtomicBoolean announced = new AtomicBoolean();
+
+    /**
+     * stacktale's own counters (#96). Ops has no other way to answer "is it running, and is it
+     * still writing?" — a pipeline that never throws is also a pipeline that fails quietly.
+     *
+     * <p>Every increment is on the error path. A non-error event returns before the first of
+     * them, so the cheap happy path stays exactly as cheap; an atomic add against a report that
+     * already cost a distill, a render and a write is not measurable.
+     */
+    private final java.util.concurrent.atomic.AtomicLong reportsWritten =
+            new java.util.concurrent.atomic.AtomicLong();
+    private final java.util.concurrent.atomic.AtomicLong summariesWritten =
+            new java.util.concurrent.atomic.AtomicLong();
+    private final java.util.concurrent.atomic.AtomicLong dedupSuppressed =
+            new java.util.concurrent.atomic.AtomicLong();
+    private final java.util.concurrent.atomic.AtomicLong stormSuppressed =
+            new java.util.concurrent.atomic.AtomicLong();
+    private final java.util.concurrent.atomic.AtomicLong failures =
+            new java.util.concurrent.atomic.AtomicLong();
     /**
      * When a logical thread last produced a full report — used to suppress container echoes.
      * Keyed by the event's thread NAME (not the physical thread) so it stays correct under
@@ -284,6 +303,39 @@ public final class ReportPipeline {
     }
 
     /**
+     * A snapshot of what this pipeline has done, for health checks and metrics (#96).
+     *
+     * <p>{@code parked} is the one to alarm on. After repeated write failures the pipeline stops
+     * producing for the rest of the run — deliberately, so a dead destination cannot burn the
+     * application's CPU forever — and until now the only trace was one warning at the moment it
+     * happened. An error-reporting tool that has silently stopped reporting is the failure this
+     * is here to make visible.
+     *
+     * <p>{@code dedupSuppressed} counts occurrences held back by the dedup window, {@code
+     * stormSuppressed} those the rate limit dropped: both are errors that happened and were not
+     * written, and a report file is misread without them.
+     *
+     * @param active false when configuration was broken at startup and this is a no-op
+     */
+    public record Stats(
+            boolean active,
+            boolean parked,
+            long reportsWritten,
+            long summariesWritten,
+            long dedupSuppressed,
+            long stormSuppressed,
+            long failures,
+            long rotations
+    ) {}
+
+    /** Counters as of now; cheap enough to call from a metrics scrape. */
+    public Stats stats() {
+        return new Stats(isActive(), parked, reportsWritten.get(), summariesWritten.get(),
+                dedupSuppressed.get(), stormSuppressed.get(), failures.get(),
+                writer == null ? 0L : writer.rotations());
+    }
+
+    /**
      * The report file as an absolute path, for every line a human reads.
      *
      * <p>The configured value is normally relative ({@code errors-ai.log}), and it resolves
@@ -338,6 +390,7 @@ public final class ReportPipeline {
                     StormLimiter.Outcome storm = stormLimiter.onReport();
                     if (storm.action() == StormLimiter.Action.SUPPRESS) {
                         deduper.rollback(fingerprint); // #51: report not written — re-arm a fresh one
+                        stormSuppressed.incrementAndGet();
                         return;
                     }
                     if (storm.action() == StormLimiter.Action.STORM_LINE) {
@@ -345,6 +398,7 @@ public final class ReportPipeline {
                             writer.append(renderer.stormLine(storm.suppressed(), stormLimiter.maxPerWindow()));
                             stormLimiter.confirmStormLine(storm.suppressed()); // #57: clear only once written
                         } finally {
+                            stormSuppressed.incrementAndGet(); // this error's report was dropped too
                             // #51: this error's own report was never written — and that is true
                             // whether or not the storm line itself made it. The rollback used to
                             // sit after the append, so a failure here skipped it and left
@@ -379,6 +433,7 @@ public final class ReportPipeline {
                     }
                     // past this point the report is on disk: a failing shipper must not
                     // undo dedup state (that would duplicate the next occurrence's report)
+                    reportsWritten.incrementAndGet();
                     deduper.confirmReport(fingerprint); // #51: clears the retry flag now it's written
                     String reportedOn = ThreadKey.of(event);
                     if (reportedOn != null) {
@@ -394,11 +449,13 @@ public final class ReportPipeline {
                     // only now is the count durably on file; a failed append above throws
                     // to the outer catch and leaves it pending for close()'s drainPending()
                     deduper.confirmWritten(fingerprint, decision.count());
+                    summariesWritten.incrementAndGet();
                 }
-                case SILENT -> { /* counted; nothing to write */ }
+                case SILENT -> dedupSuppressed.incrementAndGet(); // counted; nothing to write
             }
             consecutiveFailures.set(0); // the write path is healthy again
         } catch (Throwable t) {
+            this.failures.incrementAndGet();
             int failures = consecutiveFailures.incrementAndGet();
             if (warnedOnce.compareAndSet(false, true)) {
                 host.warn("stacktale failed to process an event", t);

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportWriter.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportWriter.java
@@ -42,6 +42,12 @@ final class ReportWriter {
     private final BiConsumer<String, Throwable> warn;
     private boolean sessionHandled;
     private boolean rotationBlockedWarned;
+    /**
+     * Completed rotations, for {@code ReportPipeline.Stats} (#96). Guarded by the same monitor
+     * as {@code append}, so a plain long is enough; it is read from another thread, where a
+     * stale value costs a metrics scrape nothing.
+     */
+    private long rotations;
 
     ReportWriter(Path file, long maxBytes, String header,
                  String sessionMarker, boolean truncateOnStart, int maxBackups) {
@@ -96,6 +102,7 @@ final class ReportWriter {
             long size = Files.exists(file) ? Files.size(file) : 0;
             byte[] bytes = block.getBytes(StandardCharsets.UTF_8);
             if (size > 0 && size + bytes.length > maxBytes && tryRotate()) {
+                rotations++;
                 size = 0;
             }
             if (size == 0) {
@@ -123,6 +130,11 @@ final class ReportWriter {
 
     private void appendBytes(byte[] bytes) throws IOException {
         Files.write(file, bytes, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+    }
+
+    /** Completed rotations this run. A blocked rotation is not one — the file kept growing. */
+    long rotations() {
+        return rotations;
     }
 
     /**

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportPipelineTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportPipelineTest.java
@@ -272,6 +272,58 @@ class ReportPipelineTest {
         assertThat(f.summaryCount()).isGreaterThan(summariesBeforeClose);
     }
 
+    /**
+     * The counters have to agree with the file, or they are a second story about the same run.
+     * Asserted side by side with the block counts for exactly that reason.
+     */
+    @Test
+    void statsCountWhatReachedTheFileAndWhatDidNot(@TempDir Path dir) {
+        Fixture f = fixture(dir, 1); // one full report per window
+
+        f.pipeline().process(error("alpha", f.clock().get()));  // ALLOW -> written
+        f.pipeline().process(error("alpha", f.clock().get()));  // repeat -> summary
+        f.pipeline().process(error("beta", f.clock().get()));   // over limit -> STORM_LINE
+        f.pipeline().process(error("gamma", f.clock().get()));  // over limit -> SUPPRESS
+
+        ReportPipeline.Stats stats = f.pipeline().stats();
+
+        assertThat(stats.active()).isTrue();
+        assertThat(stats.parked()).isFalse();
+        assertThat(stats.reportsWritten()).isEqualTo(f.reportCount());
+        assertThat(stats.summariesWritten()).isEqualTo(f.summaryCount());
+        // two errors happened and produced no report of their own — the number a report file
+        // cannot tell you, and the reason these counters exist
+        assertThat(stats.stormSuppressed()).isEqualTo(2);
+        assertThat(stats.failures()).isZero();
+    }
+
+    /**
+     * The state worth alarming on. A parked pipeline has stopped reporting for the rest of the
+     * run, and the only other trace is one warning at the moment it happened.
+     */
+    @Test
+    void statsReportParkedOnceThePipelineHasGivenUp(@TempDir Path dir) {
+        Fixture f = fixture(dir, 0);
+
+        f.pipeline().process(error("alpha", f.clock().get()));
+        assertThat(f.pipeline().stats().parked()).isFalse();
+
+        try {
+            Files.delete(f.file());
+            Files.createDirectory(f.file()); // every append from here fails
+        } catch (java.io.IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        for (int i = 0; i < 6; i++) {
+            f.pipeline().process(error("failure" + i, f.clock().get()));
+        }
+
+        ReportPipeline.Stats stats = f.pipeline().stats();
+        assertThat(stats.parked()).isTrue();
+        assertThat(stats.failures()).isGreaterThanOrEqualTo(5);
+        assertThat(stats.reportsWritten()).isEqualTo(1); // only the one from before the breakage
+    }
+
     @Test
     void processNeverThrowsAndParksAfterRepeatedWriteFailures(@TempDir Path dir) {
         Fixture f = fixture(dir, 0);

--- a/stacktale-jul/src/main/java/io/github/gabrielbbaldez/stacktale/jul/StacktaleJulHandler.java
+++ b/stacktale-jul/src/main/java/io/github/gabrielbbaldez/stacktale/jul/StacktaleJulHandler.java
@@ -95,6 +95,18 @@ public final class StacktaleJulHandler extends Handler {
         return v == null || Boolean.parseBoolean(v.trim());
     }
 
+    /**
+     * stacktale's own counters, or {@code null} before the appender has started (#96).
+     *
+     * <p>The one to watch is {@code parked}: after repeated write failures the pipeline stops
+     * producing for the rest of the run, and an error reporter that has quietly stopped
+     * reporting is exactly the failure worth an alarm.
+     */
+    public ReportPipeline.Stats stats() {
+        ReportPipeline p = this.pipeline;
+        return p == null ? null : p.stats();
+    }
+
     @Override
     public void publish(LogRecord record) {
         if (record == null || !isLoggable(record)) return;

--- a/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
+++ b/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
@@ -78,6 +78,17 @@ public final class StacktaleAppender extends AbstractAppender {
         return super.stop(timeout, timeUnit);
     }
 
+    /**
+     * stacktale's own counters (#96).
+     *
+     * <p>The one to watch is {@code parked}: after repeated write failures the pipeline stops
+     * producing for the rest of the run, and an error reporter that has quietly stopped
+     * reporting is exactly the failure worth an alarm.
+     */
+    public ReportPipeline.Stats stats() {
+        return pipeline.stats();
+    }
+
     @Override
     public void append(LogEvent event) {
         try {

--- a/stacktale-spring-boot-starter/pom.xml
+++ b/stacktale-spring-boot-starter/pom.xml
@@ -47,6 +47,16 @@
       <artifactId>spring-boot-configuration-processor</artifactId>
       <optional>true</optional>
     </dependency>
+    <!--
+      Optional on purpose: the metrics binder is @ConditionalOnClass(MeterRegistry), so an
+      application without Micrometer never sees it and never pays for it. Version comes from
+      the Spring Boot BOM, so it moves with the user's Boot version rather than with ours.
+    -->
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-core</artifactId>
+      <optional>true</optional>
+    </dependency>
     <dependency>
       <groupId>jakarta.servlet</groupId>
       <artifactId>jakarta.servlet-api</artifactId>

--- a/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleAutoConfiguration.java
+++ b/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleAutoConfiguration.java
@@ -151,6 +151,27 @@ public class StacktaleAutoConfiguration {
      * {@code startsOnAReactiveAppWithNoServletApi}) — this is removing the hazard, not
      * chasing a reproduction.
      */
+    /**
+     * stacktale's own counters as Micrometer meters (#96), when Micrometer is present.
+     *
+     * <p>Nested behind a class-level condition, like the filter below. Unlike that one this is a
+     * precaution rather than a fix for an observed failure: a method-level
+     * {@code @ConditionalOnClass} on a bean returning {@code MeterBinder} also starts cleanly
+     * without Micrometer on the classpath — I flattened it and the tests stayed green. Spring
+     * reads bean metadata with ASM and never loads the return type, so nothing forces the class.
+     * The nesting keeps the two optional integrations shaped the same way and does not depend on
+     * that remaining true.
+     */
+    @Configuration(proxyBeanMethods = false)
+    @ConditionalOnClass(io.micrometer.core.instrument.MeterRegistry.class)
+    static class MetricsConfiguration {
+
+        @Bean
+        public io.micrometer.core.instrument.binder.MeterBinder stacktaleMetrics(StacktaleAppender appender) {
+            return new StacktaleMetrics(appender);
+        }
+    }
+
     @Configuration(proxyBeanMethods = false)
     @ConditionalOnClass(jakarta.servlet.Filter.class)
     @ConditionalOnWebApplication(type = ConditionalOnWebApplication.Type.SERVLET)

--- a/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleMetrics.java
+++ b/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleMetrics.java
@@ -1,0 +1,89 @@
+package io.github.gabrielbbaldez.stacktale.spring;
+
+import io.github.gabrielbbaldez.stacktale.ReportPipeline;
+import io.github.gabrielbbaldez.stacktale.logback.StacktaleAppender;
+import io.micrometer.core.instrument.FunctionCounter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+
+import java.util.function.ToDoubleFunction;
+
+/**
+ * Publishes stacktale's own counters as Micrometer meters (#96).
+ *
+ * <p>Not metrics <em>about</em> the application's errors — the reports are that. These are
+ * about stacktale: is it running, is it still writing, and how much is it holding back. An
+ * error reporter is the one component whose own failure is invisible by construction, because
+ * the way it reports problems is the thing that broke.
+ *
+ * <p>{@code stacktale.parked} is the meter worth an alert. After repeated write failures the
+ * pipeline stops producing for the rest of the run — deliberately, so a dead destination cannot
+ * burn the application's CPU forever — and the only other trace is one warning at the moment it
+ * happened, hours before anyone looks.
+ *
+ * <p>Registered only when Micrometer is on the classpath, so an application without it never
+ * pays for this.
+ */
+class StacktaleMetrics implements MeterBinder {
+
+    private final StacktaleAppender appender;
+
+    StacktaleMetrics(StacktaleAppender appender) {
+        this.appender = appender;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        counter(registry, "stacktale.reports", "Full st/ report blocks written",
+                ReportPipeline.Stats::reportsWritten);
+        counter(registry, "stacktale.summaries", "Repeat-count summary lines written",
+                ReportPipeline.Stats::summariesWritten);
+        counter(registry, "stacktale.suppressed.dedup",
+                "Occurrences held back by the dedup window — errors that happened and were not written",
+                ReportPipeline.Stats::dedupSuppressed);
+        counter(registry, "stacktale.suppressed.storm",
+                "Reports dropped by the per-minute rate limit",
+                ReportPipeline.Stats::stormSuppressed);
+        counter(registry, "stacktale.failures",
+                "Throwables swallowed on the report path — the never-throw guarantee, counted",
+                ReportPipeline.Stats::failures);
+        counter(registry, "stacktale.rotations", "Times the report file rolled",
+                ReportPipeline.Stats::rotations);
+
+        // Two states rather than one meter with a tag: "configured badly at startup" and
+        // "gave up after failing to write" are different incidents with different fixes.
+        gauge(registry, "stacktale.active",
+                "1 while the pipeline is configured and able to write, 0 when startup config was broken",
+                stats -> stats.active() ? 1 : 0);
+        gauge(registry, "stacktale.parked",
+                "1 once the pipeline has stopped producing after repeated write failures — alert on this",
+                stats -> stats.parked() ? 1 : 0);
+    }
+
+    private void counter(MeterRegistry registry, String name, String description,
+                         ToDoubleFunction<ReportPipeline.Stats> value) {
+        FunctionCounter.builder(name, appender, a -> read(a, value))
+                .description(description)
+                .register(registry);
+    }
+
+    private void gauge(MeterRegistry registry, String name, String description,
+                       ToDoubleFunction<ReportPipeline.Stats> value) {
+        Gauge.builder(name, appender, a -> read(a, value))
+                .description(description)
+                .register(registry);
+    }
+
+    /**
+     * Reads one counter, tolerating an appender that has not started yet.
+     *
+     * <p>Meters are registered when the context comes up, which can be before the appender is
+     * attached; {@code stats()} answers {@code null} until then. Zero is the honest reading for
+     * "nothing has happened yet", and it keeps a scrape during startup from failing.
+     */
+    private static double read(StacktaleAppender appender, ToDoubleFunction<ReportPipeline.Stats> value) {
+        ReportPipeline.Stats stats = appender.stats();
+        return stats == null ? 0 : value.applyAsDouble(stats);
+    }
+}

--- a/stacktale-spring-boot-starter/src/test/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleMetricsTest.java
+++ b/stacktale-spring-boot-starter/src/test/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleMetricsTest.java
@@ -1,0 +1,73 @@
+package io.github.gabrielbbaldez.stacktale.spring;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * stacktale's own counters, published as meters (#96).
+ *
+ * <p>An error reporter is the one component whose failure is invisible by construction: the way
+ * it would tell you something broke is the thing that broke. These meters are how an operator
+ * finds out anyway.
+ */
+class StacktaleMetricsTest {
+
+    private final ApplicationContextRunner runner = new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(StacktaleAutoConfiguration.class));
+
+    @Test
+    void theMetersFollowWhatThePipelineActuallyWrote() {
+        Path file = Path.of("target", "metrics-test-errors.log");
+        try {
+            Files.deleteIfExists(file);
+        } catch (Exception ignored) {
+            // a leftover from a previous run only affects the file, not the counters
+        }
+
+        runner.withPropertyValues("stacktale.file=" + file).run(context -> {
+            MeterRegistry registry = new SimpleMeterRegistry();
+            context.getBean(MeterBinder.class).bindTo(registry);
+
+            // nothing has happened yet: registered, readable, and honest about being at zero
+            assertThat(registry.get("stacktale.reports").functionCounter().count()).isZero();
+            assertThat(registry.get("stacktale.active").gauge().value()).isEqualTo(1);
+            assertThat(registry.get("stacktale.parked").gauge().value()).isZero();
+
+            org.slf4j.LoggerFactory.getLogger("com.acme.Svc")
+                    .error("charge failed", new IllegalStateException("gateway timeout"));
+
+            assertThat(registry.get("stacktale.reports").functionCounter().count()).isEqualTo(1);
+            assertThat(registry.get("stacktale.failures").functionCounter().count()).isZero();
+        });
+    }
+
+    /**
+     * Micrometer is an optional dependency, so the common case is an application without it —
+     * and it has to start exactly as before, with the appender still in place.
+     *
+     * <p>This does not prove the nesting is what makes that work: flattening the binder to a
+     * method-level {@code @ConditionalOnClass} passes here too, because Spring reads bean
+     * metadata with ASM and never loads the return type. What it pins is the behaviour users
+     * depend on, whichever arrangement provides it.
+     */
+    @Test
+    void anApplicationWithoutMicrometerStartsWithoutIt() {
+        runner.withClassLoader(new FilteredClassLoader(MeterRegistry.class))
+                .withPropertyValues("stacktale.file=target/metrics-absent-errors.log")
+                .run(context -> {
+                    assertThat(context).hasNotFailed();
+                    assertThat(context).hasSingleBean(
+                            io.github.gabrielbbaldez.stacktale.logback.StacktaleAppender.class);
+                });
+    }
+}

--- a/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
+++ b/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
@@ -294,6 +294,18 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
         return Csv.parse(s);
     }
 
+    /**
+     * stacktale's own counters, or {@code null} before the appender has started (#96).
+     *
+     * <p>The one to watch is {@code parked}: after repeated write failures the pipeline stops
+     * producing for the rest of the run, and an error reporter that has quietly stopped
+     * reporting is exactly the failure worth an alarm.
+     */
+    public ReportPipeline.Stats stats() {
+        ReportPipeline p = this.pipeline;
+        return p == null ? null : p.stats();
+    }
+
     // --- Logback config setters ---
 
     public void setFile(String file) { this.file = file; }


### PR DESCRIPTION
Closes #96.

An error reporter is the one component whose failure is invisible by construction: the way it
would tell you something broke is the thing that broke. Today an operator has no way to answer
"is stacktale running, and is it still writing".

The sharp case is `parked`. After five consecutive write failures the pipeline stops producing
for the rest of the run — deliberately, so a dead destination cannot burn the application's CPU
forever — and the only trace is one warning at the moment it happens, hours before anyone looks
at the file and finds it ends mid-afternoon.

## What is counted

`ReportPipeline.stats()` returns a snapshot: `active`, `parked`, `reportsWritten`,
`summariesWritten`, `dedupSuppressed`, `stormSuppressed`, `failures`, `rotations`.

Two of those are numbers the report file **cannot** give you. `dedupSuppressed` and
`stormSuppressed` are errors that happened and were deliberately not written; without them the
file reads as though they never occurred.

`stats()` is on the Logback, Log4j2 and JUL adapters, not just the one the starter uses — the
same class of gap as #210, and not worth repeating.

## Micrometer

The Spring starter publishes them as `stacktale.*` meters: `FunctionCounter` for the monotonic
ones, `Gauge` for `active` and `parked`. `micrometer-core` is an `<optional>` dependency behind
`@ConditionalOnClass`, so an application without Micrometer never sees it. Its version comes
from the Spring Boot BOM, so it moves with the user's Boot version rather than with ours.

`active` and `parked` are two meters rather than one with a tag: "configured badly at startup"
and "gave up after failing to write" are different incidents with different fixes.

## A comment I had to take back

I first wrote that the binder is nested inside a `@Configuration` "for the same reason as the
servlet filter" — that a method-level condition would leave `MeterBinder` in a signature Spring
must load, the shape #62 hit. Then I flattened it to check, and **the tests stayed green**:
Spring reads bean metadata with ASM and never loads the return type.

The nesting stays, because it keeps the two optional integrations shaped alike and does not
depend on that remaining true. The comment now says that, rather than claiming a danger I could
not reproduce. The test's javadoc says the same: it pins the behaviour users depend on, not the
mechanism.

## Verified

The counters are asserted **side by side with the file's own block counts** — a counter that
disagrees with the file is a second story about the same run:

```java
assertThat(stats.reportsWritten()).isEqualTo(f.reportCount());
assertThat(stats.summariesWritten()).isEqualTo(f.summaryCount());
assertThat(stats.stormSuppressed()).isEqualTo(2);   // the two the file cannot show
```

The park case breaks the destination mid-test (the report file becomes a directory) and asserts
`parked` flips while `reportsWritten` stays at the one report from before the breakage. The
Micrometer test reads a meter at zero, logs one error, and reads it at one — a before/after
inside one run, so it cannot pass vacuously.

`stacktale-core` 136, starter 13, full reactor `mvn -B verify` green.

## Cost

Nothing on the happy path: a non-error event returns before the first increment, so the
cheap-happy-path guarantee is untouched. On the error path an atomic add sits next to a
distill, a render and a file write.
