### PR TITLE
docs(native): cover Quarkus, with a native binary behind it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,16 @@ and pinned by golden-file tests.
 
 ### Changed
 
+- **`docs/native.md` covers Quarkus, with a native binary behind it.** The page explained
+  GraalVM native-image for the core and the Spring starter and said nothing about the module
+  built for it. Measured rather than reasoned: the same application and the same error, JVM and
+  native side by side. It works with **no configuration** — a report is written, and `env:`
+  keeps the git sha, because Quarkus honours the `META-INF/native-image` resource metadata
+  `stacktale-core` already bundles. So no `NativeImageResourceBuildItem` is needed in the
+  extension, which is what the issue expected to be the fix. `fields:` is empty until the
+  exception type carries `@RegisterForReflection`, verified both ways on the same binary.
+  Tested against Quarkus 3.15.1 with GraalVM 21.0.5 — the floor, and the page says so, since
+  Quarkus 3.39 will not build native below GraalVM 25. (#204)
 - `docs/FORMAT.md` files the `repro:` section under **§3 Report block** and gives it a row in
   that section's field table. It was a subsection of §5 *Non-report entries*, next to
   `repeated`, `app start` and `storm:` — the three things that are not reports. (#216)

--- a/docs/native.md
+++ b/docs/native.md
@@ -1,9 +1,12 @@
 # stacktale on GraalVM native-image
 
 stacktale's report pipeline is almost entirely reflection-free, so it works under
-GraalVM native-image (including Spring Boot 3 AOT) with **no configuration**. The one
-section that needs your help is `fields:`, because it reflects over *your* exception
-types — which only you can enumerate for the image.
+GraalVM native-image — Spring Boot 3 AOT and Quarkus alike — with **no configuration**. The
+one section that needs your help is `fields:`, because it reflects over *your* exception
+types, which only you can enumerate for the image.
+
+The Quarkus section below is measured rather than assumed: a native binary, a real error, and
+the report it wrote.
 
 ## What works with zero metadata
 
@@ -75,6 +78,74 @@ class MyHints implements RuntimeHintsRegistrar {
 Only exception types you care about seeing state for need this — stacktale reads at most
 8 value-typed getters/fields per report.
 
+## Quarkus — measured, and it needs nothing
+
+`stacktale-quarkus` is the module where this matters most: native image is a first-class
+Quarkus story rather than an afterthought, and the extension's whole shape — the
+runtime/deployment split, the `@Recorder`, deciding configuration at build time — exists so
+that Quarkus can close the world at build time.
+
+It works with **no configuration**. Same application, same error, JVM mode and native side by
+side:
+
+| | JVM | native |
+|---|---|---|
+| a report is written at all | yes | yes |
+| headline, culprit frame, `← YOUR CODE` | yes | yes |
+| `story`, distilled `stack`, dedup | yes | yes |
+| `env:` including the git sha | yes | yes |
+| `first seen:` and its sidecar | yes | yes |
+| `fields:` | yes | **empty** until you register the type |
+
+Two things carry `env:` through, and neither needs anything from you:
+
+- `git.properties` survives because **Quarkus honours the `META-INF/native-image/…`
+  resource metadata that `stacktale-core` already bundles**. No `NativeImageResourceBuildItem`
+  is needed in the extension; the resource registration a plain native-image build reads is
+  read here too.
+- the application **name and version** do not come from a resource at all — the extension
+  reads `quarkus.application.name` and `.version` at build time and records them, so they are
+  compiled into the image.
+
+The extension also marks `ReportPipeline` and `StacktaleJulHandler` runtime-initialized, which
+is what keeps a file handle and a background flusher out of the image heap. (Whether a build
+would fail without that was not isolated — a passing build with it removed would not prove much
+either way, since nothing in a minimal app forces those classes to initialize at build time.)
+
+### `fields:` in Quarkus
+
+Same rule as everywhere else — reflection over *your* exception types — with Quarkus's own
+annotation:
+
+```java
+@RegisterForReflection
+public class OrderException extends IllegalStateException {
+    public long getOrderId() { ... }
+}
+```
+
+Verified both ways on the same binary: without the annotation the section is absent, with it
+the report carries `fields: orderId=999 retryable=false`. As everywhere, an unregistered type
+degrades to an empty section rather than a crash.
+
+### What this was tested against
+
+**Quarkus 3.15.1** — the floor of the compatibility matrix — with Oracle GraalVM 21.0.5
+(native-image 23.1), on Windows.
+
+Not the top of the range, and that is worth knowing rather than glossing: Quarkus 3.39 refuses
+to build native with anything older than GraalVM/Mandrel **25.0.0**, so checking the current
+version needs a newer toolchain than the floor does:
+
+```
+Out of date version of GraalVM or Mandrel detected: 23.1.
+Quarkus currently supports 25.0.0.
+```
+
+Nothing in the extension's native surface is version-specific — a bundled resource
+registration and a build-time recorded value — so the result should hold across the range. It
+has not been observed there.
+
 ## `captured:` — not available in native
 
 The `captured:` section comes from the optional `stacktale-agent`, a `-javaagent`.
@@ -85,14 +156,23 @@ class isn't present — again, graceful, no crash.
 ## Verifying
 
 With a GraalVM JDK, build your app native the usual way — stacktale needs no special flags
-beyond registering your exception types (above). For a Spring Boot app using the starter:
+beyond registering your exception types (above).
 
 ```bash
-mvn -Pnative native:compile
-./target/your-app     # trigger an error, then check ./errors-ai.log
+mvn -Pnative native:compile        # Spring Boot
+mvn package -Dnative               # Quarkus
+./target/your-app                  # trigger an error, then check ./errors-ai.log
 ```
 
-`env:` should keep your version/git sha (the bundled resource metadata + the starter's
-`RuntimeHintsRegistrar` handle that), and `fields:` should be populated for every exception
-type you registered. There is no native job in CI — native-image needs a GraalVM toolchain
-and minutes per build — so run this check yourself when validating a native deployment.
+Check the report itself, not the build. Native-image failures of this kind are **runtime**
+failures — a missing resource or a pruned reflective call — so the binary links happily and
+then the section is quietly absent. What to look at:
+
+- `env:` keeps your version and git sha,
+- `fields:` is populated for every exception type you registered,
+- and there is a report at all.
+
+There is no native job in CI: native-image needs a GraalVM toolchain and minutes per build, and
+the toolchain does not follow the compatibility matrix — Quarkus 3.39 requires GraalVM 25 while
+3.15 accepts 23.1, so one runner cannot cover the range. Run this yourself when validating a
+native deployment.


### PR DESCRIPTION
Closes #204.

The page explained native-image for the core and the Spring starter, and said nothing about the
module built for it. The issue framed the work honestly — two things unknown, and *finding out*
is most of it:

> 1. Does it work at all today? 2. Does it need a `NativeImageResourceBuildItem`?

**Yes, and no.** Both answered by building a native binary and reading the report it wrote, not
by reasoning about the build steps.

## The measurement

A minimal Quarkus app with the extension and a domain exception, run in JVM mode and native,
same error both times:

| | JVM | native |
|---|---|---|
| a report is written at all | yes | yes |
| headline, culprit frame, `← YOUR CODE` | yes | yes |
| `story`, distilled `stack` | yes | yes |
| `env:` including the git sha | yes | yes |
| `first seen:` and its sidecar | yes | yes |
| `fields:` | yes | **empty** |

The native report, verbatim:

```
━━━ ERROR #58e9b8eb ━━━ 2026-09-04 17:10:42.538 thread=main ━━━
Probe$OrderException: customer cache returned null for order 999
at Probe.run(Probe.java:18) ← YOUR CODE
log: "Failed to confirm order 999" logger=c.a.Probe
first seen: NEW in this build (7e3c1f)

story (thread main, last 4 events, 0ms):
  17:10:42.538 INFO  quarkus  native-probe 9.9.9 native (powered by Quarkus 3.15.1) started in 0.013s.
  …
env: app=native-probe 9.9.9 (git 7e3c1f) | java 21.0.5 | windows
━━━ END #58e9b8eb ━━━
```

## No build item needed, and that is the finding

The issue expected a `NativeImageResourceBuildItem` to be the likely fix. It is not: the git sha
is *in that env line*. **Quarkus honours the `META-INF/native-image/…` resource metadata
`stacktale-core` already bundles** — the same registration a plain native-image build reads is
read here too.

The application name and version do not come from a resource at all. They are recorded at build
time from `quarkus.application.*` — which only became true in #215, earlier today. Before that,
this row of the table would have read `app=?`.

`first seen:` and its sidecar also survive, so provenance (#225) works in native, file write and
all.

## `fields:`, verified both ways on the same binary

Absent without the annotation; with `@RegisterForReflection` on the exception, the same native
build reports `fields: orderId=999 retryable=false`. Same rule as everywhere else — reflection
over *your* types — and now written down with Quarkus's own annotation rather than by analogy
with Spring's.

## What it was tested against, and what that does not cover

**Quarkus 3.15.1 with Oracle GraalVM 21.0.5 (native-image 23.1)** — the floor of the
compatibility matrix, not the top. The page says so, because "works" and "works on the version
you are running" are different claims. Quarkus 3.39 refuses:

```
Out of date version of GraalVM or Mandrel detected: 23.1.
Quarkus currently supports 25.0.0.
```

Nothing in the extension's native surface is version-specific — a bundled resource registration
and a build-time recorded value — so the result should hold across the range. It has not been
observed there, and the page says that too.

That version gap is also the honest answer to why there is still no native job in CI: the
toolchain does not follow the compatibility matrix, so one runner cannot cover 3.15 and 3.39 at
once. The `Verifying` section now says that instead of just "it takes minutes".

## One thing deliberately not claimed

`StacktaleProcessor` marks `ReportPipeline` and `StacktaleJulHandler` runtime-initialized. I did
not test removing it. A passing build without it would not have proved much either way — nothing
in a minimal app forces those classes to initialize at build time — so the page states what the
step does and says the necessity was not isolated, rather than implying the experiment happened.

Docs only; no source change.
