### PR TITLE
fix(docs): the MCP setup page was installing 1.1.0

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -125,6 +125,11 @@ jobs:
           sed -i -E 's|(io\.github\.gabrielbbaldez:stacktale-mcp:)[0-9.]+|\1${{ inputs.version }}|' plugins/stacktale/.mcp.json
           sed -i -E 's|("version"[[:space:]]*:[[:space:]]*")[0-9.]+(")|\1${{ inputs.version }}\2|' .claude-plugin/marketplace.json
           sed -i -E 's|("version"[[:space:]]*:[[:space:]]*")[0-9.]+(")|\1${{ inputs.version }}\2|' plugins/stacktale/.claude-plugin/plugin.json
+          # The setup page is prose, not a manifest, which is how it went unnoticed the
+          # longest: it pinned 1.1.0 through three releases while the paragraph above the
+          # command listed tools that version did not have. It is also the copy a person
+          # actually pastes into their client.
+          sed -i -E 's|(io\.github\.gabrielbbaldez:stacktale-mcp:)[0-9.]+|\1${{ inputs.version }}|g' docs/mcp-setup.md
           bash scripts/check-plugin-versions.sh
 
       - name: Commit the release, then the next snapshot

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,9 +73,25 @@ and pinned by golden-file tests.
 - `docs/FORMAT.md` files the `repro:` section under **§3 Report block** and gives it a row in
   that section's field table. It was a subsection of §5 *Non-report entries*, next to
   `repeated`, `app start` and `storm:` — the three things that are not reports. (#216)
+- The tests that guard the adapters' configuration surfaces now fail when a knob stops
+  arriving, rather than when it stops binding. `everyPropertyReachesTheAppender` asserted on the
+  properties bean, so a value that bound and was then never passed to the appender read as
+  covered — the exact shape of the `repro` bug below. `LogbackXmlConfigTest` also picks up
+  `appName` and `appVersion`, settable since #150 and named in no test in the module. (#210)
 
 ### Fixed
 
+- **The MCP setup page told people to install version 1.1.0.** `docs/mcp-setup.md` hard-pins the
+  `stacktale-mcp` coordinate in four commands, and nothing bumped it — so for three releases the
+  page listed tools while handing out a version that did not have them. The three plugin
+  manifests were already covered by `check-plugin-versions.sh` after the same thing happened to
+  them in #142; the setup page is prose rather than a manifest, which is how it drifted the
+  furthest and was noticed last. Now stamped by `prepare-release` and checked by that guard —
+  every occurrence, not the first, since a page can update one command and leave the three below
+  it behind.
+- **The report file's own header did not mention `first seen:`.** That block exists so an AI
+  opening the file with no prior knowledge learns the format from it, and it listed every
+  section but the one added above.
 - **Vendor API keys and PEM private keys reached the report file.** Every redaction rule but
   one needs *context* — a keyword before the value, a scheme word, a quoted JSON member — so a
   credential sitting in an ordinary log sentence had nothing around it to recognise. Measured
@@ -113,14 +129,6 @@ and pinned by golden-file tests.
   `Ignoring unknown property [repro]`, `@ConfigurationProperties` drops unknown fields, Quarkus
   warns and starts — so the knob looked set and the `repro:` section simply never appeared.
   (#210)
-
-### Changed
-
-- The tests that guard those three surfaces now fail when a knob stops arriving, rather than
-  when it stops binding. `everyPropertyReachesTheAppender` asserted on the properties bean, so
-  a value that bound and was then never passed to the appender read as covered — which is the
-  exact shape of the bug above. `LogbackXmlConfigTest` also picks up `appName` and `appVersion`,
-  settable since #150 and named in no test in the module. (#210)
 
 ## [1.3.1] — 2026-09-03
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -19,7 +19,7 @@ If you have [JBang](https://www.jbang.dev), there's nothing to download. From yo
 **Claude Code** — one command:
 
 ```bash
-claude mcp add stacktale -- jbang run io.github.gabrielbbaldez:stacktale-mcp:1.1.0 --file "$PWD/errors-ai.log"
+claude mcp add stacktale -- jbang run io.github.gabrielbbaldez:stacktale-mcp:1.3.1 --file "$PWD/errors-ai.log"
 ```
 
 **Cursor** — drop this into `.cursor/mcp.json` (swap in your absolute path):
@@ -27,7 +27,7 @@ claude mcp add stacktale -- jbang run io.github.gabrielbbaldez:stacktale-mcp:1.1
 ```json
 { "mcpServers": { "stacktale": {
     "command": "jbang",
-    "args": ["run", "io.github.gabrielbbaldez:stacktale-mcp:1.1.0", "--file", "/abs/path/errors-ai.log"]
+    "args": ["run", "io.github.gabrielbbaldez:stacktale-mcp:1.3.1", "--file", "/abs/path/errors-ai.log"]
 } } }
 ```
 
@@ -44,7 +44,7 @@ It's on Maven Central. Three ways, easiest first:
 **JBang** (zero install, if you have JBang):
 
 ```bash
-jbang run io.github.gabrielbbaldez:stacktale-mcp:1.1.0 --file /path/to/errors-ai.log
+jbang run io.github.gabrielbbaldez:stacktale-mcp:1.3.1 --file /path/to/errors-ai.log
 ```
 
 **Download the jar directly** (curl):
@@ -58,7 +58,7 @@ curl -L -o stacktale-mcp.jar \
 
 ```bash
 mvn dependency:copy \
-  -Dartifact=io.github.gabrielbbaldez:stacktale-mcp:1.1.0 \
+  -Dartifact=io.github.gabrielbbaldez:stacktale-mcp:1.3.1 \
   -DoutputDirectory=.
 ```
 

--- a/scripts/check-plugin-versions.sh
+++ b/scripts/check-plugin-versions.sh
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 # Guard the Claude plugin / marketplace manifests against drifting from the release.
 #
-# Three files hard-pin a version and are not touched by the version bump:
+# Four files hard-pin a version and are not touched by the version bump:
 #   plugins/stacktale/.mcp.json                  -> the stacktale-mcp coordinate jbang runs
 #   .claude-plugin/marketplace.json              -> the version the marketplace advertises
 #   plugins/stacktale/.claude-plugin/plugin.json -> the version the installed plugin reports
+#   docs/mcp-setup.md                            -> the coordinate a human copy-pastes
+#
+# The fourth was added after it drifted the furthest of any of them: mcp-setup.md sat on
+# 1.1.0 through three releases while the page above the command promised tools that version
+# did not have. It is the one a person actually runs, and nothing checked it.
 #
 # THE RULE: they pin the most recent *released* version, which is the newest version
 # heading in CHANGELOG.md.
@@ -59,6 +64,21 @@ do
   fi
 done
 
+# Prose, so every occurrence is checked rather than the first: a page can update one command
+# and leave the three below it behind, which reads worse than a single stale number.
+setup_pins=$(grep -oE 'io\.github\.gabrielbbaldez:stacktale-mcp:[0-9]+\.[0-9]+\.[0-9]+' \
+  docs/mcp-setup.md | sed 's/.*://' | sort -u || true)
+if [ -z "$setup_pins" ]; then
+  echo "docs/mcp-setup.md names no stacktale-mcp coordinate; the install instructions lost it" >&2
+  fail=1
+fi
+for actual in $setup_pins; do
+  if [ "$actual" != "$expected" ]; then
+    echo "docs/mcp-setup.md pins $actual, expected $expected (the latest release, per CHANGELOG.md)" >&2
+    fail=1
+  fi
+done
+
 # A release commit sets the parent to the version it is releasing. If the parent is not a
 # SNAPSHOT and disagrees with the changelog, one of the two was not updated -- and the
 # check above would have compared against the wrong number without noticing.
@@ -74,7 +94,7 @@ case "$pom" in
 esac
 
 if [ "$fail" -eq 0 ]; then
-  echo "plugin manifests pin $expected"
+  echo "plugin manifests and setup docs pin $expected"
 fi
 
 exit "$fail"

--- a/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportRenderer.java
+++ b/stacktale-core/src/main/java/io/github/gabrielbbaldez/stacktale/ReportRenderer.java
@@ -139,6 +139,7 @@ final class ReportRenderer implements Renderer {
                 # Sections: headline (root cause first), at (culprit frame), log, mdc,
                 # fields (state carried by the exception's own getters/fields),
                 # repro (opt-in: the throw site's typed signature and argument values),
+                # first seen (opt-in: which build this error id was first seen on),
                 # story (events leading up to and including the error, oldest first),
                 # stack (distilled; framework frames collapsed), env. "← YOUR CODE" marks app frames.
                 # Repeated errors append "━ #<id> repeated N× ━" lines instead of new reports.


### PR DESCRIPTION
A pre-release pass over the twelve `[Unreleased]` entries, before recommending 1.4.0. Two
findings, both about what a *user* sees rather than what the tests cover.

## The setup page has been installing 1.1.0

`docs/mcp-setup.md` hard-pins the coordinate in four commands:

```
jbang run io.github.gabrielbbaldez:stacktale-mcp:1.1.0 --file /path/to/errors-ai.log
```

Nothing bumped it. Every other pinned coordinate in the repository is at 1.3.1 — I checked all
of them:

```
      2 stacktale-jul:1.3.1          1 stacktale-junit:1.3.1
      2 stacktale-log4j2:1.3.1       2 stacktale-spring-boot-starter:1.3.1
      2 stacktale:1.3.1              1 stacktale-mcp:1.3.1   (plugins/stacktale/.mcp.json)
      4 stacktale-mcp:1.1.0          (docs/mcp-setup.md)
```

So for three releases the page has listed tools above a command that installs a version without
them — and after 1.4.0 that gap would be five tools wide. It is the copy a person actually
pastes into their client.

The three plugin manifests are already guarded, after the same thing happened to them in #142.
The setup page is prose rather than a manifest, which is exactly how it drifted furthest and was
found last. Now:

- `prepare-release` stamps it, with the sed verified against the real file (all four
  occurrences rewritten, not the first);
- `check-plugin-versions.sh` checks it — **every** occurrence, since a page can update one
  command and leave the three below it behind, which reads worse than a single stale number.

Proved by putting the repository back into the state it was in an hour ago:

```
$ sed -i 's|stacktale-mcp:1.3.1|stacktale-mcp:1.1.0|' docs/mcp-setup.md
$ bash scripts/check-plugin-versions.sh
docs/mcp-setup.md pins 1.1.0, expected 1.3.1 (the latest release, per CHANGELOG.md)
exit 1
```

## `[Unreleased]` had two `### Changed` sections

One from the first PR of the day, one from a later one, with `### Fixed` between them. Keep a
Changelog wants one section per type, and `prepare-release` turns this block into the published
1.4.0 entry verbatim — so it would have shipped that way. Merged, and the orphaned entry
reworded now that it no longer sits directly under the bug it refers to.

## The file header lost a section

The `#` block at the top of every report file exists so that an AI opening it cold learns the
format from the file itself. It lists `repro` and never learned about `first seen:` — the
section I added in #225 this afternoon.

## Where the finding came from

Not from reading the diff. I drove all ten MCP tools through the built jar in one process,
twice: once against a hand-written report, then against one rendered by the production
renderer with **both** new sections present, because a hand-written fixture can be accidentally
easier to parse than the real thing.

All ten answered; nothing regressed from `first seen:` landing between `seen:` and `story`. The
header gap is visible in that second output, which is where I noticed it.

`mvn -B verify`: 559 tests, 0 failures.

## What this does not change

No behaviour, no format. `first seen:` was already rendered and already specified in
FORMAT.md §3 — the header is documentation shipped inside the file, and §2 says its exact text
is not part of the contract.
