### PR TITLE
release: 1.4.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "stacktale",
       "source": "./plugins/stacktale",
       "description": "Read your Java app's AI-ready error reports, and run a fix-run-check loop until the app is clean.",
-      "version": "1.3.1",
+      "version": "1.4.0",
       "author": {
         "name": "Gabriel Baldez"
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to stacktale are documented here. The format follows
 [SemVer](https://semver.org/). The report format (`st/1`) is versioned independently
 and pinned by golden-file tests.
 
-## [Unreleased]
+## [1.4.0] — 2026-09-04
 
 ### Added
 
@@ -148,6 +148,8 @@ and pinned by golden-file tests.
   `Ignoring unknown property [repro]`, `@ConfigurationProperties` drops unknown fields, Quarkus
   warns and starts — so the knob looked set and the `repro:` section simply never appeared.
   (#210)
+
+[1.4.0]: https://github.com/stacktale/stacktale/releases/tag/v1.4.0
 
 ## [1.3.1] — 2026-09-03
 

--- a/README.md
+++ b/README.md
@@ -118,13 +118,13 @@ All artifacts are on Maven Central.
 **Gradle (Groovy)**
 
 ```groovy
-implementation 'io.github.gabrielbbaldez:stacktale-spring-boot-starter:1.3.1'
+implementation 'io.github.gabrielbbaldez:stacktale-spring-boot-starter:1.4.0'
 ```
 
 **Gradle (Kotlin DSL)**
 
 ```kotlin
-implementation("io.github.gabrielbbaldez:stacktale-spring-boot-starter:1.3.1")
+implementation("io.github.gabrielbbaldez:stacktale-spring-boot-starter:1.4.0")
 ```
 
 That's it — no logback.xml editing. The starter registers the appender on the root
@@ -170,13 +170,13 @@ written in Kotlin or Java.
 **Gradle (Groovy)**
 
 ```groovy
-implementation 'io.github.gabrielbbaldez:stacktale:1.3.1'
+implementation 'io.github.gabrielbbaldez:stacktale:1.4.0'
 ```
 
 **Gradle (Kotlin DSL)**
 
 ```kotlin
-implementation("io.github.gabrielbbaldez:stacktale:1.3.1")
+implementation("io.github.gabrielbbaldez:stacktale:1.4.0")
 ```
 
 ```xml
@@ -213,13 +213,13 @@ itself on startup, and the file header explains the format to any AI that opens 
 **Gradle (Groovy)**
 
 ```groovy
-implementation 'io.github.gabrielbbaldez:stacktale-log4j2:1.3.1'
+implementation 'io.github.gabrielbbaldez:stacktale-log4j2:1.4.0'
 ```
 
 **Gradle (Kotlin DSL)**
 
 ```kotlin
-implementation("io.github.gabrielbbaldez:stacktale-log4j2:1.3.1")
+implementation("io.github.gabrielbbaldez:stacktale-log4j2:1.4.0")
 ```
 
 ```xml
@@ -252,13 +252,13 @@ by default — with no SLF4J bridge:
 **Gradle (Groovy)**
 
 ```groovy
-implementation 'io.github.gabrielbbaldez:stacktale-jul:1.3.1'
+implementation 'io.github.gabrielbbaldez:stacktale-jul:1.4.0'
 ```
 
 **Gradle (Kotlin DSL)**
 
 ```kotlin
-implementation("io.github.gabrielbbaldez:stacktale-jul:1.3.1")
+implementation("io.github.gabrielbbaldez:stacktale-jul:1.4.0")
 ```
 
 ```properties
@@ -339,7 +339,7 @@ an agent: told to "fix it, re-run the tests, then check what changed", it would 
 ```
 
 ```groovy
-testImplementation 'io.github.gabrielbbaldez:stacktale-junit:1.3.1'
+testImplementation 'io.github.gabrielbbaldez:stacktale-junit:1.4.0'
 ```
 
 **If your tests set a correlation key**, add `StacktaleExtension`. The listener is notified

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -19,7 +19,7 @@ If you have [JBang](https://www.jbang.dev), there's nothing to download. From yo
 **Claude Code** — one command:
 
 ```bash
-claude mcp add stacktale -- jbang run io.github.gabrielbbaldez:stacktale-mcp:1.3.1 --file "$PWD/errors-ai.log"
+claude mcp add stacktale -- jbang run io.github.gabrielbbaldez:stacktale-mcp:1.4.0 --file "$PWD/errors-ai.log"
 ```
 
 **Cursor** — drop this into `.cursor/mcp.json` (swap in your absolute path):
@@ -27,7 +27,7 @@ claude mcp add stacktale -- jbang run io.github.gabrielbbaldez:stacktale-mcp:1.3
 ```json
 { "mcpServers": { "stacktale": {
     "command": "jbang",
-    "args": ["run", "io.github.gabrielbbaldez:stacktale-mcp:1.3.1", "--file", "/abs/path/errors-ai.log"]
+    "args": ["run", "io.github.gabrielbbaldez:stacktale-mcp:1.4.0", "--file", "/abs/path/errors-ai.log"]
 } } }
 ```
 
@@ -44,7 +44,7 @@ It's on Maven Central. Three ways, easiest first:
 **JBang** (zero install, if you have JBang):
 
 ```bash
-jbang run io.github.gabrielbbaldez:stacktale-mcp:1.3.1 --file /path/to/errors-ai.log
+jbang run io.github.gabrielbbaldez:stacktale-mcp:1.4.0 --file /path/to/errors-ai.log
 ```
 
 **Download the jar directly** (curl):
@@ -58,7 +58,7 @@ curl -L -o stacktale-mcp.jar \
 
 ```bash
 mvn dependency:copy \
-  -Dartifact=io.github.gabrielbbaldez:stacktale-mcp:1.3.1 \
+  -Dartifact=io.github.gabrielbbaldez:stacktale-mcp:1.4.0 \
   -DoutputDirectory=.
 ```
 

--- a/examples/plain-java-jul/pom.xml
+++ b/examples/plain-java-jul/pom.xml
@@ -13,7 +13,7 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <stacktale.version>1.3.1</stacktale.version>
+        <stacktale.version>1.4.0</stacktale.version>
     </properties>
 
     <dependencies>

--- a/examples/spring-boot-mvc/pom.xml
+++ b/examples/spring-boot-mvc/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <stacktale.version>1.3.1</stacktale.version>
+        <stacktale.version>1.4.0</stacktale.version>
     </properties>
 
     <dependencies>

--- a/examples/spring-boot-webflux/pom.xml
+++ b/examples/spring-boot-webflux/pom.xml
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>17</java.version>
-        <stacktale.version>1.3.1</stacktale.version>
+        <stacktale.version>1.4.0</stacktale.version>
     </properties>
 
     <dependencies>

--- a/plugins/stacktale/.claude-plugin/plugin.json
+++ b/plugins/stacktale/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "stacktale",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Read your Java app's AI-ready error reports, and run a fix-run-check loop until the app is clean.",
   "author": {
     "name": "Gabriel Baldez",

--- a/plugins/stacktale/.mcp.json
+++ b/plugins/stacktale/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "stacktale": {
       "command": "jbang",
-      "args": ["run", "io.github.gabrielbbaldez:stacktale-mcp:1.3.1"]
+      "args": ["run", "io.github.gabrielbbaldez:stacktale-mcp:1.4.0"]
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.gabrielbbaldez</groupId>
   <artifactId>stacktale-parent</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>stacktale-parent</name>
@@ -61,7 +61,7 @@
       Bump it to the release date when cutting a release. Any fixed ISO-8601 instant works;
       what matters is that it does not move between builds of one commit.
     -->
-    <project.build.outputTimestamp>2026-09-04T00:00:00Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-09-04T22:51:17Z</project.build.outputTimestamp>
     <logback.version>1.6.3</logback.version>
     <junit.version>6.1.3</junit.version>
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>io.github.gabrielbbaldez</groupId>
   <artifactId>stacktale-parent</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.0</version>
   <packaging>pom</packaging>
 
   <name>stacktale-parent</name>
@@ -61,7 +61,7 @@
       Bump it to the release date when cutting a release. Any fixed ISO-8601 instant works;
       what matters is that it does not move between builds of one commit.
     -->
-    <project.build.outputTimestamp>2026-09-03T22:26:02Z</project.build.outputTimestamp>
+    <project.build.outputTimestamp>2026-09-04T00:00:00Z</project.build.outputTimestamp>
     <logback.version>1.6.3</logback.version>
     <junit.version>6.1.3</junit.version>
     <!--

--- a/stacktale-agent/pom.xml
+++ b/stacktale-agent/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-agent</artifactId>

--- a/stacktale-agent/pom.xml
+++ b/stacktale-agent/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
   </parent>
 
   <artifactId>stacktale-agent</artifactId>

--- a/stacktale-core/pom.xml
+++ b/stacktale-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
   </parent>
 
   <artifactId>stacktale-core</artifactId>

--- a/stacktale-core/pom.xml
+++ b/stacktale-core/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-core</artifactId>

--- a/stacktale-jul/pom.xml
+++ b/stacktale-jul/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-jul</artifactId>

--- a/stacktale-jul/pom.xml
+++ b/stacktale-jul/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
   </parent>
 
   <artifactId>stacktale-jul</artifactId>

--- a/stacktale-junit/pom.xml
+++ b/stacktale-junit/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-junit</artifactId>

--- a/stacktale-junit/pom.xml
+++ b/stacktale-junit/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
   </parent>
 
   <artifactId>stacktale-junit</artifactId>

--- a/stacktale-log4j2/pom.xml
+++ b/stacktale-log4j2/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
   </parent>
 
   <artifactId>stacktale-log4j2</artifactId>

--- a/stacktale-log4j2/pom.xml
+++ b/stacktale-log4j2/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-log4j2</artifactId>

--- a/stacktale-mcp/pom.xml
+++ b/stacktale-mcp/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
   </parent>
 
   <artifactId>stacktale-mcp</artifactId>

--- a/stacktale-mcp/pom.xml
+++ b/stacktale-mcp/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-mcp</artifactId>

--- a/stacktale-quarkus/deployment/pom.xml
+++ b/stacktale-quarkus/deployment/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-quarkus-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-quarkus-deployment</artifactId>

--- a/stacktale-quarkus/deployment/pom.xml
+++ b/stacktale-quarkus/deployment/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-quarkus-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
   </parent>
 
   <artifactId>stacktale-quarkus-deployment</artifactId>

--- a/stacktale-quarkus/pom.xml
+++ b/stacktale-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-quarkus-parent</artifactId>

--- a/stacktale-quarkus/pom.xml
+++ b/stacktale-quarkus/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
   </parent>
 
   <artifactId>stacktale-quarkus-parent</artifactId>

--- a/stacktale-quarkus/runtime/pom.xml
+++ b/stacktale-quarkus/runtime/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-quarkus-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
   </parent>
 
   <artifactId>stacktale-quarkus</artifactId>

--- a/stacktale-quarkus/runtime/pom.xml
+++ b/stacktale-quarkus/runtime/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-quarkus-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-quarkus</artifactId>

--- a/stacktale-spring-boot-starter/pom.xml
+++ b/stacktale-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale-spring-boot-starter</artifactId>

--- a/stacktale-spring-boot-starter/pom.xml
+++ b/stacktale-spring-boot-starter/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
   </parent>
 
   <artifactId>stacktale-spring-boot-starter</artifactId>

--- a/stacktale/pom.xml
+++ b/stacktale/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
   </parent>
 
   <artifactId>stacktale</artifactId>

--- a/stacktale/pom.xml
+++ b/stacktale/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>io.github.gabrielbbaldez</groupId>
     <artifactId>stacktale-parent</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>stacktale</artifactId>


### PR DESCRIPTION
Cut by `prepare-release` and already published to Maven Central; this PR brings the tagged commit into `main`'s history. The org still blocks Actions from opening pull requests, so it is created by hand, as in 1.3.1.

Twelve entries, and the shape of the release is one theme carried end to end: the `repro:` seed was reachable from two adapters out of five and missing from `st-json/1` entirely, so the first four changes made it real, and the rest built on it — `repro_for`, then `culprit_source` and `tests_covering` to complete the fix loop.

Alongside that: deploy provenance (`first seen: NEW in this build`), stacktale's own counters as Micrometer meters, `audit_redaction`, vendor API keys and PEM blocks now masked by shape, and three guards — configuration parity across the adapters, the hot path against its merge base, and the setup docs against the released version.

**Merge with a merge commit, not a squash**, so v1.4.0 stays reachable from main.