### PR TITLE
infra: guard the documented MCP tool surface

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Config parity guard
         if: matrix.java == 21
         run: bash scripts/check-config-parity.sh
+      - name: MCP tool surface guard
+        if: matrix.java == 21
+        run: bash scripts/check-mcp-tools.sh
       # After the build, because it reads the jars' manifests rather than the poms alone —
       # the point is what actually ships, not what the pom meant to say.
       - name: JPMS module name guard

--- a/plugins/stacktale/README.md
+++ b/plugins/stacktale/README.md
@@ -16,7 +16,7 @@ Maven Central on first run.
 
 ## What you get
 
-**Six tools** over the report file, read-only, no network:
+**Ten tools** over the report file, read-only, no network:
 
 | Tool | |
 |---|---|

--- a/scripts/check-mcp-tools.sh
+++ b/scripts/check-mcp-tools.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Guard the documented MCP tool surface.
+#
+# StacktaleMcpServer registers the tools; three documents describe them, and none of the
+# three knows when a tool is added. #218 added `repro_for` and left the README saying "Six
+# tools"; it was caught by hand two PRs later. That is the same failure mode #210 and #203
+# already have a guard for.
+#
+# Two halves, because they fail differently:
+#
+#   every registered name appears in all three documents  -- tells you which file you forgot
+#   the "**N tools**" count equals the number registered  -- what a reader trusts at a glance
+#
+# The count is spelled in words. Rather than teach a shell script English, the words it has
+# met are mapped below; an unmapped one is reported rather than skipped, so growing past the
+# list fails loudly instead of silently passing.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+server="stacktale-mcp/src/main/java/io/github/gabrielbbaldez/stacktale/mcp/StacktaleMcpServer.java"
+docs=("README.md" "docs/mcp-setup.md" "plugins/stacktale/README.md")
+
+fail=0
+
+# `|| true`: a grep that matches nothing exits 1, which `set -e` would take as this script
+# failing rather than as the finding it is.
+names="$(grep -oE 'tools\.add\(tool\("[a-z_]+"' "$server" | sed 's/.*"\(.*\)"/\1/' || true)"
+if [ -z "$names" ]; then
+  echo "check-mcp-tools: no tool registrations found in $server — has the call shape changed?" >&2
+  exit 1
+fi
+count="$(printf '%s\n' "$names" | wc -l | tr -d ' ')"
+
+for doc in "${docs[@]}"; do
+  if [ ! -f "$doc" ]; then
+    echo "check-mcp-tools: $doc is missing" >&2
+    fail=1
+    continue
+  fi
+  while IFS= read -r name; do
+    if ! grep -qF "$name" "$doc"; then
+      echo "check-mcp-tools: the server registers '$name', absent from $doc" >&2
+      fail=1
+    fi
+  done <<< "$names"
+done
+
+# The words this sentence has needed so far. Add to the map when the surface grows.
+word_for() {
+  case "$1" in
+    1) echo "One" ;;   2) echo "Two" ;;    3) echo "Three" ;; 4) echo "Four" ;;
+    5) echo "Five" ;;  6) echo "Six" ;;    7) echo "Seven" ;; 8) echo "Eight" ;;
+    9) echo "Nine" ;;  10) echo "Ten" ;;   11) echo "Eleven" ;; 12) echo "Twelve" ;;
+    *) echo "" ;;
+  esac
+}
+want="$(word_for "$count")"
+if [ -z "$want" ]; then
+  echo "check-mcp-tools: $count tools registered, and this script has no word for that number" >&2
+  echo "check-mcp-tools: add it to word_for, or write the sentence with a digit" >&2
+  exit 1
+fi
+
+for doc in "${docs[@]}"; do
+  [ -f "$doc" ] || continue
+  claimed="$(grep -oE '\*\*[A-Z][a-z]+ tools\*\*' "$doc" | head -1 | sed 's/\*\*\([A-Za-z]*\) tools\*\*/\1/' || true)"
+  [ -z "$claimed" ] && continue      # this document does not open with a count
+  if [ "$claimed" != "$want" ]; then
+    echo "check-mcp-tools: $doc says '**$claimed tools**'; the server registers $count ($want)" >&2
+    fail=1
+  fi
+done
+
+if [ "$fail" -eq 0 ]; then
+  echo "MCP tool surface agrees with all three documents ($count tools)"
+fi
+
+exit "$fail"

--- a/scripts/check-mcp-tools.sh
+++ b/scripts/check-mcp-tools.sh
@@ -11,6 +11,11 @@
 #   every registered name appears in all three documents  -- tells you which file you forgot
 #   the "**N tools**" count equals the number registered  -- what a reader trusts at a glance
 #
+# A name is looked for wrapped in backticks, not bare. `errors_since` is a prefix of
+# `errors_since_last_check`, so a bare substring match is satisfied by the longer
+# sibling: undocument the short one and the guard reports that all three agree. All
+# three documents already write every name as code, so the backticks are the anchor.
+#
 # The count is spelled in words. Rather than teach a shell script English, the words it has
 # met are mapped below; an unmapped one is reported rather than skipped, so growing past the
 # list fails loudly instead of silently passing.
@@ -39,7 +44,8 @@ for doc in "${docs[@]}"; do
     continue
   fi
   while IFS= read -r name; do
-    if ! grep -qF "$name" "$doc"; then
+    # Escaped: an unescaped backtick inside double quotes is command substitution.
+    if ! grep -qF -- "\`$name\`" "$doc"; then
       echo "check-mcp-tools: the server registers '$name', absent from $doc" >&2
       fail=1
     fi
@@ -64,12 +70,16 @@ fi
 
 for doc in "${docs[@]}"; do
   [ -f "$doc" ] || continue
-  claimed="$(grep -oE '\*\*[A-Z][a-z]+ tools\*\*' "$doc" | head -1 | sed 's/\*\*\([A-Za-z]*\) tools\*\*/\1/' || true)"
-  [ -z "$claimed" ] && continue      # this document does not open with a count
-  if [ "$claimed" != "$want" ]; then
-    echo "check-mcp-tools: $doc says '**$claimed tools**'; the server registers $count ($want)" >&2
-    fail=1
-  fi
+  # Every occurrence, not just the first: a second count further down a file is the
+  # same stale sentence a reader trusts, and check-plugin-versions.sh reads them all.
+  claimed="$(grep -oE '\*\*[A-Z][a-z]+ tools\*\*' "$doc" | sed 's/\*\*\([A-Za-z]*\) tools\*\*/\1/' || true)"
+  [ -z "$claimed" ] && continue      # this document does not state a count
+  while IFS= read -r one; do
+    if [ "$one" != "$want" ]; then
+      echo "check-mcp-tools: $doc says '**$one tools**'; the server registers $count ($want)" >&2
+      fail=1
+    fi
+  done <<< "$claimed"
 done
 
 if [ "$fail" -eq 0 ]; then


### PR DESCRIPTION
Closes #219

**Problem.** Three documents describe `StacktaleMcpServer`'s registrations and none of them knows when a tool is added. #218 left the README saying Six; it was caught by hand two PRs later.

**Change.** `scripts/check-mcp-tools.sh`, in the shape of `check-module-names.sh` and `check-config-parity.sh`, wired into `ci.yml` beside them. Two halves, as the issue asks:

- every `tools.add(tool("<name>"` in the server has its name in `README.md`, `docs/mcp-setup.md` and `plugins/stacktale/README.md`;
- the `**N tools**` count equals the number registered.

It found one on the first run — `plugins/stacktale/README.md` said **Six** while listing ten. Fixed here, so the guard is green.

The words are mapped rather than parsed. An unmapped count fails loudly and says to add it, so growing past the list cannot pass quietly.

**Verify.** Not just that it passes on a clean tree:

```
bash scripts/check-mcp-tools.sh
# MCP tool surface agrees with all three documents (10 tools)
```

Adding a throwaway registration names it in all three, and the count too:

```
check-mcp-tools: the server registers 'throwaway_probe', absent from README.md
check-mcp-tools: the server registers 'throwaway_probe', absent from docs/mcp-setup.md
check-mcp-tools: the server registers 'throwaway_probe', absent from plugins/stacktale/README.md
check-mcp-tools: README.md says '**Ten tools**'; the server registers 11 (Eleven)
```

Deleting one row from the plugin README names that file specifically:

```
check-mcp-tools: the server registers 'tests_covering', absent from plugins/stacktale/README.md
```

Three files, +4/-1 plus the script. No behaviour change.