### PR TITLE
feat: deploy provenance — `first seen: NEW in this build`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and pinned by golden-file tests.
 
 ### Added
 
+- **`first seen: NEW in this build (7e3c1f)` — deploy provenance.** The first question of any
+  triage is whether the change just shipped caused the failure, and a report could not answer
+  it: `seen:` is session-scoped and resets on restart, and the `env:` line names the build the
+  error happened *on*, never the build it started on. With `provenance=true`, stacktale keeps a
+  bounded `<report file>.seen` sidecar recording which build each error id was first seen on,
+  and leads with `NEW in this build` or `build 9a2b1c, 2 builds ago`. Strictly local — no
+  network, no account — and it works at all only because the report id already survives edits to
+  the source. Off by default, since it writes a second file. Missing, corrupt or unwritable, the
+  sidecar costs that one line and nothing else; the count of builds is omitted rather than
+  invented when the first build has been evicted. In `st-json/1` as `firstSeen`, with
+  `newInThisBuild` as a boolean so a dashboard never matches on English. (#137)
 - **stacktale's own counters, and Micrometer meters for them.** An error reporter is the one
   component whose failure is invisible by construction: the way it would tell you something
   broke is the thing that broke. `ReportPipeline.stats()` — reachable as `stats()` on the

--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ Everything is optional — as appender properties in `logback.xml`, or `stacktal
 | `reportErrorsWithoutThrowable` | `true` | `log.error(...)` without exception still reports |
 | `captureExceptionFields` | `true` | Read exception getters into `fields:` |
 | `repro` | `false` | Add a `repro:` seed: the throw site's typed signature and argument values. Needs `stacktale-agent`. Off by default — it is the only section that renders values against a named signature |
+| `provenance` | `false` | Remember across restarts which build each error was first seen on, and lead the report with `first seen: NEW in this build (7e3c1f)` or `first seen: build 9a2b1c, 2 builds ago`. Writes a `<file>.seen` sidecar; nothing leaves the machine |
 | `redactionEnabled` | `true` | Mask secrets/PII in report content |
 | `redactPattern` / `redactPatterns` | — | Extra redaction regexes (see note below) |
 | `redactionCorrelation` | `false` | Tag masked values with a stable keyed token (`███(a1b2)`) so an AI can see the same secret recurring |

--- a/docs/FORMAT.md
+++ b/docs/FORMAT.md
@@ -99,11 +99,38 @@ Fields:
 | `log:` | the original SLF4J/Log4j2 message **pattern** (not the interpolated text), its `args`, and the logger name abbreviated `c.a.s.OrderService`. |
 | `mdc:` / `fields:` | space-separated `key=value` pairs, keys sorted. Omitted when empty. `mdc:` also carries SLF4J 2.0 event key-values (`log.atError().addKeyValue("orderId", 889)`), merged into the same line — MDC wins on a key clash. |
 | `seen:` | recurrence — `N× this session, first at <HH:mm:ss.SSS>`. Present **only** when the error has occurred before this session (its absence means the error is new). Session-scoped: resets on restart. |
+| `first seen:` | present only when `provenance` is on: which build this error id was first seen on. Detailed below. |
 | `captured:` | present only when the agent is attached; method frames with argument values. |
 | `repro:` | present only when `repro` is on **and** the agent is attached: the throw site's typed signature and argument values. Detailed below. |
 | `story` | events leading up to and including the error, oldest first. `<label>` is `traceId=…` (correlated) or `thread <name>` (fallback). The error's own line ends with `   ← this error`. A `… N earlier event(s) older than the story window omitted` line appears when events were dropped by age (vs never logged). Omitted when empty. |
 | `stack` | the distilled stack: shown frames plus `… N collapsed (<framework groups>)` markers; the culprit frame ends with `← culprit`. Omitted for reports with no throwable. |
 | `env:` | `app=<name> <version> (git <sha>) \| java <ver> \| profile=<p> \| <os>`; unknown parts degrade (`app=?`, no `(git …)`, no `profile=`). |
+
+### `first seen:` — deploy provenance
+
+Off by default. Switched on with `provenance=true`, which keeps a `<report file>.seen` sidecar
+beside the log. Nothing leaves the machine.
+
+It answers the question a triage opens with — *did the change I just shipped cause this?* —
+which no other line can. `seen:` is session-scoped and resets on restart, and the `env:` line
+names the build the error happened **on**, never the build it started on.
+
+```
+first seen: NEW in this build (7e3c1f)
+first seen: build 9a2b1c, 2 builds ago (2026-07-19)
+first seen: build 9a2b1c (2026-07-19)
+```
+
+- The first form is the one worth grepping for across a directory of reports.
+- The count of builds is **omitted** when the sidecar no longer holds the first build — after
+  eviction, or when the file was copied from another machine. A distance from an unknown
+  position would be invented.
+- The date is a date, not a timestamp: provenance spans deploys, and a millisecond there is
+  noise.
+- The build is the git sha when there is one, else the application version. With neither there
+  is no way to tell two builds apart, so the section is absent rather than misleading.
+- The sidecar is **bounded** (50 builds, 2000 ids, oldest evicted) and **never fatal**: missing,
+  corrupt or unwritable, it costs this section and nothing else.
 
 ### `repro:` — the reproduction seed
 
@@ -238,6 +265,12 @@ A `report` object (pretty-printed here; on disk it is one line):
   "mdc": { "traceId": "7c2e" },
   "fields": { "orderId": "889", "retryable": "false" },
   "captured": ["PaymentService.charge(orderId=889, amount=149.90)"],
+  "firstSeen": {
+    "newInThisBuild": false,
+    "build": "9a2b1c",
+    "ts": "2026-07-19T09:12:33.004Z",
+    "buildsAgo": 2
+  },
   "repro": {
     "className": "com.acme.shop.PaymentService",
     "methodName": "charge",
@@ -263,7 +296,7 @@ A `report` object (pretty-printed here; on disk it is one line):
 Rules:
 
 - Timestamps are ISO-8601 with fixed millisecond precision (`.SSS`) and an offset (`Z` for UTC).
-- Optional members (`mdc`, `fields`, `captured`, `repro`, `recurrence`, `error.wrappedBy`,
+- Optional members (`mdc`, `fields`, `captured`, `repro`, `firstSeen`, `recurrence`, `error.wrappedBy`,
   `error.culprit`, `stack`, `env`) are **omitted** when empty — absence is the signal.
 - A no-throwable report has `"error": { "noException": true, "message": "…" }` and no `stack`.
 - Redaction is identical to the text format: a secret-named key masks its value, a
@@ -297,4 +330,5 @@ below, so the mapping never has to be inferred from the example above.
 | `story.events[].thisError` | the `   ← this error` suffix on the error's own event |
 | `stack.shown` / `stack.total` | the `X of Y frames` in the `stack (distilled, …)` header |
 | `stack.frames[]` | the frame lines, including the `… N collapsed (…)` markers |
+| `firstSeen` | the `first seen:` line (§3). `newInThisBuild` is the boolean behind the phrase, so a consumer never matches on English; `buildsAgo` is omitted rather than negative when the first build is no longer on file |
 | `repro.className` + `repro.methodName` + `repro.params[]` | the `repro:` block (§3). The block's `throws` line has no member of its own: it restates the root cause, which is already `error.type` and `error.message` |

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/EnvCollector.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/EnvCollector.java
@@ -15,6 +15,7 @@ final class EnvCollector {
     private final ClassLoader classLoader;
     private final String configuredAppName, configuredAppVersion;
     private volatile String cached;
+    private volatile String cachedBuildId;
 
     EnvCollector(ClassLoader classLoader, String configuredAppName, String configuredAppVersion) {
         this.classLoader = classLoader;
@@ -35,6 +36,35 @@ final class EnvCollector {
             cached = line;
         }
         return line;
+    }
+
+    /**
+     * What identifies this build, for provenance (#137): the git sha when there is one, else the
+     * application version, else empty.
+     *
+     * <p>Distinct from the {@code env:} line, which is for a human to read. This is a key — it
+     * decides whether two runs are the same build, so the most specific value available wins and
+     * an absent one is empty rather than the line's {@code ?} placeholder.
+     */
+    String buildId() {
+        String id = cachedBuildId;
+        if (id == null) {
+            try {
+                Properties git = load("git.properties");
+                Properties buildInfo = load("META-INF/build-info.properties");
+                id = firstNonBlank(
+                        System.getProperty("stacktale.app.build"),
+                        git.getProperty("git.commit.id.abbrev"),
+                        System.getProperty("stacktale.app.version"),
+                        buildInfo.getProperty("build.version"),
+                        configuredAppVersion,
+                        "");
+            } catch (Throwable t) {
+                id = ""; // provenance is enrichment; never let it cost a report
+            }
+            cachedBuildId = id;
+        }
+        return id;
     }
 
     private String build() {

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/JsonReportRenderer.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/JsonReportRenderer.java
@@ -52,6 +52,7 @@ final class JsonReportRenderer implements Renderer {
         appendIfPresent(b, "fields", mapObj(r.fields()));
         appendIfPresent(b, "captured", cleanArr(r.captured()));
         appendIfPresent(b, "repro", reproObj(r.repro()));
+        appendIfPresent(b, "firstSeen", firstSeenObj(r.provenance()));
         if (r.occurrences() > 1) {
             b.append(",\"recurrence\":{\"count\":").append(r.occurrences())
                     .append(",\"firstSeen\":").append(quote(iso(r.firstSeenMillis()))).append('}');
@@ -140,6 +141,24 @@ final class JsonReportRenderer implements Renderer {
         String prefix = nz(p.name()) + " = ";
         String redacted = redactor.redact(prefix + nz(p.value()));
         return redacted.startsWith(prefix) ? redacted.substring(prefix.length()) : redacted;
+    }
+
+    /**
+     * Provenance (#137), mirroring {@link Provenance} member for member.
+     *
+     * <p>{@code buildsAgo} is omitted rather than sent as {@code -1} when the store no longer
+     * holds the first build: absence is this format's way of saying "not known", and a negative
+     * count is something a consumer would have to learn to special-case.
+     */
+    private String firstSeenObj(Provenance p) {
+        if (p == null) return null;
+        StringBuilder b = new StringBuilder("{\"newInThisBuild\":").append(p.newInThisBuild())
+                .append(",\"build\":").append(quote(nz(p.firstBuild())))
+                .append(",\"ts\":").append(quote(iso(p.firstSeenMillis())));
+        if (p.buildsAgo() >= 0) {
+            b.append(",\"buildsAgo\":").append(p.buildsAgo());
+        }
+        return b.append('}').toString();
     }
 
     private String logObj(Report r) {

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/Provenance.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/Provenance.java
@@ -1,0 +1,19 @@
+package io.github.gabrielbbaldez.stacktale;
+
+/**
+ * What this error's history says about the current deploy (#137).
+ *
+ * <p>The first question of any triage is whether the change just shipped caused the failure, and
+ * a report could not answer it: {@code seen:} resets on restart, and the {@code env:} line names
+ * the build the error happened <em>on</em>, never the one it started on.
+ *
+ * @param newInThisBuild first seen on the build now running — the single most actionable thing
+ *                       this project can print, and the reason the rest of this record exists
+ * @param firstBuild the build it was first seen on
+ * @param firstSeenMillis when that was
+ * @param buildsAgo how many builds back that was, or {@code -1} when the store no longer has
+ *                  that build on file — an evicted or copied-in sidecar legitimately does not,
+ *                  and inventing a number would be worse than omitting one
+ */
+public record Provenance(boolean newInThisBuild, String firstBuild, long firstSeenMillis, int buildsAgo) {
+}

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/Report.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/Report.java
@@ -19,8 +19,19 @@ public record Report(
         String envLine,
         int occurrences,
         long firstSeenMillis,
-        ReproSeed repro
+        ReproSeed repro,
+        Provenance provenance
 ) {
+    /** Without provenance — the ordinary case, since it is opt-in and needs a build identity. */
+    public Report(String id, long epochMillis, String threadName, DistilledStack stack,
+                  String messagePattern, Object[] args, String loggerName,
+                  Map<String, String> mdc, Map<String, String> fields, List<String> captured,
+                  Story story, String envLine, int occurrences, long firstSeenMillis,
+                  ReproSeed repro) {
+        this(id, epochMillis, threadName, stack, messagePattern, args, loggerName, mdc, fields,
+                captured, story, envLine, occurrences, firstSeenMillis, repro, null);
+    }
+
     /**
      * Without a seed — the ordinary case. Only a throw site instrumented by
      * {@code stacktale-agent}, with {@code repro} switched on, produces one.
@@ -30,6 +41,6 @@ public record Report(
                   Map<String, String> mdc, Map<String, String> fields, List<String> captured,
                   Story story, String envLine, int occurrences, long firstSeenMillis) {
         this(id, epochMillis, threadName, stack, messagePattern, args, loggerName, mdc, fields,
-                captured, story, envLine, occurrences, firstSeenMillis, null);
+                captured, story, envLine, occurrences, firstSeenMillis, null, null);
     }
 }

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportPipeline.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportPipeline.java
@@ -41,6 +41,7 @@ public final class ReportPipeline {
             boolean reportErrorsWithoutThrowable,
             boolean captureExceptionFields,
             boolean repro,
+            boolean provenance,
             boolean redactionEnabled,
             List<Pattern> redactPatterns,
             boolean redactionCorrelation,
@@ -109,6 +110,14 @@ public final class ReportPipeline {
              * a bigger privacy surface than the rest of a report put together.
              */
             private boolean repro = false;
+            /**
+             * Remember, across restarts, which build each error id was first seen on (#137).
+             *
+             * <p>Off by default because it writes a second file — {@code <report file>.seen}
+             * beside the log — and a deployment that has decided exactly what its process may
+             * write should opt in rather than discover it.
+             */
+            private boolean provenance = false;
             private boolean redactionEnabled = true;
             private List<Pattern> redactPatterns = List.of();
             private boolean redactionCorrelation = false;
@@ -140,6 +149,8 @@ public final class ReportPipeline {
             public Builder reportErrorsWithoutThrowable(boolean v) { this.reportErrorsWithoutThrowable = v; return this; }
             public Builder captureExceptionFields(boolean v) { this.captureExceptionFields = v; return this; }
             public Builder repro(boolean v) { this.repro = v; return this; }
+
+            public Builder provenance(boolean v) { this.provenance = v; return this; }
             public Builder redactionEnabled(boolean v) { this.redactionEnabled = v; return this; }
             public Builder redactPatterns(List<Pattern> v) { this.redactPatterns = v; return this; }
             public Builder redactionCorrelation(boolean v) { this.redactionCorrelation = v; return this; }
@@ -154,7 +165,7 @@ public final class ReportPipeline {
             public Settings build() {
                 return new Settings(file, appName,appVersion,appPackages, storySize, storyWindowMillis, dedupWindowMillis,
                         maxFileBytes, maxBackups, truncateOnStart, reportErrorsWithoutThrowable,
-                        captureExceptionFields, repro, redactionEnabled, redactPatterns, redactionCorrelation,
+                        captureExceptionFields, repro, provenance, redactionEnabled, redactPatterns, redactionCorrelation,
                         correlationMdcKeys, zone,
                         echoSuppressionMillis, containerLoggers, emitReportsToLogger, maxReportsPerMinute,
                         jsonFormat);
@@ -187,6 +198,8 @@ public final class ReportPipeline {
     private final EnvCollector env;
     private final Renderer renderer;
     private final ReportWriter writer; // null = broken config, pipeline is a no-op
+    /** Cross-restart memory of which build each id started on; null when provenance is off (#137). */
+    private final SeenStore seen;
     private final AtomicBoolean warnedOnce = new AtomicBoolean();
     private volatile String absolutePath;
 
@@ -257,6 +270,20 @@ public final class ReportPipeline {
         this.env = new EnvCollector(Thread.currentThread().getContextClassLoader(),
                 settings.appName(),
                 settings.appVersion());
+        // Opened once, at construction: the sidecar is read from disk, and doing that on the
+        // first error would put file I/O inside the first failing request.
+        SeenStore store = null;
+        if (settings.provenance() && writer != null) {
+            try {
+                store = SeenStore.open(Path.of(settings.file()), env.buildId(), host::warn);
+                if (store != null) {
+                    store.noteBuild(clock.getAsLong());
+                }
+            } catch (Throwable t) {
+                store = null; // enrichment: a broken sidecar costs the provenance line, nothing else
+            }
+        }
+        this.seen = store;
     }
 
     /** Never throws: a broken configuration produces a warned, no-op pipeline. */
@@ -422,7 +449,8 @@ public final class ReportPipeline {
                                 // resolved only when asked for: the seed costs a reflective
                                 // call and carries argument values, so an app that has not
                                 // opted in never materialises one
-                                settings.repro() ? AgentCaptures.seedFor(throwable) : null);
+                                settings.repro() ? AgentCaptures.seedFor(throwable) : null,
+                                seen == null ? null : seen.record(fingerprint, event.epochMillis()));
                         rendered = renderer.render(report);
                         writer.append(rendered);
                     } catch (Throwable t) {

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportRenderer.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportRenderer.java
@@ -22,6 +22,8 @@ final class ReportRenderer implements Renderer {
 
     private final DateTimeFormatter dateTime;
     private final DateTimeFormatter time;
+    /** Provenance spans deploys, so its dates are days old; a millisecond there is noise. */
+    private final DateTimeFormatter date;
     private final Redactor redactor;
 
     ReportRenderer(ZoneId zone) {
@@ -31,6 +33,7 @@ final class ReportRenderer implements Renderer {
     ReportRenderer(ZoneId zone, Redactor redactor) {
         this.dateTime = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS").withZone(zone);
         this.time = DateTimeFormatter.ofPattern("HH:mm:ss.SSS").withZone(zone);
+        this.date = DateTimeFormatter.ofPattern("yyyy-MM-dd").withZone(zone);
         this.redactor = redactor;
     }
 
@@ -103,6 +106,8 @@ final class ReportRenderer implements Renderer {
             sb.append("seen: ").append(r.occurrences()).append("× this session, first at ")
                     .append(time.format(Instant.ofEpochMilli(r.firstSeenMillis()))).append('\n');
         }
+
+        renderFirstSeen(sb, r);
 
         renderStory(sb, r);
 
@@ -192,6 +197,34 @@ final class ReportRenderer implements Renderer {
             if (message != null && !message.isBlank()) sb.append(": ").append(clean(message));
             sb.append('\n');
         }
+    }
+
+    /**
+     * Provenance: whether this error predates the build now running (#137).
+     *
+     * <p>Sits next to {@code seen:} because both answer "how new is this", on different clocks —
+     * {@code seen:} counts this session, this counts deploys. Only the first resets when the
+     * process restarts, which is exactly why it could never settle the question a triage opens
+     * with.
+     */
+    private void renderFirstSeen(StringBuilder sb, Report r) {
+        Provenance p = r.provenance();
+        if (p == null) return;
+
+        sb.append("first seen: ");
+        if (p.newInThisBuild()) {
+            // the point of the whole feature, phrased so it can be grepped for
+            sb.append("NEW in this build (").append(clean(p.firstBuild())).append(')');
+        } else {
+            sb.append("build ").append(clean(p.firstBuild()));
+            // -1 means the store no longer holds that build; a count would be invented
+            if (p.buildsAgo() > 0) {
+                sb.append(", ").append(p.buildsAgo())
+                        .append(p.buildsAgo() == 1 ? " build ago" : " builds ago");
+            }
+            sb.append(" (").append(date.format(Instant.ofEpochMilli(p.firstSeenMillis()))).append(')');
+        }
+        sb.append('\n');
     }
 
     private void renderStory(StringBuilder sb, Report r) {

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/SeenStore.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/SeenStore.java
@@ -1,0 +1,234 @@
+package io.github.gabrielbbaldez.stacktale;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Remembers which build each error id was first seen on, so a report can answer the first
+ * question of any triage: <em>did my change cause this?</em> (#137)
+ *
+ * <p>Nothing else in stacktale survives a restart. {@code seen:} is session-scoped by design, so
+ * "3× this session" says nothing about whether the error predates the deploy, and the {@code
+ * env:} line names the build the error happened <em>on</em>, never the build it started on.
+ *
+ * <p>Strictly local: a sibling file beside the report, no network, no account. That is a large
+ * part of why anyone adopts this, and it is also what makes the feature cheap — the id already
+ * survives edits to the source (it is fingerprinted on the culprit frame without its line
+ * number), which is the only reason cross-build history means anything.
+ *
+ * <p>Never fatal. A missing, unreadable, corrupt or unwritable sidecar degrades to no
+ * provenance line at all; it is enrichment, and enrichment does not get to cost a report.
+ *
+ * <h2>Format</h2>
+ *
+ * <p>One record per line, appended:
+ *
+ * <pre>
+ * b &lt;build&gt; &lt;firstSeenMillis&gt;              a build this application has run as
+ * e &lt;id&gt; &lt;build&gt; &lt;firstSeenMillis&gt;        an error id, and the build it was first seen on
+ * </pre>
+ *
+ * <p>Lines rather than JSON because {@code stacktale-core} has no JSON parser and a report must
+ * not depend on one — and because an append is atomic enough to survive a kill, where a
+ * rewritten document is not. An unparseable line is skipped, exactly as {@code st-json/1}
+ * requires of its readers.
+ */
+final class SeenStore {
+
+    /** Distinct builds kept. Enough to answer "how many deploys ago" for any useful window. */
+    private static final int MAX_BUILDS = 50;
+    /**
+     * Distinct error ids kept. Bounded like every other piece of state here: a file that grows
+     * with distinct errors forever is a slow leak, and the oldest ids are the least useful —
+     * an error nobody has seen in two thousand fingerprints is not the one being triaged.
+     */
+    private static final int MAX_ERRORS = 2_000;
+
+    private final Path file;
+    private final String build;
+    private final java.util.function.BiConsumer<String, Throwable> warn;
+
+    /** build -> first seen, insertion-ordered oldest-first. */
+    private final Map<String, Long> builds = new LinkedHashMap<>();
+    /** error id -> the build it was first seen on, and when. Access-ordered so eviction is LRU. */
+    private final Map<String, Entry> errors = new LinkedHashMap<>(64, 0.75f, true);
+
+    private record Entry(String build, long firstSeenMillis) {
+    }
+
+    private boolean usable = true;
+    private boolean warned;
+
+    private SeenStore(Path file, String build, java.util.function.BiConsumer<String, Throwable> warn) {
+        this.file = file;
+        this.build = build;
+        this.warn = warn;
+    }
+
+    /**
+     * Opens the sidecar beside {@code reportFile}, or returns {@code null} when provenance is off
+     * or cannot work.
+     *
+     * <p>A blank build id is not a failure but it is not provenance either: without something to
+     * compare, every run looks like the same build and "NEW in this build" would be a lie.
+     */
+    static SeenStore open(Path reportFile, String build,
+                          java.util.function.BiConsumer<String, Throwable> warn) {
+        if (reportFile == null || build == null || build.isBlank()) {
+            return null;
+        }
+        try {
+            Path sidecar = reportFile.resolveSibling(reportFile.getFileName() + ".seen");
+            SeenStore store = new SeenStore(sidecar, build.trim(), warn);
+            store.load();
+            return store;
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    /**
+     * Records that {@code id} was seen now, and says what the report should print.
+     *
+     * <p>The first call for an unknown id is the one that matters: it is written through to disk
+     * straight away, because the interesting case is a process that crashes shortly after
+     * producing the error, and a record kept only in memory would be lost exactly then.
+     */
+    synchronized Provenance record(String id, long nowMillis) {
+        Entry existing = errors.get(id);
+        if (existing != null) {
+            return provenance(existing);
+        }
+        Entry entry = new Entry(build, nowMillis);
+        errors.put(id, entry);
+        evict();
+        append("e " + id + " " + build + " " + nowMillis);
+        return provenance(entry);
+    }
+
+    /** Notes the current build, so "how many builds ago" has something to count against. */
+    synchronized void noteBuild(long nowMillis) {
+        if (builds.containsKey(build)) {
+            return;
+        }
+        builds.put(build, nowMillis);
+        evict();
+        append("b " + build + " " + nowMillis);
+    }
+
+    private Provenance provenance(Entry entry) {
+        boolean isNew = build.equals(entry.build());
+        return new Provenance(isNew, entry.build(), entry.firstSeenMillis(),
+                isNew ? 0 : buildsSince(entry.build()));
+    }
+
+    /**
+     * How many builds ago {@code firstBuild} was, or {@code -1} when this store never saw it.
+     *
+     * <p>A store that has been evicted, or one carried over from another machine, legitimately
+     * has an error whose first build is not in its build list. Counting from an unknown position
+     * would invent a number, so the renderer is told there is none.
+     */
+    private int buildsSince(String firstBuild) {
+        List<String> order = new ArrayList<>(builds.keySet());
+        int at = order.indexOf(firstBuild);
+        return at < 0 ? -1 : order.size() - 1 - at;
+    }
+
+    private void evict() {
+        while (errors.size() > MAX_ERRORS) {
+            errors.remove(errors.keySet().iterator().next());
+        }
+        while (builds.size() > MAX_BUILDS) {
+            builds.remove(builds.keySet().iterator().next());
+        }
+    }
+
+    private void load() {
+        if (!Files.exists(file)) {
+            return;
+        }
+        List<String> lines;
+        try {
+            lines = Files.readAllLines(file, StandardCharsets.UTF_8);
+        } catch (IOException | RuntimeException e) {
+            // Unreadable: run without provenance rather than without reports — but say so. The
+            // user switched this on; silently giving them a report with no `first seen:` line
+            // looks like the feature does nothing.
+            degrade(e);
+            return;
+        }
+        for (String line : lines) {
+            String[] parts = line.strip().split(" ");
+            try {
+                if (parts.length == 3 && "b".equals(parts[0])) {
+                    builds.put(parts[1], Long.parseLong(parts[2]));
+                } else if (parts.length == 4 && "e".equals(parts[0])) {
+                    errors.put(parts[1], new Entry(parts[2], Long.parseLong(parts[3])));
+                }
+            } catch (RuntimeException malformed) {
+                // a torn line from a kill mid-append: skip it, keep the rest — the same rule
+                // st-json/1 puts on its own readers
+            }
+        }
+        evict();
+        if (lines.size() > (MAX_ERRORS + MAX_BUILDS) * 2) {
+            compact();
+        }
+    }
+
+    /** Rewrites the file from memory once the append log has grown past what it represents. */
+    private void compact() {
+        StringBuilder out = new StringBuilder();
+        for (Map.Entry<String, Long> b : builds.entrySet()) {
+            out.append("b ").append(b.getKey()).append(' ').append(b.getValue()).append('\n');
+        }
+        for (Map.Entry<String, Entry> e : errors.entrySet()) {
+            out.append("e ").append(e.getKey()).append(' ').append(e.getValue().build())
+                    .append(' ').append(e.getValue().firstSeenMillis()).append('\n');
+        }
+        try {
+            Path pending = file.resolveSibling(file.getFileName() + ".compacting");
+            Files.writeString(pending, out.toString(), StandardCharsets.UTF_8);
+            Files.move(pending, file, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException | RuntimeException e) {
+            degrade(e); // keep serving from memory; the file stays as it was
+        }
+    }
+
+    private void append(String line) {
+        if (!usable) {
+            return;
+        }
+        try {
+            Files.writeString(file, line + "\n", StandardCharsets.UTF_8,
+                    StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+        } catch (IOException | RuntimeException e) {
+            degrade(e);
+        }
+    }
+
+    /**
+     * Stops writing after a failure, and says so once.
+     *
+     * <p>In-memory answers stay correct for the rest of this run; only the memory across restarts
+     * is lost. Warning once matters because the failure is usually permanent — a read-only
+     * directory does not become writable between two errors — and a warning per report would
+     * flood the very log this is meant to make readable.
+     */
+    private void degrade(Throwable t) {
+        usable = false;
+        if (!warned && warn != null) {
+            warned = true;
+            warn.accept("stacktale could not write " + file.getFileName()
+                    + "; provenance stays in memory for this run only", t);
+        }
+    }
+}

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/JsonReportRendererTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/JsonReportRendererTest.java
@@ -192,6 +192,49 @@ class JsonReportRendererTest {
                 "app=shop 2.1.0 | java 21 | linux", 1, 0L, seed);
     }
 
+    /**
+     * Provenance in the format a pipeline reads (#137). `newInThisBuild` is a boolean rather than
+     * a phrase for the same reason the rest of this format exists: a dashboard should not have to
+     * match on English.
+     */
+    @Test
+    void provenanceIsAddressableJson() throws Exception {
+        JsonNode j = parse(renderer.render(withProvenance(new Provenance(false, "9a2b1c", 1_000_412L, 2))));
+
+        assertThat(j.at("/firstSeen/newInThisBuild").asBoolean()).isFalse();
+        assertThat(j.at("/firstSeen/build").asText()).isEqualTo("9a2b1c");
+        assertThat(j.at("/firstSeen/ts").asText()).isEqualTo("1970-01-01T00:16:40.412Z");
+        assertThat(j.at("/firstSeen/buildsAgo").asInt()).isEqualTo(2);
+    }
+
+    /**
+     * Absence is this format's way of saying "not known" (§7), so an unknown distance is an
+     * omitted member rather than a {@code -1} every consumer would have to special-case.
+     */
+    @Test
+    void anUnknownBuildDistanceIsOmittedRatherThanNegative() throws Exception {
+        JsonNode j = parse(renderer.render(withProvenance(new Provenance(false, "longgone", 1_000_412L, -1))));
+
+        assertThat(j.at("/firstSeen/build").asText()).isEqualTo("longgone");
+        assertThat(j.at("/firstSeen").has("buildsAgo")).isFalse();
+    }
+
+    @Test
+    void withoutProvenanceTheFirstSeenMemberIsAbsentEntirely() throws Exception {
+        assertThat(parse(renderer.render(withProvenance(null))).has("firstSeen")).isFalse();
+    }
+
+    /** One report shaped for the provenance assertions; only the provenance varies. */
+    private static Report withProvenance(Provenance provenance) {
+        DistilledStack stack = new DistilledStack("IllegalStateException", "payment gateway refused",
+                "PaymentService.charge(PaymentService.java:118)", true, List.of(),
+                List.of("PaymentService.charge(PaymentService.java:118) ← culprit"), 1, 1, List.of());
+        return new Report("5eed0001", 1_000_412L, "main", stack, "charge failed", new Object[0],
+                "com.acme.shop.PaymentService", Map.of(), Map.of(), List.of(),
+                new Story(List.of(), "thread main"), "app=shop | java 21 | linux",
+                1, 0L, null, provenance);
+    }
+
     @Test
     void nonReportEntriesAreTypedJson() throws Exception {
         assertThat(parse(renderer.fileHeader()).get("format").asText()).isEqualTo("st-json/1");

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportPipelineTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportPipelineTest.java
@@ -324,6 +324,73 @@ class ReportPipelineTest {
         assertThat(stats.reportsWritten()).isEqualTo(1); // only the one from before the breakage
     }
 
+    /**
+     * The whole chain, across a simulated deploy: settings → sidecar → report → file. The two
+     * runs share a directory, which is the only thing that carries state between them — the point
+     * being that nothing else in stacktale does.
+     */
+    @Test
+    void provenanceSurvivesARestartAndNamesTheBuildTheErrorStartedOn(@TempDir Path dir) {
+        String previous = System.getProperty("stacktale.app.build");
+        try {
+            System.setProperty("stacktale.app.build", "9a2b1c");
+            ReportPipeline first = provenancePipeline(dir);
+            first.process(error("alpha", 1_700_000_000_000L));
+            first.close();
+
+            // deploy: same machine, same log, new build
+            System.setProperty("stacktale.app.build", "7e3c1f");
+            ReportPipeline afterDeploy = provenancePipeline(dir);
+            afterDeploy.process(error("alpha", 1_700_000_100_000L));   // pre-existing
+            afterDeploy.process(error("beta", 1_700_000_100_000L));    // introduced by this build
+            afterDeploy.close();
+
+            String written = read(dir.resolve("errors-ai.log"));
+            assertThat(written).contains("first seen: build 9a2b1c, 1 build ago");
+            assertThat(written).contains("first seen: NEW in this build (7e3c1f)");
+            assertThat(Files.exists(dir.resolve("errors-ai.log.seen"))).isTrue();
+        } finally {
+            if (previous == null) {
+                System.clearProperty("stacktale.app.build");
+            } else {
+                System.setProperty("stacktale.app.build", previous);
+            }
+        }
+    }
+
+    /** Off by default, and off means no sidecar on disk — not an empty one. */
+    @Test
+    void withoutProvenanceNoSidecarIsWrittenAndNoLineAppears(@TempDir Path dir) {
+        Fixture f = fixture(dir, 0);
+        f.pipeline().process(error("alpha", f.clock().get()));
+
+        assertThat(f.contents()).doesNotContain("first seen:");
+        assertThat(Files.exists(dir.resolve("errors-ai.log.seen"))).isFalse();
+    }
+
+    private static ReportPipeline provenancePipeline(Path dir) {
+        Path file = dir.resolve("errors-ai.log");
+        ReportPipeline.Settings settings = ReportPipeline.Settings.builder()
+                .file(file.toString())
+                .provenance(true)
+                .echoSuppressionMillis(0)
+                .zone(ZoneId.of("UTC"))
+                .build();
+        RecordingHost host = new RecordingHost();
+        Renderer renderer = new ReportRenderer(settings.zone(), Redactor.disabled());
+        ReportWriter writer = new ReportWriter(file, settings.maxFileBytes(), renderer.fileHeader(),
+                null, false, settings.maxBackups(), host::warn);
+        return ReportPipeline.forTesting(settings, host, writer, renderer, () -> 1_700_000_000_000L);
+    }
+
+    private static String read(Path file) {
+        try {
+            return Files.exists(file) ? Files.readString(file) : "";
+        } catch (java.io.IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
     @Test
     void processNeverThrowsAndParksAfterRepeatedWriteFailures(@TempDir Path dir) {
         Fixture f = fixture(dir, 0);

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportRendererTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/ReportRendererTest.java
@@ -140,6 +140,66 @@ class ReportRendererTest {
         assertThat(new ReportRenderer(ZoneOffset.UTC).render(r)).isEqualTo(golden("repro-report.txt"));
     }
 
+    /**
+     * The line a triage opens with. "NEW in this build" is deliberately phrased so it can be
+     * grepped for across a directory of reports, and it names the build so a reader can check it
+     * against what they just deployed.
+     */
+    @Test
+    void provenanceLeadsWithWhetherTheErrorIsNewInThisBuild() {
+        Report r = withProvenance(new Provenance(true, "7e3c1f", 1_000_412L, 0));
+
+        assertThat(new ReportRenderer(ZoneOffset.UTC).render(r))
+                .contains("first seen: NEW in this build (7e3c1f)");
+    }
+
+    @Test
+    void provenanceForAnOlderErrorNamesTheBuildAndHowLongAgo() {
+        Report r = withProvenance(new Provenance(false, "9a2b1c", 1_000_412L, 2));
+
+        assertThat(new ReportRenderer(ZoneOffset.UTC).render(r))
+                .contains("first seen: build 9a2b1c, 2 builds ago (1970-01-01)");
+    }
+
+    /** One deploy back reads as a build, not "1 builds ago". */
+    @Test
+    void provenanceCountsOneBuildInTheSingular() {
+        assertThat(new ReportRenderer(ZoneOffset.UTC).render(
+                withProvenance(new Provenance(false, "9a2b1c", 1_000_412L, 1))))
+                .contains("first seen: build 9a2b1c, 1 build ago (1970-01-01)");
+    }
+
+    /**
+     * An evicted or copied-in sidecar has no distance to the first build. Printing "0 builds ago"
+     * would read as "this build", which is the opposite of what is known.
+     */
+    @Test
+    void provenanceOmitsTheCountWhenTheFirstBuildIsNoLongerOnFile() {
+        String rendered = new ReportRenderer(ZoneOffset.UTC).render(
+                withProvenance(new Provenance(false, "longgone", 1_000_412L, -1)));
+
+        assertThat(rendered).contains("first seen: build longgone (1970-01-01)");
+        assertThat(rendered).doesNotContain("builds ago");
+    }
+
+    @Test
+    void withoutProvenanceTheFirstSeenLineIsAbsentEntirely() {
+        assertThat(new ReportRenderer(ZoneOffset.UTC).render(withProvenance(null)))
+                .doesNotContain("first seen:");
+    }
+
+    /** One report shaped for the provenance assertions; only the provenance varies. */
+    private static Report withProvenance(Provenance provenance) {
+        DistilledStack stack = new DistilledStack("IllegalStateException", "payment gateway refused",
+                "PaymentService.charge(PaymentService.java:118)", true, java.util.List.of(),
+                java.util.List.of("PaymentService.charge(PaymentService.java:118) ← culprit"),
+                1, 1, java.util.List.of());
+        return new Report("5eed0001", 1_000_412L, "main", stack, "charge failed", new Object[0],
+                "com.acme.shop.PaymentService", Map.of(), Map.of(), java.util.List.of(),
+                new Story(java.util.List.of(), "thread main"), "app=shop | java 21 | linux",
+                1, 0L, null, provenance);
+    }
+
     @Test
     void withoutASeedTheReproSectionIsAbsentEntirely() throws Exception {
         Report r = new Report("cafe", 2_000_000L, "main", null,

--- a/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/SeenStoreTest.java
+++ b/stacktale-core/src/test/java/io/github/gabrielbbaldez/stacktale/SeenStoreTest.java
@@ -1,0 +1,160 @@
+package io.github.gabrielbbaldez.stacktale;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The one piece of stacktale state that outlives the process (#137).
+ *
+ * <p>Every test here opens a second store over the same file, because that is the whole feature:
+ * an in-memory answer is what {@code seen:} already gives, and it is exactly the answer that
+ * cannot say whether an error predates the deploy.
+ */
+class SeenStoreTest {
+
+    private static final long DAY = 24 * 60 * 60 * 1000L;
+
+    private final List<String> warnings = new ArrayList<>();
+
+    private SeenStore open(Path dir, String build) {
+        SeenStore store = SeenStore.open(dir.resolve("errors-ai.log"), build,
+                (message, thrown) -> warnings.add(message));
+        assertThat(store).isNotNull();
+        store.noteBuild(1_000_000L);
+        return store;
+    }
+
+    @Test
+    void anErrorFirstSeenNowIsNewInThisBuild(@TempDir Path dir) {
+        Provenance p = open(dir, "7e3c1f").record("a1b2c3d4", 1_000_000L);
+
+        assertThat(p.newInThisBuild()).isTrue();
+        assertThat(p.firstBuild()).isEqualTo("7e3c1f");
+        assertThat(p.buildsAgo()).isZero();
+    }
+
+    /** The question the feature exists for: after a deploy, is this error mine or was it here? */
+    @Test
+    void anErrorSurvivingADeployIsNotNewAndSaysWhichBuildStartedIt(@TempDir Path dir) {
+        open(dir, "9a2b1c").record("a1b2c3d4", 1_000_000L);
+
+        // a new process, a new build, the same sidecar
+        SeenStore afterDeploy = open(dir, "7e3c1f");
+        Provenance p = afterDeploy.record("a1b2c3d4", 1_000_000L + DAY);
+
+        assertThat(p.newInThisBuild()).isFalse();
+        assertThat(p.firstBuild()).isEqualTo("9a2b1c");
+        assertThat(p.firstSeenMillis()).isEqualTo(1_000_000L); // the original sighting, not today's
+        assertThat(p.buildsAgo()).isEqualTo(1);
+
+        // and an error genuinely introduced by this deploy still reads as new
+        assertThat(afterDeploy.record("beefbeef", 1_000_000L + DAY).newInThisBuild()).isTrue();
+    }
+
+    @Test
+    void buildsAgoCountsDeploysRatherThanRestarts(@TempDir Path dir) {
+        open(dir, "b1").record("a1b2c3d4", 1_000_000L);
+        open(dir, "b1"); // same build restarted: not a deploy
+        open(dir, "b2");
+        open(dir, "b3");
+
+        assertThat(open(dir, "b3").record("a1b2c3d4", 2_000_000L).buildsAgo()).isEqualTo(2);
+    }
+
+    /**
+     * A store that no longer holds the first build cannot count back to it — an evicted or
+     * copied-in sidecar legitimately does not — and a made-up number is worse than none.
+     */
+    @Test
+    void anUnknownFirstBuildReportsNoDistanceRatherThanGuessing(@TempDir Path dir) throws IOException {
+        Files.writeString(dir.resolve("errors-ai.log.seen"),
+                "e a1b2c3d4 longgone 1000000\n", StandardCharsets.UTF_8);
+
+        Provenance p = open(dir, "7e3c1f").record("a1b2c3d4", 2_000_000L);
+
+        assertThat(p.newInThisBuild()).isFalse();
+        assertThat(p.firstBuild()).isEqualTo("longgone");
+        assertThat(p.buildsAgo()).isEqualTo(-1);
+    }
+
+    /** A kill mid-append leaves a torn line. Skipping it must not cost the rest of the file. */
+    @Test
+    void aTornLineIsSkippedAndTheRestOfTheFileSurvives(@TempDir Path dir) throws IOException {
+        Files.writeString(dir.resolve("errors-ai.log.seen"), """
+                b 9a2b1c 1000000
+                e a1b2c3d4 9a2b1c 1000000
+                e broken-half-writ
+                e beefbeef 9a2b1c notanumber
+                e cafecafe 9a2b1c 1000500
+                """, StandardCharsets.UTF_8);
+
+        SeenStore store = open(dir, "7e3c1f");
+
+        assertThat(store.record("a1b2c3d4", 2_000_000L).firstBuild()).isEqualTo("9a2b1c");
+        assertThat(store.record("cafecafe", 2_000_000L).firstBuild()).isEqualTo("9a2b1c");
+        assertThat(store.record("beefbeef", 2_000_000L).newInThisBuild()).isTrue(); // the bad line was dropped
+    }
+
+    /**
+     * Bounded like every other piece of state here — an unbounded sidecar is a slow leak. Loading
+     * an oversized file is the cheap way to prove the cap: it exercises the same eviction the
+     * append path uses, without two thousand file opens.
+     */
+    @Test
+    void anOversizedSidecarIsCappedOnLoad(@TempDir Path dir) throws IOException {
+        StringBuilder oversized = new StringBuilder("b 9a2b1c 1000000\n");
+        for (int i = 0; i < 2_100; i++) {
+            oversized.append("e ").append(String.format("%08x", i)).append(" 9a2b1c 1000000\n");
+        }
+        Files.writeString(dir.resolve("errors-ai.log.seen"), oversized.toString(), StandardCharsets.UTF_8);
+
+        // a later build, so "still on file" and "new here" are distinguishable — under the same
+        // build both read as new and the assertion would prove nothing
+        SeenStore store = open(dir, "7e3c1f");
+
+        assertThat(store.record(String.format("%08x", 0), 2_000_000L).newInThisBuild())
+                .withFailMessage("the oldest id should have been evicted")
+                .isTrue();
+        assertThat(store.record(String.format("%08x", 2_099), 2_000_000L).newInThisBuild())
+                .withFailMessage("the newest id should have been kept")
+                .isFalse();
+    }
+
+    /**
+     * Enrichment does not get to cost a report. An unwritable sidecar keeps answering from memory
+     * for the rest of the run, and says so once — the failure is normally permanent, and a
+     * warning per report would flood the log this is meant to keep readable.
+     */
+    @Test
+    void anUnwritableSidecarWarnsOnceAndKeepsWorkingInMemory(@TempDir Path dir) throws IOException {
+        Files.createDirectory(dir.resolve("errors-ai.log.seen")); // a directory: every write fails
+
+        SeenStore store = open(dir, "7e3c1f");
+        assertThat(store.record("a1b2c3d4", 1_000_000L).newInThisBuild()).isTrue();
+        assertThat(store.record("beefbeef", 1_000_000L).newInThisBuild()).isTrue();
+        // in-memory answers stay correct within the run
+        assertThat(store.record("a1b2c3d4", 1_000_000L).firstSeenMillis()).isEqualTo(1_000_000L);
+
+        assertThat(warnings).hasSize(1);
+        assertThat(warnings.get(0)).contains("provenance stays in memory");
+    }
+
+    /**
+     * Without something to compare, every run looks like the same build and "NEW in this build"
+     * would be a lie — so there is no store at all rather than a misleading one.
+     */
+    @Test
+    void noBuildIdentityMeansNoProvenance(@TempDir Path dir) {
+        assertThat(SeenStore.open(dir.resolve("errors-ai.log"), "", (m, t) -> { })).isNull();
+        assertThat(SeenStore.open(dir.resolve("errors-ai.log"), null, (m, t) -> { })).isNull();
+    }
+}

--- a/stacktale-jul/src/main/java/io/github/gabrielbbaldez/stacktale/jul/StacktaleJulHandler.java
+++ b/stacktale-jul/src/main/java/io/github/gabrielbbaldez/stacktale/jul/StacktaleJulHandler.java
@@ -213,6 +213,9 @@ public final class StacktaleJulHandler extends Handler {
         Boolean repro = boolProp(m, p + "repro");
         if (repro != null) b.repro(repro);
 
+        Boolean provenance = boolProp(m, p + "provenance");
+        if (provenance != null) b.provenance(provenance);
+
         Boolean truncate = boolProp(m, p + "truncateOnStart");
         if (truncate != null) b.truncateOnStart(truncate);
 

--- a/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
+++ b/stacktale-log4j2/src/main/java/io/github/gabrielbbaldez/stacktale/log4j2/StacktaleAppender.java
@@ -174,6 +174,7 @@ public final class StacktaleAppender extends AbstractAppender {
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private boolean reportErrorsWithoutThrowable = true;
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private boolean captureExceptionFields = true;
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private boolean repro = false;
+        @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private boolean provenance = false;
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private boolean redactionEnabled = true;
         /** Extra redaction regexes, separated by {@code ;;} (regexes may contain commas). */
         @SuppressWarnings("log4j.public.setter") @PluginBuilderAttribute private String redactPatterns = "";
@@ -230,6 +231,7 @@ public final class StacktaleAppender extends AbstractAppender {
                     .reportErrorsWithoutThrowable(reportErrorsWithoutThrowable)
                     .captureExceptionFields(captureExceptionFields)
                     .repro(repro)
+                    .provenance(provenance)
                     .redactionEnabled(redactionEnabled)
                     .redactPatterns(compiled)
                     .redactionCorrelation(redactionCorrelation)

--- a/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleConfig.java
+++ b/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleConfig.java
@@ -68,6 +68,13 @@ public interface StacktaleConfig {
     @WithDefault("false")
     boolean repro();
 
+    /**
+     * Remember across restarts which build each error was first seen on, so a report can say
+     * whether it is new in the build now running. Writes a sibling file beside the log.
+     */
+    @WithDefault("false")
+    boolean provenance();
+
     /** Redact secrets (tokens, passwords, emails, …) from reports. */
     @WithDefault("true")
     boolean redactionEnabled();

--- a/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRecorder.java
+++ b/stacktale-quarkus/runtime/src/main/java/io/github/gabrielbbaldez/stacktale/quarkus/runtime/StacktaleRecorder.java
@@ -68,6 +68,7 @@ public class StacktaleRecorder {
                 .reportErrorsWithoutThrowable(config.reportErrorsWithoutThrowable())
                 .captureExceptionFields(config.captureExceptionFields())
                 .repro(config.repro())
+                .provenance(config.provenance())
                 .redactionEnabled(config.redactionEnabled())
                 .redactPatterns(compilePatterns(config.redactPatterns().orElse(List.of())))
                 .redactionCorrelation(config.redactionCorrelation())

--- a/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleAutoConfiguration.java
+++ b/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleAutoConfiguration.java
@@ -80,6 +80,7 @@ public class StacktaleAutoConfiguration {
         appender.setReportErrorsWithoutThrowable(props.isReportErrorsWithoutThrowable());
         appender.setCaptureExceptionFields(props.isCaptureExceptionFields());
         appender.setRepro(props.isRepro());
+        appender.setProvenance(props.isProvenance());
         appender.setRedactionEnabled(props.isRedactionEnabled());
         props.getRedactPatterns().forEach(appender::addRedactPattern);
         appender.setRedactionCorrelation(props.isRedactionCorrelation());

--- a/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleProperties.java
+++ b/stacktale-spring-boot-starter/src/main/java/io/github/gabrielbbaldez/stacktale/spring/StacktaleProperties.java
@@ -49,6 +49,9 @@ public class StacktaleProperties {
     /** Add a repro: seed — the throw site's typed signature and argument values. Needs stacktale-agent. */
     private boolean repro = false;
 
+    /** Remember across restarts which build each error was first seen on, for a first seen: line. */
+    private boolean provenance = false;
+
     /** Mask secrets/PII (JWTs, bearer tokens, key=value secrets, emails, cards). */
     private boolean redactionEnabled = true;
 
@@ -111,6 +114,8 @@ public class StacktaleProperties {
     public void setCaptureExceptionFields(boolean captureExceptionFields) { this.captureExceptionFields = captureExceptionFields; }
     public boolean isRepro() { return repro; }
     public void setRepro(boolean repro) { this.repro = repro; }
+    public boolean isProvenance() { return provenance; }
+    public void setProvenance(boolean provenance) { this.provenance = provenance; }
     public boolean isRedactionEnabled() { return redactionEnabled; }
     public void setRedactionEnabled(boolean redactionEnabled) { this.redactionEnabled = redactionEnabled; }
     public List<String> getRedactPatterns() { return redactPatterns; }

--- a/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
+++ b/stacktale/src/main/java/io/github/gabrielbbaldez/stacktale/logback/StacktaleAppender.java
@@ -45,6 +45,7 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
     private boolean reportErrorsWithoutThrowable = true;
     private boolean captureExceptionFields = true;
     private boolean repro = false;
+    private boolean provenance = false;
     private boolean redactionEnabled = true;
     private final List<String> redactPatterns = new java.util.ArrayList<>();
     private boolean redactionCorrelation = false;
@@ -103,6 +104,7 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
                 .reportErrorsWithoutThrowable(reportErrorsWithoutThrowable)
                 .captureExceptionFields(captureExceptionFields)
                 .repro(repro)
+                .provenance(provenance)
                 .redactionEnabled(redactionEnabled)
                 .redactPatterns(compiled)
                 .redactionCorrelation(redactionCorrelation)
@@ -343,6 +345,13 @@ public final class StacktaleAppender extends UnsynchronizedAppenderBase<ILogging
      * to nothing and the section is simply absent.
      */
     public void setRepro(boolean repro) { this.repro = repro; }
+
+    /**
+     * Opt-in: remember across restarts which build each error was first seen on, so a report
+     * can say whether the error is new in the build now running. Writes a sibling file next
+     * to the log; nothing leaves the machine.
+     */
+    public void setProvenance(boolean provenance) { this.provenance = provenance; }
 
     public void setRedactionEnabled(boolean redactionEnabled) { this.redactionEnabled = redactionEnabled; }
 


### PR DESCRIPTION
Closes #137.

The issue's own line: *"`NEW in this build` is the single most actionable string this project
could print."* It prints it now.

```
first seen: NEW in this build (7e3c1f)
first seen: build 9a2b1c, 2 builds ago (2026-07-19)
```

No line in a report could answer the question a triage opens with. `seen:` is session-scoped and
resets on restart, so "3× this session" says nothing about whether the error predates the
deploy; the `env:` line names the build the error happened **on**, never the one it started on.

## How it works

A bounded sidecar, `<report file>.seen`, recording which build each error id was first seen on.
Strictly local — no network, no account — which is a large part of why anyone adopts this. It
works at all only because the report id already survives edits to the source: without that,
every edit would look like a new error forever.

The build identity is the git sha when there is one, else the application version. With neither
there is nothing to compare, so the section is absent rather than claiming everything is new.

## Format, and why not JSON

Line-per-record, appended:

```
b <build> <firstSeenMillis>
e <id> <build> <firstSeenMillis>
```

The issue suggested `seen.json`. `stacktale-core` has no JSON parser and a report must not
depend on one — and an append survives a kill where a rewritten document does not. A torn line
is skipped and the rest of the file stands, which is the rule `st-json/1` already puts on its
own readers.

## The constraints from the issue, each with its test

| constraint | how it holds |
|---|---|
| nothing leaves the machine | a sibling file; no network code involved |
| bounded | 50 builds, 2000 ids, oldest evicted — `anOversizedSidecarIsCappedOnLoad` |
| never fatal | missing, corrupt or unwritable costs this line only — `aTornLineIsSkippedAndTheRestOfTheFileSurvives`, `anUnwritableSidecarWarnsOnceAndKeepsWorkingInMemory` |
| opt-in | `provenance=false` by default; `withoutProvenanceNoSidecarIsWrittenAndNoLineAppears` asserts no sidecar is created at all |

Two decisions the tests pushed back on:

**A count of builds is omitted, never guessed.** An evicted or copied-in sidecar legitimately
has an error whose first build it no longer holds. Printing "0 builds ago" would read as "this
build" — the opposite of what is known — so the renderer gets `-1` and prints
`first seen: build 9a2b1c (2026-07-19)`.

**An unreadable sidecar now warns.** The first version set itself unusable and said nothing, and
`anUnwritableSidecarWarnsOnceAndKeepsWorkingInMemory` caught it: a user who switched provenance
on and gets reports with no `first seen:` line would conclude the feature does nothing. It warns
once — the failure is normally permanent, and one per report would flood the log this exists to
keep readable — and keeps answering from memory for the rest of the run.

## Verified end to end, across a simulated deploy

`provenanceSurvivesARestartAndNamesTheBuildTheErrorStartedOn` runs two pipelines over one
directory under two build ids, and asserts the written file carries both forms — the
pre-existing error as `build 9a2b1c, 1 build ago`, the one this build introduced as
`NEW in this build (7e3c1f)`. The directory is the only thing shared between the two runs, which
is the point.

`stacktale-core` 152 tests, full reactor `mvn -B verify` green.

## Reach

The knob is on all five adapters, and `check-config-parity.sh` (#214) proved it rather than my
memory: 113 → 118 pairs. That guard was written this morning for exactly the gap `repro` had
left, and this is the first new knob to go through it.

`st/1` gains a section and `st-json/1` a `firstSeen` member — additive, so §6 holds and readers
that skip unknowns are unaffected. `newInThisBuild` is a boolean there rather than a phrase, so
a dashboard never has to match on English.
