### PR TITLE
infra: a hot-path regression guard that compares instead of trusting a number

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -1,0 +1,32 @@
+name: Performance
+
+# Only when the measured code changes. The job builds the branch and its base and runs both,
+# which is minutes — not something a README edit should pay for.
+on:
+  pull_request:
+    paths:
+      - "stacktale-core/src/main/**"
+      - "stacktale/src/main/**"
+      - "scripts/check-perf.sh"
+      - "scripts/perf/**"
+      - ".github/workflows/perf.yml"
+
+jobs:
+  hot-path:
+    name: Hot path vs base
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The base commit has to be in the clone: the guard builds it as a worktree and
+          # measures against it. A shallow checkout has nothing to compare with.
+          fetch-depth: 0
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+          cache: maven
+      - name: Hot path against the merge base
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+        run: bash scripts/check-perf.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,15 @@ and pinned by golden-file tests.
   arrives as an explicit `TODO`, never as a literal: `String token = "███"` compiles, reads as
   data, and would reproduce a call that never happened. A report with no seed gets the two
   switches it needs rather than an error. (#135)
+- **A hot-path regression guard that compares, rather than trusting a number.**
+  `check-perf.sh` builds a PR and its merge base and runs the same probe against them
+  alternately, failing on the ratio — because a benchmark figure is only comparable to another
+  taken within seconds of it. The same code drifted ~8% between sessions on an idle machine,
+  which is the size of the regressions a fixed threshold would be asked to detect. Calibrated
+  against a null (the same commit on both arms) and proved against an injected slowdown, which
+  it reports as `info is 2.363x the base`. The probe refuses to report timings unless stacktale
+  actually wrote a report — a misconfigured run degrades to a no-op by design, and would
+  otherwise have produced a confident ratio of 1.0 forever. (#98)
 - **A guard that keeps the five adapters' configuration surfaces in step.**
   `check-config-parity.sh` reads the README's configuration table and asserts each knob is
   reachable from Logback, Log4j2, JUL, the Spring starter and Quarkus — matching the shape

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,31 @@ find . -path '*/target/*.jar' | sort | xargs sha256sum | diff -u /tmp/first.txt 
 If that ever diverges, the usual causes are a plugin writing a build time into
 `MANIFEST.MF` or a newly added plugin too old to honour the property.
 
+## Performance
+
+`scripts/check-perf.sh` guards the hot path, and CI runs it on any PR that touches
+`stacktale-core/src/main` or `stacktale/src/main`. It does **not** compare against a number in
+a file. It builds your branch and its merge base and runs the same probe against them
+alternately, comparing medians — a benchmark figure is only comparable to another taken within
+seconds of it, and on this project's own machine the same code drifted ~8% between sessions.
+
+Run it yourself before pushing something hot-path shaped:
+
+```bash
+bash scripts/check-perf.sh                    # against origin/main
+BASE_REF=abc1234 ROUNDS=5 bash scripts/check-perf.sh
+```
+
+It reports both paths and fails when either is more than `MAX_RATIO` (1.5) times the base. That
+limit is deliberately loose, and the script's header carries the calibration behind it: run
+against a null — the same commit on both arms — the ratios still came back between 0.87 and
+1.19. What it reliably catches is the thing #98 was opened for, a refactor quietly multiplying
+the per-event cost. It is not a 5% detector, and the printed numbers are there so a ratio
+creeping upward is visible before it fails.
+
+If you are changing the probe, calibrate it the same way: point it at a commit that changes
+nothing and check that it says so.
+
 ## Mutation testing (`stacktale-core`)
 
 Line coverage says a line ran; a mutation score says the tests would actually

--- a/scripts/check-perf.sh
+++ b/scripts/check-perf.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# Guard the hot path against a regression, by comparison rather than against a number.
+#
+# THE PROBLEM WITH A THRESHOLD. #98 asked for a JMH run in CI failing past a fixed
+# threshold "with headroom to avoid flakiness on shared runners". Measured on an idle
+# developer machine — quieter than any shared runner — the same code timed 5092 ns/op in one
+# session and 5581 in another minutes later. That is ~8% of drift with nothing changed, and
+# the regressions worth catching are not much larger. Headroom wide enough to survive that
+# lets a real regression through; headroom narrow enough to catch one fires on a noisy
+# neighbour. Both end with somebody muting the job.
+#
+# WHAT THIS DOES INSTEAD. Build the pull request and its merge base, then run the same probe
+# against them **alternately**, in one sitting. Drift hits both arms inside the same few
+# seconds and cancels in the ratio. The comparison is base-vs-head medians; the absolute
+# numbers are printed for a human but nothing is asserted about them.
+#
+# The third-party dependencies come from the head build for both arms on purpose: the
+# question is what *this* change cost, not what a Logback upgrade cost.
+#
+# WHAT IT IS CALIBRATED TO CATCH. #98 wants to stop "a refactor silently 10x-ing the hot
+# path", and that is the size of thing this reliably reports. It is not a 5% detector, and
+# pretending otherwise would make it a liar: run against a null — the same commit on both
+# arms, true ratio 1.000 — the measured ratios came back
+#
+#   400k/20k iterations, 1 alternation    info 1.188   error 0.931
+#   400k/20k iterations, 5 alternations   info 0.938   error 1.117
+#   2M/100k iterations,  3 alternations   info 0.865   error 0.935
+#
+# Longer rounds tightened the error path; the happy path stayed at roughly +-10% however it
+# was measured, because at ~200ns/op the variation is between JVM processes — each arm gets
+# its own JIT compilation plan — and alternating cancels drift, not that. So the limit sits
+# well clear of the noise floor, and a ratio creeping toward it is visible in the printed
+# numbers long before it fails.
+#
+#   BASE_REF   what to compare against            (default: origin/main)
+#   ROUNDS     alternations per arm               (default: 3)
+#   MAX_RATIO  head/base median that fails        (default: 1.5)
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+BASE_REF="${BASE_REF:-origin/main}"
+ROUNDS="${ROUNDS:-3}"
+MAX_RATIO="${MAX_RATIO:-1.5}"
+
+work="$(mktemp -d)"
+base_tree="$work/base"
+cleanup() {
+  git worktree remove --force "$base_tree" >/dev/null 2>&1 || true
+  rm -rf "$work"
+}
+trap cleanup EXIT
+
+# Windows/Git Bash: java wants ';' between classpath entries, and MSYS rewrites anything that
+# looks like a path list unless told not to. Scoped to the java/javac calls rather than
+# exported — setting it for the whole script breaks Maven's own launcher, which depends on the
+# conversion it disables.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) SEP=';'; NO_CONV='MSYS2_ARG_CONV_EXCL=*'; WINDOWS=1 ;;
+  *) SEP=':'; NO_CONV=''; WINDOWS=0 ;;
+esac
+
+# With conversion disabled, a POSIX path reaches the JVM unchanged and is not a path there:
+# the classpath entry silently does not exist, Logback falls back to its default console
+# config, and the probe times something else entirely. Convert explicitly instead.
+native_path() {
+  if [ "$WINDOWS" -eq 1 ]; then cygpath -w "$1"; else printf '%s' "$1"; fi
+}
+
+base_sha="$(git rev-parse "$BASE_REF")"
+head_sha="$(git rev-parse HEAD)"
+if [ "$base_sha" = "$head_sha" ]; then
+  echo "check-perf: HEAD is $BASE_REF; nothing to compare"
+  exit 0
+fi
+
+echo "check-perf: comparing $(git rev-parse --short HEAD) against $BASE_REF ($(git rev-parse --short "$base_sha"))"
+
+build() { # <tree> <label>
+  ( cd "$1" && mvn -q -B -pl stacktale -am -DskipTests package ) \
+    || { echo "check-perf: could not build the $2 tree" >&2; exit 1; }
+}
+
+git worktree add --detach "$base_tree" "$base_sha" >/dev/null 2>&1
+build "." "head"
+build "$base_tree" "base"
+
+# One classpath of third-party jars, from the head build, shared by both arms.
+mvn -q -B -pl stacktale dependency:build-classpath -Dmdep.outputFile="$work/cp.txt" -DincludeScope=runtime
+deps="$(cat "$work/cp.txt")"
+
+# The probe is compiled once, from the head checkout, and run against both. It uses only
+# SLF4J and the appender's class name — a probe calling stacktale's own API would stop
+# compiling against an older base and report that as a regression.
+mkdir -p "$work/probe"
+# Both arguments need the native form for the same reason: with conversion off, `-d` would
+# create a literal `C:\c\Users\…` tree and the class would not be where the classpath looks.
+env ${NO_CONV:+"$NO_CONV"} javac -nowarn \
+    -cp "$deps" \
+    -d "$(native_path "$work/probe")" \
+    "$(native_path "$PWD/scripts/perf/PerfProbe.java")"
+
+arm_cp() { # <tree>
+  local entries=(
+    "$work/probe"                        # the compiled probe
+    "$PWD/scripts/perf"                  # logback-perf.xml
+    "$1/stacktale/target/classes"        # the arm under measurement
+    "$1/stacktale-core/target/classes"
+  )
+  local out=""
+  local entry
+  for entry in "${entries[@]}"; do
+    out="$out$(native_path "$entry")$SEP"
+  done
+  printf '%s%s' "$out" "$deps"
+}
+
+report_file="$(native_path "$work/perf-errors-ai.log")"
+
+run() { # <tree> -> "info=<ns>\nerror=<ns>"
+  env ${NO_CONV:+"$NO_CONV"} java \
+      -Dlogback.configurationFile=logback-perf.xml \
+      -Dstacktale.perf.file="$report_file" \
+      -cp "$(arm_cp "$1")" PerfProbe
+}
+
+base_info=(); base_error=(); head_info=(); head_error=()
+for round in $(seq 1 "$ROUNDS"); do
+  # base first on odd rounds, head first on even: whichever runs first pays for a cold page
+  # cache, and alternating the order keeps that from landing on one arm every time.
+  if [ $((round % 2)) -eq 1 ]; then order="$base_tree ."; else order=". $base_tree"; fi
+  for tree in $order; do
+    out="$(run "$tree")"
+    info="$(printf '%s\n' "$out" | sed -n 's/^info=//p')"
+    error="$(printf '%s\n' "$out" | sed -n 's/^error=//p')"
+    if [ -z "$info" ] || [ -z "$error" ]; then
+      echo "check-perf: the probe produced no measurement for $tree" >&2
+      printf '%s\n' "$out" >&2
+      exit 1
+    fi
+    if [ "$tree" = "." ]; then head_info+=("$info"); head_error+=("$error")
+    else base_info+=("$info"); base_error+=("$error"); fi
+  done
+  echo "  round $round done"
+done
+
+median() { printf '%s\n' "$@" | sort -n | awk '{ v[NR]=$1 } END { print v[int((NR+1)/2)] }'; }
+
+fail=0
+for metric in info error; do
+  if [ "$metric" = "info" ]; then
+    b="$(median "${base_info[@]}")"; h="$(median "${head_info[@]}")"
+  else
+    b="$(median "${base_error[@]}")"; h="$(median "${head_error[@]}")"
+  fi
+  ratio="$(awk -v h="$h" -v b="$b" 'BEGIN { printf "%.3f", (b > 0 ? h / b : 0) }')"
+  printf '  %-6s base %6s ns   head %6s ns   ratio %s\n' "$metric" "$b" "$h" "$ratio"
+  over="$(awk -v r="$ratio" -v m="$MAX_RATIO" 'BEGIN { print (r > m) ? 1 : 0 }')"
+  if [ "$over" -eq 1 ]; then
+    echo "check-perf: $metric is ${ratio}x the base, over the $MAX_RATIO limit" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "check-perf: within $MAX_RATIO of $BASE_REF over $ROUNDS alternations"
+fi
+
+exit "$fail"

--- a/scripts/check-perf.sh
+++ b/scripts/check-perf.sh
@@ -86,7 +86,16 @@ build "." "head"
 build "$base_tree" "base"
 
 # One classpath of third-party jars, from the head build, shared by both arms.
-mvn -q -B -pl stacktale dependency:build-classpath -Dmdep.outputFile="$work/cp.txt" -DincludeScope=runtime
+#
+# Resolved inside the same reactor run as the build (`-am`) rather than as a standalone
+# invocation: on a clean machine stacktale-core:<version>-SNAPSHOT is not in the local
+# repository, and a standalone goal has no reactor to find it in. That passes on a developer
+# machine, where an earlier `install` left it there, and fails on a fresh runner — which is
+# where it did fail.
+#
+# Our own artifacts are excluded, so `deps` is third-party only and cannot shadow the arm
+# being measured.
+mvn -q -B -pl stacktale -am -DskipTests package     dependency:build-classpath     -Dmdep.outputFile="$work/cp.txt"     -DincludeScope=runtime     -DexcludeGroupIds=io.github.gabrielbbaldez
 deps="$(cat "$work/cp.txt")"
 
 # The probe is compiled once, from the head checkout, and run against both. It uses only

--- a/scripts/perf/PerfProbe.java
+++ b/scripts/perf/PerfProbe.java
@@ -1,0 +1,105 @@
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Times the two paths the "negligible overhead" claim is about, and prints one line per result.
+ *
+ * <p>Driven by {@code scripts/check-perf.sh}, which runs this against two builds of stacktale —
+ * the pull request's and its merge base — alternating between them. That is the whole design: a
+ * benchmark number is only comparable to another taken within seconds of it, and this program
+ * exists to be run twice in a row rather than to produce an absolute figure.
+ *
+ * <p>Deliberately not JMH. JMH's rigour is aimed at getting one number right; the problem here is
+ * drift between two numbers, which more forking and warmup does not fix. What fixes it is
+ * measuring both arms in the same few seconds, which is the driver's job.
+ *
+ * <p>Only SLF4J and the appender's class name are used, and both are stable across every version
+ * this could run against. A probe calling stacktale's own API would stop compiling against an
+ * older base the first time a signature changed, and the driver would report that as a
+ * regression.
+ */
+public final class PerfProbe {
+
+    /**
+     * Sized so a round takes a few hundred milliseconds on either path.
+     *
+     * <p>Calibrated against a null — the same commit on both arms, where the true ratio is 1.0.
+     * At 400k/20k a round took tens of milliseconds and the null came back at 1.188 and 0.931:
+     * ±19% of noise on a question whose answer is zero, which would have made the guard fire on
+     * a documentation change. Longer rounds are the cheapest way to buy that back, because
+     * scheduling noise is roughly constant per round rather than per iteration.
+     */
+    private static final int INFO_ITERATIONS = 2_000_000;
+    private static final int ERROR_ITERATIONS = 100_000;
+    private static final int ROUNDS = 5;
+
+    private static int sink;
+
+    public static void main(String[] args) throws Exception {
+        Logger log = LoggerFactory.getLogger("com.acme.PerfProbe");
+        RuntimeException recurring = new IllegalStateException("gateway timeout");
+        recurring.setStackTrace(new StackTraceElement[]{
+                new StackTraceElement("com.acme.PaymentService", "charge", "PaymentService.java", 118),
+        });
+
+        // The happy path: a non-error event. It reaches the story buffer and returns, which is
+        // where "stacktale costs nothing until something breaks" has to hold.
+        report("info", INFO_ITERATIONS, () -> log.info("charging card for order {}", 889));
+
+        // The error path, deduplicated: one full report, then repeats. A distinct error every
+        // time would measure the filesystem instead of stacktale.
+        report("error", ERROR_ITERATIONS, () -> log.error("charge failed for order {}", 889, recurring));
+
+        assertStacktaleActuallyRan();
+    }
+
+    /**
+     * The failure this guard would otherwise never notice.
+     *
+     * <p>A misconfigured classpath, an unreadable file path, a Logback config that was not found:
+     * every one of them ends with stacktale degrading to a no-op — by design, since it must never
+     * break the host — and the probe happily timing a logger that does nothing. Numbers would
+     * still be produced, the ratio would still be ~1.0, and the guard would pass forever while
+     * measuring nothing. It cost an hour to find the first time, on a run whose only symptom was
+     * being slow.
+     */
+    private static void assertStacktaleActuallyRan() throws Exception {
+        String file = System.getProperty("stacktale.perf.file");
+        if (file == null || file.isBlank()) {
+            throw new IllegalStateException("stacktale.perf.file is not set; cannot verify the appender ran");
+        }
+        Path path = Path.of(file);
+        if (!Files.exists(path)) {
+            throw new IllegalStateException("stacktale wrote no report to " + path.toAbsolutePath()
+                    + " — the appender is not attached, and these timings measure nothing");
+        }
+        String content = Files.readString(path, StandardCharsets.UTF_8);
+        if (!content.contains("ERROR #")) {
+            throw new IllegalStateException("no report block in " + path.toAbsolutePath()
+                    + " — the appender started but produced nothing");
+        }
+    }
+
+    private static void report(String name, int iterations, Runnable op) {
+        for (int i = 0; i < iterations / 2; i++) {
+            op.run();
+        }
+        long[] rounds = new long[ROUNDS];
+        for (int round = 0; round < ROUNDS; round++) {
+            long start = System.nanoTime();
+            for (int i = 0; i < iterations; i++) {
+                op.run();
+            }
+            rounds[round] = (System.nanoTime() - start) / iterations;
+        }
+        java.util.Arrays.sort(rounds);
+        // The median, not the mean: one descheduled round should not move the answer, which is
+        // the same reason the driver compares medians across arms.
+        System.out.println(name + "=" + rounds[ROUNDS / 2]);
+        sink += rounds[0];
+    }
+}

--- a/scripts/perf/logback-perf.xml
+++ b/scripts/perf/logback-perf.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The appender under measurement, and nothing else: no console, no encoder, no second
+  destination. Anything else attached would be measured too, and the question is what
+  stacktale costs.
+
+  Referenced by class name so the same file configures either build the driver puts on the
+  classpath.
+-->
+<configuration>
+  <appender name="STACKTALE" class="io.github.gabrielbbaldez.stacktale.logback.StacktaleAppender">
+    <file>${stacktale.perf.file:-target/perf-errors-ai.log}</file>
+    <appPackages>com.acme</appPackages>
+    <truncateOnStart>true</truncateOnStart>
+    <!--
+      The uncaught handler installs a JVM-global hook; two probe runs in a row would each
+      install one. It is not on the path being measured.
+    -->
+    <installUncaughtHandler>false</installUncaughtHandler>
+  </appender>
+
+  <root level="INFO">
+    <appender-ref ref="STACKTALE"/>
+  </root>
+</configuration>


### PR DESCRIPTION
Closes #98.

The issue asked for a JMH run in CI failing past a fixed threshold, "with headroom to avoid
flakiness on shared runners". **A fixed threshold cannot work here**, and I have the numbers
from #223: on an idle developer machine — quieter than any shared runner — the same code timed
5092 ns/op in one session and 5581 in another minutes later. ~8% of drift with nothing changed,
which is the size of the regressions such a threshold would be asked to detect. Headroom wide
enough to survive that lets a real regression through; headroom narrow enough to catch one
fires on a noisy neighbour. Both end with somebody muting the job.

## What it does instead

Builds the branch **and its merge base**, then runs the same probe against them alternately and
compares medians. Drift lands on both arms inside the same few seconds and cancels in the
ratio. Absolute numbers are printed for a human; nothing is asserted about them.

```
  info   base    212 ns   head    501 ns   ratio 2.363
check-perf: info is 2.363x the base, over the 1.5 limit
```

That is the guard catching a deliberate slowdown I injected into `StacktaleAppender.append` —
200 volatile increments — then reverted. Without it:

```
  info   base    215 ns   head    186 ns   ratio 0.865
  error  base   2150 ns   head   2011 ns   ratio 0.935
check-perf: within 1.5 of origin/main over 3 alternations
```

## The bug that shaped the design

The first working version ran for several minutes and produced no numbers. It was timing
**Logback's default console appender**. A classpath entry it could not resolve meant
`logback-perf.xml` was never found, so stacktale was never attached — and stacktale degrades to
a no-op rather than failing, by design, because it must never break the host.

The guard would still have produced timings. Both arms would have been equally not-measuring
stacktale. **The ratio would have been ~1.0 forever.** The only symptom was that it was slow;
on a faster machine I would have shipped it.

So the probe now refuses to report anything unless a report block actually reached the file:

```java
if (!content.contains("ERROR #")) {
    throw new IllegalStateException("no report block in " + path.toAbsolutePath()
            + " — the appender started but produced nothing");
}
```

The never-throw guarantee is exactly what makes a benchmark of this project fail silently. The
guarantee is right; the guard had to know about it.

## Why the limit is 1.5 and not something tighter

Calibrated against a null — the same commit on both arms, true ratio 1.000:

| iterations | alternations | info | error |
|---|---|---|---|
| 400k / 20k | 1 | 1.188 | 0.931 |
| 400k / 20k | 5 | 0.938 | 1.117 |
| 2M / 100k | 3 | 0.865 | 0.935 |

Longer rounds tightened the error path. The happy path stayed at roughly ±10% however it was
measured, because at ~200 ns/op the variation is **between JVM processes** — each arm gets its
own JIT compilation plan — and alternating cancels drift, not that.

My first default was 1.25, which the null would have tripped on a documentation change. Then I
re-read what the issue is actually for: *"a refactor could silently 10x the hot path"*. That is
the size of thing worth gating on, and 1.5 sits well clear of a measured ±19% worst case. The
script's header carries this table so nobody — including me in a month — mistakes it for a 5%
detector. The ratios print on every run, so a number creeping toward the limit is visible long
before it fails.

## Cost

Two Maven builds and six short JVM runs, on PRs that touch `stacktale-core/src/main`,
`stacktale/src/main`, or the guard itself. A README edit does not pay for it.

## One near-miss worth recording

`git checkout -- <file>` restores from the **index**, not from HEAD, so my first attempt to
revert the injected slowdown quietly restored the injected version. Caught by checking
`git diff --cached --stat` and seeing three lines of appender still staged. Without that look,
this PR would have shipped a deliberate performance regression inside a performance guard.
